### PR TITLE
get back required dependencies on wercker

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -56,6 +56,10 @@ fi
 : 'Install dependencies' && {
     echo 'Installing build dependencies ...'
     run_command_on_docker_container '' 'go get -u golang.org/x/tools/cmd/goimports'
+    run_command_on_docker_container '' 'go get -u github.com/laher/goxc'
+
+    echo 'Installing commands used with "go generate" ...'
+    run_command_on_docker_container '' 'go get -u github.com/jessevdk/go-assets-builder'
 }
 
 : "Test generator's library" && {


### PR DESCRIPTION
This PR partially reverts #9, as `goxc` and `go-assets-builder` are required to be able to run while building. We have them in our go.mod, but they are just downloaded as dependencies, not installed in $PATH. We need to explicitly install them by `go get`.