### PR TITLE
let register-payment-method be true by defalut for sandbox

### DIFF
--- a/generators/cmd/predefined/configure_sandbox.go
+++ b/generators/cmd/predefined/configure_sandbox.go
@@ -18,7 +18,7 @@ func init() {
 	ConfigureSandboxCmd.Flags().StringVar(&ConfigureSandboxAuthKey, "auth-key", "", TRCLI("cli.configure_sandbox.auth_key"))
 	ConfigureSandboxCmd.Flags().StringVar(&ConfigureSandboxEmail, "email", "", TRCLI("cli.configure_sandbox.email"))
 	ConfigureSandboxCmd.Flags().StringVar(&ConfigureSandboxPassword, "password", "", TRCLI("cli.configure_sandbox.password"))
-	ConfigureSandboxCmd.Flags().BoolVar(&ConfigureSandboxRegisterPaymentMethod, "register-payment-method", false, TRCLI("cli.configure_sandbox.register_payment_method"))
+	ConfigureSandboxCmd.Flags().BoolVar(&ConfigureSandboxRegisterPaymentMethod, "register-payment-method", true, TRCLI("cli.configure_sandbox.register_payment_method"))
 	RootCmd.AddCommand(ConfigureSandboxCmd)
 }
 
@@ -33,7 +33,7 @@ var ConfigureSandboxCmd = &cobra.Command{
 		var p *profile
 		var err error
 		if ConfigureSandboxAuthKeyID == "" || ConfigureSandboxAuthKey == "" || ConfigureSandboxEmail == "" || ConfigureSandboxPassword == "" {
-			p, err = collectSandboxProfileInfo(pn)
+			p, err = collectSandboxProfileInfo(pn, ConfigureSandboxRegisterPaymentMethod)
 			if err != nil {
 				cmd.SilenceUsage = true
 				return err

--- a/generators/cmd/predefined/profiles.go
+++ b/generators/cmd/predefined/profiles.go
@@ -27,7 +27,7 @@ type profile struct {
 	Username              *string `json:"username,omitempty"`
 	OperatorID            *string `json:"operatorId,omitempty"`
 	Endpoint              *string `json:"endpoint,omitempty"`
-	RegisterPaymentMethod bool `json:"registerPaymentMethod"`
+	RegisterPaymentMethod bool    `json:"registerPaymentMethod"`
 }
 
 type authInfo struct {
@@ -250,7 +250,7 @@ func collectProfileInfo(profileName string) (*profile, error) {
 	}, nil
 }
 
-func collectSandboxProfileInfo(profileName string) (*profile, error) {
+func collectSandboxProfileInfo(profileName string, registerPaymentMethod bool) (*profile, error) {
 	profDir, err := getProfileDir()
 	if err != nil {
 		return nil, err
@@ -274,12 +274,13 @@ func collectSandboxProfileInfo(profileName string) (*profile, error) {
 	}
 
 	return &profile{
-		Sandbox:      true,
-		CoverageType: ct,
-		Email:        sa.Email,
-		Password:     sa.Password,
-		AuthKeyID:    ai.AuthKeyID,
-		AuthKey:      ai.AuthKey,
+		Sandbox:               true,
+		CoverageType:          ct,
+		Email:                 sa.Email,
+		Password:              sa.Password,
+		AuthKeyID:             ai.AuthKeyID,
+		AuthKey:               ai.AuthKey,
+		RegisterPaymentMethod: registerPaymentMethod,
 	}, nil
 }
 


### PR DESCRIPTION
This PR fixes the issue that if a user run `soracom configure-sandbox` interactively (i.e. without authentication parameters), the specified value of `--register-payment-method` is not used and its default value was `false`, the user is never able to specify it as `true`.
The default value for `--register-payment-method` option is now `true` to suit to `/v1/sandbox/init` API's specification. Users are still able to explicitly specify `--register-payment-method` explicitly to false, if they want to do.

---

`soracom configure-sandbox` をインタラクティブに（すなわち認証用の引数なしで）実行したときに `--register-payment-method` の値が使われず、しかもデフォルトが `false` でしたので、`true` にすることができないという問題を修正しました。
`/v1/sandbox/init` API の仕様に合わせデフォルトを `true` としました。`false` にしたければ明示的に指定することもできます。
