### PR TITLE
fix `unexpected newline` issue

### DIFF
--- a/generators/cmd/predefined/profiles.go
+++ b/generators/cmd/predefined/profiles.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -164,8 +165,7 @@ func saveProfile(profileName string, prof *profile) error {
 	if _, err := os.Stat(path); err == nil {
 		// prompt if overwrites or not when already exist
 		fmt.Printf(TRCLI("cli.configure.profile.overwrite"), profileName)
-		var s string
-		_, err := fmt.Scanf("%s\n", &s)
+		s, err := readLine()
 		if err != nil {
 			return err
 		}
@@ -199,8 +199,7 @@ func saveProfile(profileName string, prof *profile) error {
 
 func confirmDeleteProfile(profileName string) bool {
 	fmt.Printf(TRCLI("cli.unconfigure.prompt"), profileName)
-	var s string
-	_, err := fmt.Scanf("%s\n", &s)
+	s, err := readLine()
 	if err != nil {
 		return false
 	}
@@ -416,4 +415,14 @@ func collectSandboxAccountInfo() (*authInfo, error) {
 	}
 	fmt.Println()
 	return &authInfo{Email: &email, Password: &password}, nil
+}
+
+func readLine() (string, error) {
+	reader := bufio.NewReader(os.Stdin)
+	s, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(s), nil
 }


### PR DESCRIPTION
A user gets `unexpected newline` error when the user input nothing and just press Enter after seeing the prompt `(Y/n)`. This is not an expected behavior. This is caused by using `fmt.Scanf()`.
We can avoid this issue by using `ReadString()` of `bufio.Reader`.

---

`(Y/n)` というプロンプトのあとでユーザーが何も入力せずに Enter だけを押すと `unexpected newline` というエラーが発生してしまいます。これは期待される動作ではありません。
これは `fmt.Scanf()` を使っているために起こります。
`bufio.Reader` の `ReadString()` を用いることでこの問題を回避することができます。