### PR TITLE
add `--raw-output` option

### DIFF
--- a/generators/cmd/templates/leaf.gotmpl
+++ b/generators/cmd/templates/leaf.gotmpl
@@ -129,12 +129,16 @@ var {{ $cmdvar }} = &cobra.Command{
       return nil
     }
 
-    {{- if not .ResponseBodyRaw}}
-    return prettyPrintStringAsJSON(body)
-    {{else}}
-    _, err = os.Stdout.Write([]byte(body))
-    return err
+    {{- if .ResponseBodyRaw}}
+    rawOutput = true
     {{end}}
+
+    if rawOutput {
+      _, err = os.Stdout.Write([]byte(body))
+    } else {
+      return prettyPrintStringAsJSON(body)
+    }
+    return err
   },
 }
 

--- a/generators/cmd/templates/root.gotmpl
+++ b/generators/cmd/templates/root.gotmpl
@@ -18,6 +18,7 @@ var providedAPIKey string
 var providedAPIToken string
 var providedAuthKeyID string
 var providedAuthKey string
+var rawOutput bool
 
 func init() {
   RootCmd.PersistentFlags().StringVar(&specifiedProfileName, "profile", "", "Specify profile name")
@@ -26,4 +27,5 @@ func init() {
   RootCmd.PersistentFlags().StringVar(&providedAPIToken, "api-token", "", "Specify API token otherwise soracom-cli performs authentication on behalf of you")
   RootCmd.PersistentFlags().StringVar(&providedAuthKeyID, "auth-key-id", "", "Specify AuthKeyId to be used for authentication. If both --auth-key-id and --auth-key are specified, soracom-cli works without profiles. It means you don't need to run 'soracom configure' before running the command. This may be suitable for temporary execution. Please don't forget specifying these options along with --coverage-type.")
   RootCmd.PersistentFlags().StringVar(&providedAuthKey, "auth-key", "", "Specify AuthKey to be used for authentication. If both --auth-key-id and --auth-key are specified, soracom-cli works without profiles. It means you don't need to run 'soracom configure' before running the command. This may be suitable for temporary execution. Please don't forget specifying these options along with --coverage-type.")
+  RootCmd.PersistentFlags().BoolVar(&rawOutput, "raw-output", false, "Specify soracom-cli to output raw JSON response from the API endpoint instead of formatting")
 }

--- a/test/data/help_en_expected.txt
+++ b/test/data/help_en_expected.txt
@@ -53,5 +53,6 @@ Flags:
       --coverage-type string   Specify coverage type, 'g' for Global, 'jp' for Japan
   -h, --help                   help for soracom
       --profile string         Specify profile name
+      --raw-output             Specify soracom-cli to output raw JSON response from the API endpoint instead of formatting
 
 Use "soracom [command] --help" for more information about a command.

--- a/test/data/help_ja_expected.txt
+++ b/test/data/help_ja_expected.txt
@@ -53,5 +53,6 @@ Flags:
       --coverage-type string   Specify coverage type, 'g' for Global, 'jp' for Japan
   -h, --help                   help for soracom
       --profile string         Specify profile name
+      --raw-output             Specify soracom-cli to output raw JSON response from the API endpoint instead of formatting
 
 Use "soracom [command] --help" for more information about a command.


### PR DESCRIPTION
Added `--raw-output` global option to workaround the unwanted behavior that `&` is escaped in URLs.

Actually we already have a special treatment only for the output for `/v1/files/{scope}/{path}` API which is possibly returning binary files (it's done by .ResponseBodyRaw template variable). By this change, users will be able to explicitly specify the behavior for other APIs. 