### PR TITLE
Support Harvest Files prefix match

### DIFF
--- a/generators/assets/soracom-api.en.yaml
+++ b/generators/assets/soracom-api.en.yaml
@@ -696,8 +696,14 @@ definitions:
         description: Created time of the file
         format: int64
         type: integer
+      directory:
+        description: Parent directory name
+        type: string
       etag:
         description: Etag of the file
+        type: string
+      filePath:
+        description: Absolute path of the file
         type: string
       filename:
         description: File name
@@ -4403,6 +4409,67 @@ paths:
       - EventHandler
       x-soracom-cli:
       - event-handlers list-for-subscriber
+  /files:
+    get:
+      consumes:
+      - application/json
+      description: Returns a list of file entries which beginnings of their file paths
+        are matched with the `prefix` query string in the ascending sorted UTF-8 bytes
+        order of their file paths. An empty list is returned if the prefix does not
+        match with any paths of file entries.
+      operationId: findFiles
+      parameters:
+      - description: Scope of the request
+        enum:
+        - private
+        - public
+        in: query
+        name: scope
+        required: true
+        type: string
+      - description: Prefix to match with file path
+        in: query
+        name: prefix
+        required: true
+        type: string
+      - default: 10
+        description: Num of entries
+        in: query
+        name: limit
+        required: false
+        type: string
+      - description: The filePath of the last file entry retrieved on the current
+          page. By specifying this parameter, you can continue to retrieve the list
+          from the next file entry onward.
+        in: query
+        name: last_evaluated_key
+        required: false
+        type: string
+      produces:
+      - application/json;charset=UTF-8
+      responses:
+        200:
+          description: List of file entries found with query parameters, which can
+            be empty if the prefix does not match with any paths of file entries.
+          schema:
+            items:
+              $ref: '#/definitions/FileEntry'
+            type: array
+        404:
+          description: The specified scope does not exist
+      security:
+      - api_key: []
+      - api_token: []
+      summary: Find files with prefix query parameter in the scope
+      tags:
+      - FileEntry
+      x-soracom-cli:
+      - files find
+      x-soracom-cli-pagination:
+        request:
+          param: last_evaluated_key
+        response:
+          header: x-soracom-next-key
   /files/{scope}/{path}:
     delete:
       description: Deletes the specified file in the scope. Only `private` scope is
@@ -4578,9 +4645,11 @@ paths:
       x-soracom-cli:
       - files delete-directory
     get:
-      description: Returns a list of files entries under the path in the scope. If
-        the total number of entries does not fit in one page, a URL for accessing
-        the next page is returned in the 'Link' header of the response.
+      description: Returns a list of file entries under the path in the scope. This
+        operation works only for directories and an error will be retrurned if the
+        file entry corresponds to the given path is not a directory. If the total
+        number of entries does not fit in one page, a URL for accessing the next page
+        is returned in the 'Link' header of the response.
       operationId: listFiles
       parameters:
       - default: private
@@ -4604,6 +4673,13 @@ paths:
         name: limit
         required: false
         type: string
+      - description: The filename  of the last file entry retrieved on the current
+          page. By specifying this parameter, you can continue to retrieve the list
+          from the next file entry onward.
+        in: query
+        name: last_evaluated_key
+        required: false
+        type: string
       responses:
         200:
           description: A list of file entries.
@@ -4621,6 +4697,11 @@ paths:
       - FileEntry
       x-soracom-cli:
       - files list
+      x-soracom-cli-pagination:
+        request:
+          param: last_evaluated_key
+        response:
+          header: x-soracom-next-key
   /files/exported/{exported_file_id}:
     get:
       consumes:

--- a/generators/assets/soracom-api.ja.yaml
+++ b/generators/assets/soracom-api.ja.yaml
@@ -696,8 +696,14 @@ definitions:
         description: ファイルの作成時刻
         format: int64
         type: integer
+      directory:
+        description: 親ディレクトリ名
+        type: string
       etag:
         description: ファイルのETag
+        type: string
+      filePath:
+        description: ファイルの絶対パス
         type: string
       filename:
         description: ファイル名
@@ -4363,6 +4369,62 @@ paths:
       - EventHandler
       x-soracom-cli:
       - event-handlers list-for-subscriber
+  /files:
+    get:
+      consumes:
+      - application/json
+      description: scope と prefix にマッチしたファイルエントリの一覧をファイルエントリを filePath の UTF-8 バイトでソートされた順
+        (昇順) で返却します。 prefix がマッチするファイルエントリが無ければ空のリストが返却されます。
+      operationId: findFiles
+      parameters:
+      - description: リクエストのスコープ
+        enum:
+        - private
+        - public
+        in: query
+        name: scope
+        required: true
+        type: string
+      - description: ファイルパスにマッチさせるプレフィックス
+        in: query
+        name: prefix
+        required: true
+        type: string
+      - default: 10
+        description: 返却するファイルエントリ数の上限
+        in: query
+        name: limit
+        required: false
+        type: string
+      - description: 現ページで取得した最後のファイルエントリの filePath 。このパラメータを指定することで次のファイルエントリ以降のリストを取得できる。
+        in: query
+        name: last_evaluated_key
+        required: false
+        type: string
+      produces:
+      - application/json;charset=UTF-8
+      responses:
+        200:
+          description: プレフィックにマッチしたエントリエントリのリスト。 prefix がマッチするファイルエントリが無ければ空のリスト。
+          schema:
+            items:
+              $ref: '#/definitions/FileEntry'
+            type: array
+        404:
+          description: 指定された scope が存在しない
+      security:
+      - api_key: []
+      - api_token: []
+      summary: scope と prefix にマッチするファイルを探します。
+      tags:
+      - FileEntry
+      x-soracom-cli:
+      - files find
+      x-soracom-cli-pagination:
+        request:
+          param: last_evaluated_key
+        response:
+          header: x-soracom-next-key
   /files/{scope}/{path}:
     delete:
       description: scope と path で指定されたファイルを削除します。`private` スコープのみが許可されます。
@@ -4534,7 +4596,8 @@ paths:
       x-soracom-cli:
       - files delete-directory
     get:
-      description: scope と path で指定された配下のファイルエントリのリストを返却します。エントリの総数が １ ページに収まらない場合、次のページへアクセスするための
+      description: scope と path で指定された配下のファイルエントリのリストを返却します。この操作はディレクトリにのみ有効で、与えられた
+        path に対応するファイルエントリがディレクトリでない場合エラーが返されます。エントリの総数が １ ページに収まらない場合、次のページへアクセスするための
         URL が Link ヘッダに含まれます。
       operationId: listFiles
       parameters:
@@ -4554,9 +4617,14 @@ paths:
         required: true
         type: string
       - default: 10
-        description: Num of entries
+        description: 返却するファイルエントリ数の上限
         in: query
         name: limit
+        required: false
+        type: string
+      - description: 現ページで取得した最後のファイルエントリの filename 。このパラメータを指定することで次のファイルエントリ以降のリストを取得できる。
+        in: query
+        name: last_evaluated_key
         required: false
         type: string
       responses:
@@ -4576,6 +4644,11 @@ paths:
       - FileEntry
       x-soracom-cli:
       - files list
+      x-soracom-cli-pagination:
+        request:
+          param: last_evaluated_key
+        response:
+          header: x-soracom-next-key
   /files/exported/{exported_file_id}:
     get:
       consumes:


### PR DESCRIPTION
Add API definitions for Harvest Files prefix match listing

This patch adds the API definitions for listing Harvest Files entries
with the prefix match introduced as GET
/v1/files?scope=${scope}&prefix=${prefix}, which corresponding
subcommand is "files find".
