### PR TITLE
enhancement: aggregate build commands into Makefile

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -16,39 +16,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Generate
-        run: go generate -v ./generagors/cmd/src/
-
-      - name: Test
-        run: go test ./generators/cmd/src
-
-      - name: Test
-        run: go test ./generators/lib
-
-      - name: Build the generator
-        run: go build -o generate-cmd ./generators/cmd/src
-
-      - name: Run the generator
-        run: ./generate-cmd -a generators/assets/soracom-api.en.yaml -s generators/assets/sandbox/soracom-sandbox-api.en.yaml -t generators/cmd/templates -p generators/cmd/predefined -o soracom/generated/cmd/
-
-      - name: Copy assets
-        run: cp -r generators/assets/ soracom/generated/cmd/assets/
-
-      - name: Generate
-        run: go generate -v ./soracom
-
-      - name: Build
-        run: |
-          GOOS=linux   GOARCH=amd64 go build -o soracom/dist/ghactions/linux-amd64/soracom   ./soracom
-          GOOS=linux   GOARCH=arm64 go build -o soracom/dist/ghactions/linux-arm64/soracom   ./soracom
-          GOOS=linux   GOARCH=386   go build -o soracom/dist/ghactions/linux-386/soracom     ./soracom
-          GOOS=linux   GOARCH=arm   go build -o soracom/dist/ghactions/linux-arm/soracom     ./soracom
-          GOOS=darwin  GOARCH=amd64 go build -o soracom/dist/ghactions/darwin-amd64/soracom  ./soracom
-          GOOS=darwin  GOARCH=arm64 go build -o soracom/dist/ghactions/darwin-arm64/soracom  ./soracom
-          GOOS=windows GOARCH=amd64 go build -o soracom/dist/ghactions/windows-amd64/soracom ./soracom
-          GOOS=windows GOARCH=386   go build -o soracom/dist/ghactions/windows-386/soracom   ./soracom
-          GOOS=freebsd GOARCH=amd64 go build -o soracom/dist/ghactions/freebsd-amd64/soracom ./soracom
-          GOOS=freebsd GOARCH=386   go build -o soracom/dist/ghactions/freebsd-386/soracom   ./soracom
+      - name: Run build-artifacts command
+        run: make ci-build-artifacts
 
       - uses: actions/upload-artifact@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -15,20 +15,20 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .DEFAULT_GOAL := help
 
-install-dev: ## Install dev dependencies
+install-dev-deps: ## Install dev dependencies
 	@echo 'Installing dependencies for development'
 	go get -u \
 		golang.org/x/lint/golint \
 		github.com/fzipp/gocyclo/cmd/gocyclo
-.PHONY:install-dev
+.PHONY:install-dev-deps
 
-install: ## Install dependencies
+install-deps: ## Install dependencies
 	@echo 'Installing build dependencies ...'
 	go get -u golang.org/x/tools/cmd/goimports
 	@echo 'Installing commands used with "go generate" ...'
 	go get -u github.com/elazarl/goproxy
 	go mod tidy
-.PHONY:install
+.PHONY:install-deps
 
 test: ## Test generator's library
 	@echo "Testing generator's source ..."
@@ -65,7 +65,7 @@ cross-build:
 	done
 .PHONY:cross-build
 
-ci-build-artifacts: install-dev install generate metrics-gocyclo test lint ## Run `build-artifacts` action
+ci-build-artifacts: install-dev-deps install-deps generate metrics-gocyclo test lint ## Run `build-artifacts` action
 	make cross-build OS_LIST="linux" ARCH_LIST="amd64 arm64 386 arm"
 	make cross-build OS_LIST="darwin" ARCH_LIST="amd64 arm64"
 	make cross-build OS_LIST="windows" ARCH_LIST="amd64 386" EXT=".exe"

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .DEFAULT_GOAL := help
 
+install-dev: ## Install dev dependencies
+	@echo 'Installing dependencies for development'
+	go get -u golang.org/x/lint/golint
+.PHONY:install-dev
+
 install: ## Install dependencies
 	@echo 'Installing build dependencies ...'
 	go get -u golang.org/x/tools/cmd/goimports
@@ -55,7 +60,7 @@ cross-build:
 	done
 .PHONY:cross-build
 
-ci-build-artifacts: install generate format test lint ## Run `build-artifacts` action
+ci-build-artifacts: install-dev install generate format test lint ## Run `build-artifacts` action
 	make cross-build OS_LIST="linux" ARCH_LIST="amd64 arm64 386 arm"
 	make cross-build OS_LIST="darwin" ARCH_LIST="amd64 arm64"
 	make cross-build OS_LIST="windows" ARCH_LIST="amd64 386" EXT=".exe"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+VERSION ?= 0.0.0
+GOOS ?= darwin
+GOARCH ?= amd64
+EXT ?= 
+
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -29,3 +34,10 @@ generate: ## Generate source code for soracom-cli
 	@echo 'Copying assets to embed ...'
 	cp -r generators/assets/ soracom/generated/cmd/assets/
 .PHONY:generate
+
+build: ## Build codes
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
+		-ldflags="-X 'github.com/soracom/soracom-cli/soracom/generated/cmd.version=$(VERSION)'" \
+		-o "soracom/dist/$(VERSION)/soracom_$(VERSION)_$(GOOS)_$(GOARCH)$(EXT)" \
+		./soracom
+.PHONY:build

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION ?= 0.0.0
-GOOS ?= darwin
-GOARCH ?= amd64
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
 ifeq ($(GOOS),windows)
 	EXT = .exe
 else

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ else
 endif
 OUTPUT ?= soracom/dist/$(VERSION)/soracom_$(VERSION)_$(GOOS)_$(GOARCH)$(EXT)
 
+GOCYCLO_OVER ?= 20
+
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -15,7 +17,9 @@ help:
 
 install-dev: ## Install dev dependencies
 	@echo 'Installing dependencies for development'
-	go get -u golang.org/x/lint/golint
+	go get -u \
+		golang.org/x/lint/golint \
+		github.com/fzipp/gocyclo/cmd/gocyclo
 .PHONY:install-dev
 
 install: ## Install dependencies
@@ -61,7 +65,7 @@ cross-build:
 	done
 .PHONY:cross-build
 
-ci-build-artifacts: install-dev install generate format test lint ## Run `build-artifacts` action
+ci-build-artifacts: install-dev install generate metrics-gocyclo test lint ## Run `build-artifacts` action
 	make cross-build OS_LIST="linux" ARCH_LIST="amd64 arm64 386 arm"
 	make cross-build OS_LIST="darwin" ARCH_LIST="amd64 arm64"
 	make cross-build OS_LIST="windows" ARCH_LIST="amd64 386" EXT=".exe"
@@ -75,3 +79,7 @@ format: ## Format codes
 lint: ## Lint codes
 	golint -set_exit_status ./...
 .PHONY:lint
+
+metrics-gocyclo: ## Metrics with gocyclo
+	gocyclo -over $(GOCYCLO_OVER) .
+.PHONY:metrics-gocyclo

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,18 @@ cross-build:
 	done
 .PHONY:cross-build
 
-ci-build-artifacts: ## Run `build-artifacts` action
-	make generate
-	make test
+ci-build-artifacts: install generate format test lint ## Run `build-artifacts` action
 	make cross-build OS_LIST="linux" ARCH_LIST="amd64 arm64 386 arm"
 	make cross-build OS_LIST="darwin" ARCH_LIST="amd64 arm64"
 	make cross-build OS_LIST="windows" ARCH_LIST="amd64 386" EXT=".exe"
 	make cross-build OS_LIST="freebsd" ARCH_LIST="amd64 386"
 .PHONY:ci-build-artifacts
+
+format: ## Format codes
+	go fmt ./...
+.PHONY:format
+
+lint: ## Lint codes
+	# FIXME: set exit status when lint failed($ golint -set_exit_status ./...)
+	golint ./... 
+.PHONY:lint

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,5 @@ format: ## Format codes
 .PHONY:format
 
 lint: ## Lint codes
-	# FIXME: set exit status when lint failed($ golint -set_exit_status ./...)
-	golint ./... 
+	golint -set_exit_status ./...
 .PHONY:lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+.DEFAULT_GOAL := help
+
+install: ## Install dependencies
+	@echo 'Installing build dependencies ...'
+	go get -u golang.org/x/tools/cmd/goimports
+	@echo 'Installing commands used with "go generate" ...'
+	go get -u github.com/elazarl/goproxy
+	go mod tidy
+.PHONY:install
+
+test: ## Test generator's library
+	@echo "Testing generator's source ..."
+	go test ./generators/cmd/src
+	go test ./generators/lib
+.PHONY:test
+
+generate: ## Generate source code for soracom-cli
+	echo 'Generating generator ...'
+	cd ./generators/cmd/src && \
+	go generate && \
+	go vet && \
+	goimports -w ./*.go && \
+	go build -o generate-cmd
+	@echo 'Generating source codes for soracom-cli by using the generator ...'
+	./generators/cmd/src/generate-cmd -a generators/assets/soracom-api.en.yaml -s generators/assets/sandbox/soracom-sandbox-api.en.yaml -t generators/cmd/templates -p generators/cmd/predefined -o soracom/generated/cmd/
+	@echo 'Copying assets to embed ...'
+	cp -r generators/assets/ soracom/generated/cmd/assets/
+.PHONY:generate

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ generate: ## Generate source code for soracom-cli
 	./generators/cmd/src/generate-cmd -a generators/assets/soracom-api.en.yaml -s generators/assets/sandbox/soracom-sandbox-api.en.yaml -t generators/cmd/templates -p generators/cmd/predefined -o soracom/generated/cmd/
 	@echo 'Copying assets to embed ...'
 	cp -r generators/assets/ soracom/generated/cmd/assets/
+	make format
 .PHONY:generate
 
 build: ## Build codes

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 VERSION ?= 0.0.0
 GOOS ?= darwin
 GOARCH ?= amd64
-EXT ?= 
+ifeq ($(GOOS),windows)
+	EXT = .exe
+else
+	EXT = 
+endif
 OUTPUT ?= soracom/dist/$(VERSION)/soracom_$(VERSION)_$(GOOS)_$(GOARCH)$(EXT)
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ else
 endif
 OUTPUT ?= soracom/dist/$(VERSION)/soracom_$(VERSION)_$(GOOS)_$(GOARCH)$(EXT)
 
-GOCYCLO_OVER ?= 20
+GOCYCLO_OVER ?= 23
 
 .PHONY: help
 help:

--- a/build/build.sh
+++ b/build/build.sh
@@ -17,35 +17,15 @@ gopath=${GOPATH:-$HOME/go}
 gopath=${gopath%%:*}
 
 : 'Install dependencies' && {
-    echo 'Installing build dependencies ...'
-    go get -u golang.org/x/tools/cmd/goimports
-
-    echo 'Installing commands used with "go generate" ...'
-    go get -u github.com/elazarl/goproxy
-    go mod tidy
+  make install
 }
 
 : "Test generator's library" && {
-    echo "Testing generator's source ..."
-    go test "$d/generators/cmd/src"
-    go test "$d/generators/lib"
+  make test
 }
 
 : 'Generate source code for soracom-cli' && {
-    echo 'Generating generator ...'
-    (
-      cd "$d/generators/cmd/src" && \
-      go generate && \
-      go vet && \
-      goimports -w ./*.go && \
-      go build -o generate-cmd
-    )
-
-    echo 'Generating source codes for soracom-cli by using the generator ...'
-    "$d/generators/cmd/src/generate-cmd" -a generators/assets/soracom-api.en.yaml -s generators/assets/sandbox/soracom-sandbox-api.en.yaml -t generators/cmd/templates -p generators/cmd/predefined -o soracom/generated/cmd/
-
-    echo 'Copying assets to embed ...'
-    cp -r generators/assets/ soracom/generated/cmd/assets/
+  make generate
 }
 
 remove_tmpdir() {

--- a/build/build.sh
+++ b/build/build.sh
@@ -17,7 +17,7 @@ gopath=${GOPATH:-$HOME/go}
 gopath=${gopath%%:*}
 
 : 'Install dependencies' && {
-  make install
+  make install-deps
 }
 
 : "Test generator's library" && {

--- a/build/build.sh
+++ b/build/build.sh
@@ -86,7 +86,7 @@ build() {
   bin="soracom_${VERSION}_${goos}_$goarch$ext"
 
   printf "  %-7s - %-5s  bin" "$goos" "$goarch"
-  make build GOOS="$goos" GOARCH="$goarch" VERSION="$VERSION" EXT="$ext"
+  make build GOOS="$goos" GOARCH="$goarch" VERSION="$VERSION" OUTPUT="$bindir/$bin"
 
   printf ", archive"
   case "$goos" in

--- a/build/build.sh
+++ b/build/build.sh
@@ -86,7 +86,7 @@ build() {
   bin="soracom_${VERSION}_${goos}_$goarch$ext"
 
   printf "  %-7s - %-5s  bin" "$goos" "$goarch"
-  GOOS="$goos" GOARCH="$goarch" go build -ldflags="-X 'github.com/soracom/soracom-cli/soracom/generated/cmd.version=$VERSION'" -o "$bindir/$bin" ./soracom
+  make build GOOS="$goos" GOARCH="$goarch" VERSION="$VERSION" EXT="$ext"
 
   printf ", archive"
   case "$goos" in

--- a/generators/cmd/predefined/lang_utils.go
+++ b/generators/cmd/predefined/lang_utils.go
@@ -163,6 +163,7 @@ func getAltLang(ll string) string {
 	return ""
 }
 
+// TRAPI ...
 func TRAPI(pathAndMethodAndField string) string {
 	initIfRequired()
 	s := getStringResource(apiResources[selectedLang], pathAndMethodAndField)
@@ -223,6 +224,7 @@ func getStringResource(data map[interface{}]interface{}, pathAndMethodAndField s
 	return str
 }
 
+// TRCLI ...
 func TRCLI(resourceID string) string {
 	initIfRequired()
 	r := cliResources[selectedLang]

--- a/generators/lib/apidef_loader.go
+++ b/generators/lib/apidef_loader.go
@@ -36,15 +36,18 @@ type APIMethod struct {
 	AlternativeCommand string                   `yaml:"x-soracom-alternative-cli"`
 }
 
+// Pagination holds information about pagination
 type Pagination struct {
 	Response Response `yaml:"response"`
 	Request  Request  `yaml:"request"`
 }
 
+// Response holds information about response
 type Response struct {
 	Header string `yaml:"header"`
 }
 
+// Request holds information about request
 type Request struct {
 	Param string `yaml:"param"`
 }
@@ -62,6 +65,7 @@ type APIParam struct {
 	Items       APIParamArrayItems `yaml:"items"`
 }
 
+// GetDefaultValueAsString returns the default value as string type
 func (p *APIParam) GetDefaultValueAsString() string {
 	if p.Default == nil {
 		return ""
@@ -73,6 +77,7 @@ func (p *APIParam) GetDefaultValueAsString() string {
 	return s
 }
 
+// GetDefaultValueAsInt64 returns the default value as int64 type
 func (p *APIParam) GetDefaultValueAsInt64() int64 {
 	if p.Default == nil {
 		return 0
@@ -84,6 +89,7 @@ func (p *APIParam) GetDefaultValueAsInt64() int64 {
 	return int64(s)
 }
 
+// GetDefaultValueAsFloat returns the default value as float64 type
 func (p *APIParam) GetDefaultValueAsFloat() float64 {
 	if p.Default == nil {
 		return 0.0
@@ -95,6 +101,7 @@ func (p *APIParam) GetDefaultValueAsFloat() float64 {
 	return s
 }
 
+// GetDefaultValueAsBool returns the default value as bool type
 func (p *APIParam) GetDefaultValueAsBool() bool {
 	if p.Default == nil {
 		return false
@@ -141,6 +148,7 @@ type StructProperty struct {
 	Default     interface{}
 }
 
+// GetDefaultValueAsString returns the default value as string type
 func (p *StructProperty) GetDefaultValueAsString() string {
 	if p.Default == nil {
 		return ""
@@ -152,6 +160,7 @@ func (p *StructProperty) GetDefaultValueAsString() string {
 	return s
 }
 
+// GetDefaultValueAsInt64 returns the default value as int64 type
 func (p *StructProperty) GetDefaultValueAsInt64() int64 {
 	if p.Default == nil {
 		return 0
@@ -163,6 +172,7 @@ func (p *StructProperty) GetDefaultValueAsInt64() int64 {
 	return int64(s)
 }
 
+// GetDefaultValueAsFloat returns the default value as float64 type
 func (p *StructProperty) GetDefaultValueAsFloat() float64 {
 	if p.Default == nil {
 		return 0.0
@@ -174,6 +184,7 @@ func (p *StructProperty) GetDefaultValueAsFloat() float64 {
 	return s
 }
 
+// GetDefaultValueAsBool returns the default value as bool type
 func (p *StructProperty) GetDefaultValueAsBool() bool {
 	if p.Default == nil {
 		return false

--- a/generators/lib/fileperm.go
+++ b/generators/lib/fileperm.go
@@ -4,6 +4,7 @@ package lib
 
 import "os"
 
+// IsFilePermissionTooOpen returns true only when the `path` doesn't have the expected permission
 func IsFilePermissionTooOpen(path string) (bool, error) {
 	s, err := os.Stat(path)
 	if err != nil {
@@ -17,6 +18,7 @@ func IsFilePermissionTooOpen(path string) (bool, error) {
 	return false, nil
 }
 
+// ProtectFile changes the mode of the specified `path`
 func ProtectFile(path string) error {
 	return os.Chmod(path, 0600)
 }

--- a/generators/lib/printer.go
+++ b/generators/lib/printer.go
@@ -5,6 +5,7 @@ import (
 	"os"
 )
 
+// PrintfStderr formats according to a format specifier and writes to standard error
 func PrintfStderr(format string, args ...interface{}) {
 	_, err := fmt.Fprintf(os.Stderr, format, args...)
 	if err != nil {
@@ -12,6 +13,7 @@ func PrintfStderr(format string, args ...interface{}) {
 	}
 }
 
+// WarnfStderr formats according to a format specifier and writes to standard error with `WARN: ` prefix
 func WarnfStderr(format string, args ...interface{}) {
 	PrintfStderr("WARN: "+format, args...)
 }

--- a/soracom/generated/cmd/lang_utils.go
+++ b/soracom/generated/cmd/lang_utils.go
@@ -163,6 +163,7 @@ func getAltLang(ll string) string {
 	return ""
 }
 
+// TRAPI ...
 func TRAPI(pathAndMethodAndField string) string {
 	initIfRequired()
 	s := getStringResource(apiResources[selectedLang], pathAndMethodAndField)
@@ -223,6 +224,7 @@ func getStringResource(data map[interface{}]interface{}, pathAndMethodAndField s
 	return str
 }
 
+// TRCLI ...
 func TRCLI(resourceID string) string {
 	initIfRequired()
 	r := cliResources[selectedLang]


### PR DESCRIPTION
# Description
This PR includes following changes:
- codes scattered around build scripts and GitHub Actions are aggregated into Makefile
- fix lint issues by adding comments for exported functions
- run lint and collect code complexity metrics just as goreportcard does

# Checklist
- [x] run ci test locally by `make ci-build-artifacts`
- [x] `./scripts/build.sh 1.2 && ./test/test.sh 1.2.3`