### PR TITLE
Specify the golang runtime version in a Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.16.5-buster
 
 RUN apt update && apt upgrade -y && apt install -y fakeroot shellcheck zip
 


### PR DESCRIPTION
`latest` is mutable and that would point to various targets; the actual target where it points is dependent on the executor's environment because of the local cache.

I've encountered an error like the following:

```
github.com/soracom/soracom-cli/generators/cmd/predefined imports
        embed: package embed is not in GOROOT (/usr/local/go/src/embed)
make: *** [Makefile:30: install-deps] Error 1
```

because I have had the local cache that associates with `latest` that contains OLD go runtime.