### PR TITLE
Add --delete-immediately option to "sigfox-devices terminate"

### DIFF
--- a/generators/assets/soracom-api.en.yaml
+++ b/generators/assets/soracom-api.en.yaml
@@ -11521,6 +11521,12 @@ paths:
         name: device_id
         required: true
         type: string
+      - default: false
+        description: If the Sigfox device is deleted immediately
+        in: query
+        name: delete_immediately
+        required: false
+        type: boolean
       produces:
       - application/json
       responses:

--- a/generators/assets/soracom-api.ja.yaml
+++ b/generators/assets/soracom-api.ja.yaml
@@ -11337,6 +11337,12 @@ paths:
         name: device_id
         required: true
         type: string
+      - default: false
+        description: Sigfox デバイスを即座に削除する
+        in: query
+        name: delete_immediately
+        required: false
+        type: boolean
       produces:
       - application/json
       responses:

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
-	golang.org/x/sys v0.0.0-20210608053332-aa57babbf139
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1
 	gopkg.in/yaml.v2 v2.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210608053332-aa57babbf139 h1:C+AwYEtBp/VQwoLntUmQ/yx3MS9vmZaKNdw5eOpoQe8=
-golang.org/x/sys v0.0.0-20210608053332-aa57babbf139/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/soracom/generated/cmd/assets/soracom-api.en.yaml
+++ b/soracom/generated/cmd/assets/soracom-api.en.yaml
@@ -11521,6 +11521,12 @@ paths:
         name: device_id
         required: true
         type: string
+      - default: false
+        description: If the Sigfox device is deleted immediately
+        in: query
+        name: delete_immediately
+        required: false
+        type: boolean
       produces:
       - application/json
       responses:

--- a/soracom/generated/cmd/assets/soracom-api.ja.yaml
+++ b/soracom/generated/cmd/assets/soracom-api.ja.yaml
@@ -11337,6 +11337,12 @@ paths:
         name: device_id
         required: true
         type: string
+      - default: false
+        description: Sigfox デバイスを即座に削除する
+        in: query
+        name: delete_immediately
+        required: false
+        type: boolean
       produces:
       - application/json
       responses:

--- a/soracom/generated/cmd/sigfox_devices_terminate.go
+++ b/soracom/generated/cmd/sigfox_devices_terminate.go
@@ -13,8 +13,13 @@ import (
 // SigfoxDevicesTerminateCmdDeviceId holds value of 'device_id' option
 var SigfoxDevicesTerminateCmdDeviceId string
 
+// SigfoxDevicesTerminateCmdDeleteImmediately holds value of 'delete_immediately' option
+var SigfoxDevicesTerminateCmdDeleteImmediately bool
+
 func init() {
 	SigfoxDevicesTerminateCmd.Flags().StringVar(&SigfoxDevicesTerminateCmdDeviceId, "device-id", "", TRAPI("Device ID of the target Sigfox device."))
+
+	SigfoxDevicesTerminateCmd.Flags().BoolVar(&SigfoxDevicesTerminateCmdDeleteImmediately, "delete-immediately", false, TRAPI("If the Sigfox device is deleted immediately"))
 	SigfoxDevicesCmd.AddCommand(SigfoxDevicesTerminateCmd)
 }
 
@@ -88,6 +93,10 @@ func buildPathForSigfoxDevicesTerminateCmd(path string) string {
 
 func buildQueryForSigfoxDevicesTerminateCmd() url.Values {
 	result := url.Values{}
+
+	if SigfoxDevicesTerminateCmdDeleteImmediately != false {
+		result.Add("delete_immediately", sprintf("%t", SigfoxDevicesTerminateCmdDeleteImmediately))
+	}
 
 	return result
 }


### PR DESCRIPTION
Curerntly Sigfox devices are deleted in twenty four hours after they are
terminated. However, we learned in some cases operators want to delete
them immediately. For instance, the user that has multiple operators
might want to transfer Sigfox devices between those operators. In that
case they might not want to wait for twenty four hours and register
their Sigfox devices for an operator right after terminating the devices
that were owned another operator.

To enable immediate deletion of the Sigfox devices, --delete-immediately
option is added for "sigfox-devices terminate" subcommand. This
immediately deletes the Sigfox device and its PAC is given in the
response. Note it is the responsibility of the operator to keep the PAC
with them.

Signed-off-by: Taku Fukushima <taku@soracom.jp>