### PR TITLE
use a public image on ECR Public Gallery to avoid docker hub rate limit

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5-buster
+FROM public.ecr.aws/bitnami/golang:latest
 
 RUN apt update && apt upgrade -y && apt install -y fakeroot shellcheck zip
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/golang:latest
+FROM public.ecr.aws/bitnami/golang:1.16.5
 
 RUN apt update && apt upgrade -y && apt install -y fakeroot shellcheck zip
 


### PR DESCRIPTION
Docker hub の公式イメージはときどき rate limit に引っかかって、soracom-cli をビルドして利用している他のリポジトリの CI などが失敗することがあるので、rate limit の上限の大きな ECR 上のイメージを使うことにしました。

bitnami の提供するイメージですが、一応 Verified アカウントのようですので大丈夫だと思います。

バージョン指定は latest にしてしまいましたが、特定のバージョンに固定したほうが良いでしょうか？