### PR TITLE
output just text instead of go-syntax rep of the value

### DIFF
--- a/generators/cmd/predefined/jq.go
+++ b/generators/cmd/predefined/jq.go
@@ -32,7 +32,7 @@ func processJQ(jqString, responseBody string) error {
 		}
 
 		if text, err := jsonScalarToString(v); err == nil {
-			fmt.Printf(text)
+			fmt.Println(text)
 		} else {
 			var jsonFragment []byte
 			jsonFragment, err = json.Marshal(v)


### PR DESCRIPTION
I found that with current `--query` implementation (#36), say running `soracom subscribers get --imsi xxx --query '.sessionStatus'` will output the result as:

```go
map[string]interface {}{"dnsServers":interface {}(nil), "imei":interface {}(nil), "lastUpdatedAt":1.628168770317e+12, "location":interface {}(nil), "online":false, "ueIpAddress":interface {}(nil)}
```

instead of:

```json
{
  "dnsServers": null,
  "imei": null,
  "lastUpdatedAt": 1628168770317,
  "location": null,
  "online": false,
  "ueIpAddress": null
}
```

Similar cases:

| command            | query                            | actual                                 | expected                 |
| ------------------ | -------------------------------- | -------------------------------------- | ------------------------ |
| `subscribers get`  | `.sessionStatus.dnsServers`      | `<nil>`                                | (blank)                  |
| `subscribers get`  | `.[] \| {imsi: .imsi, speedClass: .type}` | `map[string]interface {}{"imsi":"aaaaaaaaaaaaaaa", "speedClass":"s1.standard"}`           | `{"imsi":"aaaaaaaaaaaaaaa","speedClass":"s1.standard"}`            |
| `subscribers list` | `.[] \| [.imsi, .plan]`          | `[]interface {}{"aaaaaaaaaaaaaaa", 0}` | `["aaaaaaaaaaaaaaa", 0]` |

This PR will improve output, with shamelessly referring https://github.com/cli/cli/blob/trunk/pkg/export/filter.go so please reivew. Thanks!
