### PR TITLE
fix how to check required parameters

### DIFF
--- a/generators/cmd/predefined/check_param.go
+++ b/generators/cmd/predefined/check_param.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"fmt"
+)
+
+func checkIfRequiredStringParameterIsSupplied(propName, optionName, in string, parsedBody interface{}, varValue string) error {
+	if in == "body" {
+		contains := doesBodyContainParameter(parsedBody, propName)
+		if !contains && varValue == "" {
+			return fmt.Errorf("required parameter '%s' in body (or command line option '%s') is not specified", propName, optionName)
+		}
+		return nil
+	}
+
+	if varValue == "" {
+		return fmt.Errorf("required parameter '%s' is not specified", optionName)
+	}
+	return nil
+}
+
+func checkIfRequiredStringSliceParameterIsSupplied(propName, optionName, in string, parsedBody interface{}, varValue []string) error {
+	if in == "body" {
+		contains := doesBodyContainParameter(parsedBody, propName)
+		if !contains && len(varValue) == 0 {
+			return fmt.Errorf("required parameter '%s' in body (or command line option '%s') is not specified", propName, optionName)
+		}
+		return nil
+	}
+
+	if len(varValue) == 0 {
+		return fmt.Errorf("required parameter '%s' is not specified", optionName)
+	}
+	return nil
+}
+
+func checkIfRequiredIntegerParameterIsSupplied(propName, optionName, in string, parsedBody interface{}, varValue int64) error {
+	if in == "body" {
+		contains := doesBodyContainParameter(parsedBody, propName)
+		if !contains && varValue == 0 {
+			return fmt.Errorf("required parameter '%s' in body (or command line option '%s') is not specified", propName, optionName)
+		}
+		return nil
+	}
+
+	if varValue == 0 {
+		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
+	}
+	return nil
+}
+
+func checkIfRequiredFloatParameterIsSupplied(propName, optionName, in string, parsedBody interface{}, varValue float64) error {
+	if in == "body" {
+		contains := doesBodyContainParameter(parsedBody, propName)
+		if !contains && varValue == 0.0 {
+			return fmt.Errorf("required parameter '%s' in body (or command line option '%s') is not specified", propName, optionName)
+		}
+		return nil
+	}
+
+	if varValue == 0.0 {
+		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
+	}
+	return nil
+}
+
+func checkIfRequiredBoolParameterIsSupplied(propName, optionName, in string, parsedBody interface{}, varValue bool) error {
+	if in == "body" {
+		contains := doesBodyContainParameter(parsedBody, propName)
+		if !contains && varValue == false {
+			return fmt.Errorf("required parameter '%s' in body (or command line option '%s') is not specified", propName, optionName)
+		}
+		return nil
+	}
+
+	if varValue == false {
+		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
+	}
+	return nil
+}
+
+func doesBodyContainParameter(parsedBody interface{}, parameterName string) bool {
+	m, ok := parsedBody.(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	_, found := m[parameterName]
+	return found
+}

--- a/generators/cmd/predefined/check_param.go
+++ b/generators/cmd/predefined/check_param.go
@@ -67,13 +67,13 @@ func checkIfRequiredFloatParameterIsSupplied(propName, optionName, in string, pa
 func checkIfRequiredBoolParameterIsSupplied(propName, optionName, in string, parsedBody interface{}, varValue bool) error {
 	if in == "body" {
 		contains := doesBodyContainParameter(parsedBody, propName)
-		if !contains && varValue == false {
+		if !contains && !varValue {
 			return fmt.Errorf("required parameter '%s' in body (or command line option '%s') is not specified", propName, optionName)
 		}
 		return nil
 	}
 
-	if varValue == false {
+	if !varValue {
 		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
 	}
 	return nil

--- a/generators/cmd/templates/leaf.gotmpl
+++ b/generators/cmd/templates/leaf.gotmpl
@@ -2,17 +2,11 @@
 package cmd
 
 import (
-{{if .BodyExists }}
-{{if not .SendBodyRaw }}
+{{- if .BodyExists }}
   "encoding/json"
-{{end}}
-{{end}}
-{{if .RequiredFlagExists }}
   "fmt"
-{{end}}
-{{if .BodyExists }}
   "io/ioutil"
-{{end}}
+{{- end }}
   "net/url"
   "os"
 {{if .BodyExists}}
@@ -153,6 +147,18 @@ var {{ $cmdvar }} = &cobra.Command{
 }
 
 func collect{{$cmdvar}}Params(ac *apiClient) (*apiParams, error) {
+  {{- if .BodyExists }}
+  var body string
+  var parsedBody interface{}
+  var err error
+  {{- end }}
+  {{- if not .BodyExists}}
+  {{- if .RequiredFlagExists }}
+  var parsedBody interface{}
+  var err error
+  {{- end }}
+  {{- end }}
+
   {{- if .RequireOperatorID }}
   if {{$prefix}}OperatorId == "" {
     {{$prefix}}OperatorId = ac.OperatorID
@@ -160,9 +166,13 @@ func collect{{$cmdvar}}Params(ac *apiClient) (*apiParams, error) {
   {{end}}
 
   {{- if .BodyExists }}
-  body, err := buildBodyFor{{$suffix}}()
+  body, err = buildBodyFor{{$suffix}}()
   if err != nil {
     return nil, err
+  }
+  err = json.Unmarshal([]byte(body), &parsedBody)
+  if err != nil {
+    return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
   }
 
   {{- if .ContentTypeFromArg }}
@@ -178,14 +188,9 @@ func collect{{$cmdvar}}Params(ac *apiClient) (*apiParams, error) {
   {{- if .Required}}
   {{- if ne .VarName "OperatorId" }}
   {{- if not .DefaultValueSpecified }}
-  if {{$prefix}}{{.VarName}} == "" {
-    {{- if $bodyExists}}
-    if body == "" {
-    {{end}}
-    return nil, fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
-    {{- if $bodyExists}}
-    }
-    {{end}}
+  err = checkIfRequiredStringParameterIsSupplied("{{.Name}}", "{{.LongOption}}", "{{.In}}", parsedBody, {{$prefix}}{{.VarName}})
+  if err != nil {
+    return nil, err
   }
   {{end}}
   {{end}}
@@ -195,14 +200,9 @@ func collect{{$cmdvar}}Params(ac *apiClient) (*apiParams, error) {
   {{- range .StringSliceFlags}}
   {{- if .Required}}
   {{- if not .DefaultValueSpecified }}
-  if len({{$prefix}}{{.VarName}}) == 0 {
-    {{- if $bodyExists}}
-    if body == "" {
-    {{end}}
-    return nil, fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
-    {{- if $bodyExists}}
-    }
-    {{end}}
+  err = checkIfRequiredStringSliceParameterIsSupplied("{{.Name}}", "{{.LongOption}}", "{{.In}}", parsedBody, {{$prefix}}{{.VarName}})
+  if err != nil {
+    return nil, err
   }
   {{end}}
   {{end}}
@@ -211,14 +211,9 @@ func collect{{$cmdvar}}Params(ac *apiClient) (*apiParams, error) {
   {{- range .IntegerFlags}}
   {{- if .Required}}
   {{- if not .DefaultValueSpecified }}
-  if {{$prefix}}{{.VarName}} == 0 {
-    {{- if $bodyExists}}
-    if body == "" {
-    {{end}}
-    return nil, fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
-    {{- if $bodyExists}}
-    }
-    {{end}}
+  err = checkIfRequiredIntegerParameterIsSupplied("{{.Name}}", "{{.LongOption}}", "{{.In}}", parsedBody, {{$prefix}}{{.VarName}})
+  if err != nil {
+    return nil, err
   }
   {{end}}
   {{end}}
@@ -227,14 +222,9 @@ func collect{{$cmdvar}}Params(ac *apiClient) (*apiParams, error) {
   {{- range .FloatFlags}}
   {{- if .Required}}
   {{- if not .DefaultValueSpecified }}
-  if {{$prefix}}{{.VarName}} == 0.0 {
-    {{- if $bodyExists}}
-    if body == "" {
-    {{end}}
-    return nil, fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
-    {{- if $bodyExists}}
-    }
-    {{end}}
+  err = checkIfRequiredFloatParameterIsSupplied("{{.Name}}", "{{.LongOption}}", "{{.In}}", parsedBody, {{$prefix}}{{.VarName}})
+  if err != nil {
+    return nil, err
   }
   {{end}}
   {{end}}
@@ -243,14 +233,9 @@ func collect{{$cmdvar}}Params(ac *apiClient) (*apiParams, error) {
   {{- range .BoolFlags}}
   {{- if .Required}}
   {{- if not .DefaultValueSpecified }}
-  if {{$prefix}}{{.VarName}} == false {
-    {{- if $bodyExists}}
-    if body == "" {
-    {{end}}
-    return nil, fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
-    {{- if $bodyExists}}
-    }
-    {{end}}
+  err = checkIfRequiredBoolParameterIsSupplied("{{.Name}}", "{{.LongOption}}", "{{.In}}", parsedBody, {{$prefix}}{{.VarName}})
+  if err != nil {
+    return nil, err
   }
   {{end}}
   {{end}}

--- a/soracom/generated/cmd/auth.go
+++ b/soracom/generated/cmd/auth.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -103,9 +102,16 @@ var AuthCmd = &cobra.Command{
 }
 
 func collectAuthCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForAuthCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForAuthCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/auth_issue_password_reset_token.go
+++ b/soracom/generated/cmd/auth_issue_password_reset_token.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -70,18 +67,22 @@ var AuthIssuePasswordResetTokenCmd = &cobra.Command{
 }
 
 func collectAuthIssuePasswordResetTokenCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForAuthIssuePasswordResetTokenCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForAuthIssuePasswordResetTokenCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if AuthIssuePasswordResetTokenCmdEmail == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "email")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("email", "email", "body", parsedBody, AuthIssuePasswordResetTokenCmdEmail)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/auth_verify_password_reset_token.go
+++ b/soracom/generated/cmd/auth_verify_password_reset_token.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -75,26 +72,27 @@ var AuthVerifyPasswordResetTokenCmd = &cobra.Command{
 }
 
 func collectAuthVerifyPasswordResetTokenCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForAuthVerifyPasswordResetTokenCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForAuthVerifyPasswordResetTokenCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if AuthVerifyPasswordResetTokenCmdPassword == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "password")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("password", "password", "body", parsedBody, AuthVerifyPasswordResetTokenCmdPassword)
+	if err != nil {
+		return nil, err
 	}
 
-	if AuthVerifyPasswordResetTokenCmdToken == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "token")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("token", "token", "body", parsedBody, AuthVerifyPasswordResetTokenCmdToken)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/bills_export.go
+++ b/soracom/generated/cmd/bills_export.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -70,9 +68,12 @@ var BillsExportCmd = &cobra.Command{
 }
 
 func collectBillsExportCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if BillsExportCmdYyyyMM == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "yyyy-mm")
+	err = checkIfRequiredStringParameterIsSupplied("yyyyMM", "yyyy-mm", "path", parsedBody, BillsExportCmdYyyyMM)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/bills_get.go
+++ b/soracom/generated/cmd/bills_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var BillsGetCmd = &cobra.Command{
 }
 
 func collectBillsGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if BillsGetCmdYyyyMM == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "yyyy-mm")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("yyyyMM", "yyyy-mm", "path", parsedBody, BillsGetCmdYyyyMM)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/bills_get_daily.go
+++ b/soracom/generated/cmd/bills_get_daily.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var BillsGetDailyCmd = &cobra.Command{
 }
 
 func collectBillsGetDailyCmdParams(ac *apiClient) (*apiParams, error) {
-	if BillsGetDailyCmdYyyyMM == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "yyyy-mm")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("yyyyMM", "yyyy-mm", "path", parsedBody, BillsGetDailyCmdYyyyMM)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/cell_locations_batch_get.go
+++ b/soracom/generated/cmd/cell_locations_batch_get.go
@@ -2,8 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -66,9 +67,16 @@ var CellLocationsBatchGetCmd = &cobra.Command{
 }
 
 func collectCellLocationsBatchGetCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForCellLocationsBatchGetCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForCellLocationsBatchGetCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/cell_locations_get.go
+++ b/soracom/generated/cmd/cell_locations_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -89,13 +87,17 @@ var CellLocationsGetCmd = &cobra.Command{
 }
 
 func collectCellLocationsGetCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if CellLocationsGetCmdMcc == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "mcc")
+	err = checkIfRequiredStringParameterIsSupplied("mcc", "mcc", "query", parsedBody, CellLocationsGetCmdMcc)
+	if err != nil {
+		return nil, err
 	}
 
-	if CellLocationsGetCmdMnc == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "mnc")
+	err = checkIfRequiredStringParameterIsSupplied("mnc", "mnc", "query", parsedBody, CellLocationsGetCmdMnc)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/check_param.go
+++ b/soracom/generated/cmd/check_param.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"fmt"
+)
+
+func checkIfRequiredStringParameterIsSupplied(propName, optionName, in string, parsedBody interface{}, varValue string) error {
+	if in == "body" {
+		contains := doesBodyContainParameter(parsedBody, propName)
+		if !contains && varValue == "" {
+			return fmt.Errorf("required parameter '%s' in body (or command line option '%s') is not specified", propName, optionName)
+		}
+		return nil
+	}
+
+	if varValue == "" {
+		return fmt.Errorf("required parameter '%s' is not specified", optionName)
+	}
+	return nil
+}
+
+func checkIfRequiredStringSliceParameterIsSupplied(propName, optionName, in string, parsedBody interface{}, varValue []string) error {
+	if in == "body" {
+		contains := doesBodyContainParameter(parsedBody, propName)
+		if !contains && len(varValue) == 0 {
+			return fmt.Errorf("required parameter '%s' in body (or command line option '%s') is not specified", propName, optionName)
+		}
+		return nil
+	}
+
+	if len(varValue) == 0 {
+		return fmt.Errorf("required parameter '%s' is not specified", optionName)
+	}
+	return nil
+}
+
+func checkIfRequiredIntegerParameterIsSupplied(propName, optionName, in string, parsedBody interface{}, varValue int64) error {
+	if in == "body" {
+		contains := doesBodyContainParameter(parsedBody, propName)
+		if !contains && varValue == 0 {
+			return fmt.Errorf("required parameter '%s' in body (or command line option '%s') is not specified", propName, optionName)
+		}
+		return nil
+	}
+
+	if varValue == 0 {
+		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
+	}
+	return nil
+}
+
+func checkIfRequiredFloatParameterIsSupplied(propName, optionName, in string, parsedBody interface{}, varValue float64) error {
+	if in == "body" {
+		contains := doesBodyContainParameter(parsedBody, propName)
+		if !contains && varValue == 0.0 {
+			return fmt.Errorf("required parameter '%s' in body (or command line option '%s') is not specified", propName, optionName)
+		}
+		return nil
+	}
+
+	if varValue == 0.0 {
+		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
+	}
+	return nil
+}
+
+func checkIfRequiredBoolParameterIsSupplied(propName, optionName, in string, parsedBody interface{}, varValue bool) error {
+	if in == "body" {
+		contains := doesBodyContainParameter(parsedBody, propName)
+		if !contains && varValue == false {
+			return fmt.Errorf("required parameter '%s' in body (or command line option '%s') is not specified", propName, optionName)
+		}
+		return nil
+	}
+
+	if varValue == false {
+		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
+	}
+	return nil
+}
+
+func doesBodyContainParameter(parsedBody interface{}, parameterName string) bool {
+	m, ok := parsedBody.(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	_, found := m[parameterName]
+	return found
+}

--- a/soracom/generated/cmd/coupons_confirm.go
+++ b/soracom/generated/cmd/coupons_confirm.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var CouponsConfirmCmd = &cobra.Command{
 }
 
 func collectCouponsConfirmCmdParams(ac *apiClient) (*apiParams, error) {
-	if CouponsConfirmCmdOrderId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "order-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("order_id", "order-id", "path", parsedBody, CouponsConfirmCmdOrderId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/coupons_create.go
+++ b/soracom/generated/cmd/coupons_create.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -75,18 +72,22 @@ var CouponsCreateCmd = &cobra.Command{
 }
 
 func collectCouponsCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForCouponsCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForCouponsCreateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if CouponsCreateCmdAmount == 0.0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "amount")
-		}
-
+	err = checkIfRequiredFloatParameterIsSupplied("amount", "amount", "body", parsedBody, CouponsCreateCmdAmount)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/coupons_register.go
+++ b/soracom/generated/cmd/coupons_register.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var CouponsRegisterCmd = &cobra.Command{
 }
 
 func collectCouponsRegisterCmdParams(ac *apiClient) (*apiParams, error) {
-	if CouponsRegisterCmdCouponCode == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "coupon-code")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("coupon_code", "coupon-code", "path", parsedBody, CouponsRegisterCmdCouponCode)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/credentials_create.go
+++ b/soracom/generated/cmd/credentials_create.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var CredentialsCreateCmd = &cobra.Command{
 }
 
 func collectCredentialsCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForCredentialsCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForCredentialsCreateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if CredentialsCreateCmdCredentialsId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "credentials-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("credentials_id", "credentials-id", "path", parsedBody, CredentialsCreateCmdCredentialsId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/credentials_delete.go
+++ b/soracom/generated/cmd/credentials_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var CredentialsDeleteCmd = &cobra.Command{
 }
 
 func collectCredentialsDeleteCmdParams(ac *apiClient) (*apiParams, error) {
-	if CredentialsDeleteCmdCredentialsId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "credentials-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("credentials_id", "credentials-id", "path", parsedBody, CredentialsDeleteCmdCredentialsId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/credentials_update.go
+++ b/soracom/generated/cmd/credentials_update.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var CredentialsUpdateCmd = &cobra.Command{
 }
 
 func collectCredentialsUpdateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForCredentialsUpdateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForCredentialsUpdateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if CredentialsUpdateCmdCredentialsId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "credentials-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("credentials_id", "credentials-id", "path", parsedBody, CredentialsUpdateCmdCredentialsId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/data_delete_entry.go
+++ b/soracom/generated/cmd/data_delete_entry.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,16 +72,21 @@ var DataDeleteEntryCmd = &cobra.Command{
 }
 
 func collectDataDeleteEntryCmdParams(ac *apiClient) (*apiParams, error) {
-	if DataDeleteEntryCmdResourceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "resource-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("resource_id", "resource-id", "path", parsedBody, DataDeleteEntryCmdResourceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DataDeleteEntryCmdResourceType == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "resource-type")
+	err = checkIfRequiredStringParameterIsSupplied("resource_type", "resource-type", "path", parsedBody, DataDeleteEntryCmdResourceType)
+	if err != nil {
+		return nil, err
 	}
 
-	if DataDeleteEntryCmdTime == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "time")
+	err = checkIfRequiredIntegerParameterIsSupplied("time", "time", "path", parsedBody, DataDeleteEntryCmdTime)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/data_get.go
+++ b/soracom/generated/cmd/data_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -94,8 +92,11 @@ var DataGetCmd = &cobra.Command{
 }
 
 func collectDataGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if DataGetCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, DataGetCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/data_get_entries.go
+++ b/soracom/generated/cmd/data_get_entries.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -99,13 +97,17 @@ var DataGetEntriesCmd = &cobra.Command{
 }
 
 func collectDataGetEntriesCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if DataGetEntriesCmdResourceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "resource-id")
+	err = checkIfRequiredStringParameterIsSupplied("resource_id", "resource-id", "path", parsedBody, DataGetEntriesCmdResourceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DataGetEntriesCmdResourceType == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "resource-type")
+	err = checkIfRequiredStringParameterIsSupplied("resource_type", "resource-type", "path", parsedBody, DataGetEntriesCmdResourceType)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/data_get_entry.go
+++ b/soracom/generated/cmd/data_get_entry.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,16 +72,21 @@ var DataGetEntryCmd = &cobra.Command{
 }
 
 func collectDataGetEntryCmdParams(ac *apiClient) (*apiParams, error) {
-	if DataGetEntryCmdResourceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "resource-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("resource_id", "resource-id", "path", parsedBody, DataGetEntryCmdResourceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DataGetEntryCmdResourceType == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "resource-type")
+	err = checkIfRequiredStringParameterIsSupplied("resource_type", "resource-type", "path", parsedBody, DataGetEntryCmdResourceType)
+	if err != nil {
+		return nil, err
 	}
 
-	if DataGetEntryCmdTime == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "time")
+	err = checkIfRequiredIntegerParameterIsSupplied("time", "time", "path", parsedBody, DataGetEntryCmdTime)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_create.go
+++ b/soracom/generated/cmd/devices_create.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -138,9 +137,16 @@ var DevicesCreateCmd = &cobra.Command{
 }
 
 func collectDevicesCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForDevicesCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForDevicesCreateCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/devices_create_object_model.go
+++ b/soracom/generated/cmd/devices_create_object_model.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -103,9 +102,16 @@ var DevicesCreateObjectModelCmd = &cobra.Command{
 }
 
 func collectDevicesCreateObjectModelCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForDevicesCreateObjectModelCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForDevicesCreateObjectModelCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/devices_delete.go
+++ b/soracom/generated/cmd/devices_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var DevicesDeleteCmd = &cobra.Command{
 }
 
 func collectDevicesDeleteCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesDeleteCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesDeleteCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_delete_device_tag.go
+++ b/soracom/generated/cmd/devices_delete_device_tag.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var DevicesDeleteDeviceTagCmd = &cobra.Command{
 }
 
 func collectDevicesDeleteDeviceTagCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesDeleteDeviceTagCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesDeleteDeviceTagCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesDeleteDeviceTagCmdTagName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "tag-name")
+	err = checkIfRequiredStringParameterIsSupplied("tag_name", "tag-name", "path", parsedBody, DevicesDeleteDeviceTagCmdTagName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_delete_object_model.go
+++ b/soracom/generated/cmd/devices_delete_object_model.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var DevicesDeleteObjectModelCmd = &cobra.Command{
 }
 
 func collectDevicesDeleteObjectModelCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesDeleteObjectModelCmdModelId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "model-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("model_id", "model-id", "path", parsedBody, DevicesDeleteObjectModelCmdModelId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_execute_resource.go
+++ b/soracom/generated/cmd/devices_execute_resource.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -90,42 +87,37 @@ var DevicesExecuteResourceCmd = &cobra.Command{
 }
 
 func collectDevicesExecuteResourceCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForDevicesExecuteResourceCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForDevicesExecuteResourceCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if DevicesExecuteResourceCmdDeviceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesExecuteResourceCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesExecuteResourceCmdInstance == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "instance")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("instance", "instance", "path", parsedBody, DevicesExecuteResourceCmdInstance)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesExecuteResourceCmdObject == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "object")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("object", "object", "path", parsedBody, DevicesExecuteResourceCmdObject)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesExecuteResourceCmdResource == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "resource")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("resource", "resource", "path", parsedBody, DevicesExecuteResourceCmdResource)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_get.go
+++ b/soracom/generated/cmd/devices_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,8 +67,11 @@ var DevicesGetCmd = &cobra.Command{
 }
 
 func collectDevicesGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesGetCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesGetCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_get_data.go
+++ b/soracom/generated/cmd/devices_get_data.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -94,8 +92,11 @@ var DevicesGetDataCmd = &cobra.Command{
 }
 
 func collectDevicesGetDataCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesGetDataCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesGetDataCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_get_instance.go
+++ b/soracom/generated/cmd/devices_get_instance.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -79,16 +77,21 @@ var DevicesGetInstanceCmd = &cobra.Command{
 }
 
 func collectDevicesGetInstanceCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesGetInstanceCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesGetInstanceCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesGetInstanceCmdInstance == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "instance")
+	err = checkIfRequiredStringParameterIsSupplied("instance", "instance", "path", parsedBody, DevicesGetInstanceCmdInstance)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesGetInstanceCmdObject == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "object")
+	err = checkIfRequiredStringParameterIsSupplied("object", "object", "path", parsedBody, DevicesGetInstanceCmdObject)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_get_object_model.go
+++ b/soracom/generated/cmd/devices_get_object_model.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var DevicesGetObjectModelCmd = &cobra.Command{
 }
 
 func collectDevicesGetObjectModelCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesGetObjectModelCmdModelId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "model-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("model_id", "model-id", "path", parsedBody, DevicesGetObjectModelCmdModelId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_get_resource.go
+++ b/soracom/generated/cmd/devices_get_resource.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -84,20 +82,26 @@ var DevicesGetResourceCmd = &cobra.Command{
 }
 
 func collectDevicesGetResourceCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesGetResourceCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesGetResourceCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesGetResourceCmdInstance == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "instance")
+	err = checkIfRequiredStringParameterIsSupplied("instance", "instance", "path", parsedBody, DevicesGetResourceCmdInstance)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesGetResourceCmdObject == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "object")
+	err = checkIfRequiredStringParameterIsSupplied("object", "object", "path", parsedBody, DevicesGetResourceCmdObject)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesGetResourceCmdResource == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "resource")
+	err = checkIfRequiredStringParameterIsSupplied("resource", "resource", "path", parsedBody, DevicesGetResourceCmdResource)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_observe_resource.go
+++ b/soracom/generated/cmd/devices_observe_resource.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -84,20 +82,26 @@ var DevicesObserveResourceCmd = &cobra.Command{
 }
 
 func collectDevicesObserveResourceCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesObserveResourceCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesObserveResourceCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesObserveResourceCmdInstance == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "instance")
+	err = checkIfRequiredStringParameterIsSupplied("instance", "instance", "path", parsedBody, DevicesObserveResourceCmdInstance)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesObserveResourceCmdObject == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "object")
+	err = checkIfRequiredStringParameterIsSupplied("object", "object", "path", parsedBody, DevicesObserveResourceCmdObject)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesObserveResourceCmdResource == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "resource")
+	err = checkIfRequiredStringParameterIsSupplied("resource", "resource", "path", parsedBody, DevicesObserveResourceCmdResource)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_observe_resources.go
+++ b/soracom/generated/cmd/devices_observe_resources.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -79,16 +77,21 @@ var DevicesObserveResourcesCmd = &cobra.Command{
 }
 
 func collectDevicesObserveResourcesCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesObserveResourcesCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesObserveResourcesCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesObserveResourcesCmdInstance == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "instance")
+	err = checkIfRequiredStringParameterIsSupplied("instance", "instance", "path", parsedBody, DevicesObserveResourcesCmdInstance)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesObserveResourcesCmdObject == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "object")
+	err = checkIfRequiredStringParameterIsSupplied("object", "object", "path", parsedBody, DevicesObserveResourcesCmdObject)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_put_device_tags.go
+++ b/soracom/generated/cmd/devices_put_device_tags.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,18 +72,22 @@ var DevicesPutDeviceTagsCmd = &cobra.Command{
 }
 
 func collectDevicesPutDeviceTagsCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForDevicesPutDeviceTagsCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForDevicesPutDeviceTagsCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if DevicesPutDeviceTagsCmdDeviceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesPutDeviceTagsCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_put_resource.go
+++ b/soracom/generated/cmd/devices_put_resource.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -90,42 +87,37 @@ var DevicesPutResourceCmd = &cobra.Command{
 }
 
 func collectDevicesPutResourceCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForDevicesPutResourceCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForDevicesPutResourceCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if DevicesPutResourceCmdDeviceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesPutResourceCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesPutResourceCmdInstance == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "instance")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("instance", "instance", "path", parsedBody, DevicesPutResourceCmdInstance)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesPutResourceCmdObject == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "object")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("object", "object", "path", parsedBody, DevicesPutResourceCmdObject)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesPutResourceCmdResource == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "resource")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("resource", "resource", "path", parsedBody, DevicesPutResourceCmdResource)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_set_group.go
+++ b/soracom/generated/cmd/devices_set_group.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -75,18 +72,22 @@ var DevicesSetGroupCmd = &cobra.Command{
 }
 
 func collectDevicesSetGroupCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForDevicesSetGroupCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForDevicesSetGroupCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if DevicesSetGroupCmdDeviceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesSetGroupCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_set_object_model_scope.go
+++ b/soracom/generated/cmd/devices_set_object_model_scope.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var DevicesSetObjectModelScopeCmd = &cobra.Command{
 }
 
 func collectDevicesSetObjectModelScopeCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForDevicesSetObjectModelScopeCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForDevicesSetObjectModelScopeCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if DevicesSetObjectModelScopeCmdModelId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "model-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("model_id", "model-id", "path", parsedBody, DevicesSetObjectModelScopeCmdModelId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_unobserve_resource.go
+++ b/soracom/generated/cmd/devices_unobserve_resource.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -79,20 +77,26 @@ var DevicesUnobserveResourceCmd = &cobra.Command{
 }
 
 func collectDevicesUnobserveResourceCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesUnobserveResourceCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesUnobserveResourceCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesUnobserveResourceCmdInstance == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "instance")
+	err = checkIfRequiredStringParameterIsSupplied("instance", "instance", "path", parsedBody, DevicesUnobserveResourceCmdInstance)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesUnobserveResourceCmdObject == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "object")
+	err = checkIfRequiredStringParameterIsSupplied("object", "object", "path", parsedBody, DevicesUnobserveResourceCmdObject)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesUnobserveResourceCmdResource == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "resource")
+	err = checkIfRequiredStringParameterIsSupplied("resource", "resource", "path", parsedBody, DevicesUnobserveResourceCmdResource)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_unobserve_resources.go
+++ b/soracom/generated/cmd/devices_unobserve_resources.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,16 +72,21 @@ var DevicesUnobserveResourcesCmd = &cobra.Command{
 }
 
 func collectDevicesUnobserveResourcesCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesUnobserveResourcesCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesUnobserveResourcesCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesUnobserveResourcesCmdInstance == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "instance")
+	err = checkIfRequiredStringParameterIsSupplied("instance", "instance", "path", parsedBody, DevicesUnobserveResourcesCmdInstance)
+	if err != nil {
+		return nil, err
 	}
 
-	if DevicesUnobserveResourcesCmdObject == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "object")
+	err = checkIfRequiredStringParameterIsSupplied("object", "object", "path", parsedBody, DevicesUnobserveResourcesCmdObject)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_unset_group.go
+++ b/soracom/generated/cmd/devices_unset_group.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var DevicesUnsetGroupCmd = &cobra.Command{
 }
 
 func collectDevicesUnsetGroupCmdParams(ac *apiClient) (*apiParams, error) {
-	if DevicesUnsetGroupCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, DevicesUnsetGroupCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/devices_update_object_model.go
+++ b/soracom/generated/cmd/devices_update_object_model.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -110,18 +107,22 @@ var DevicesUpdateObjectModelCmd = &cobra.Command{
 }
 
 func collectDevicesUpdateObjectModelCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForDevicesUpdateObjectModelCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForDevicesUpdateObjectModelCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if DevicesUpdateObjectModelCmdModelId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "model-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("model_id", "model-id", "path", parsedBody, DevicesUpdateObjectModelCmdModelId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/diagnostics_get.go
+++ b/soracom/generated/cmd/diagnostics_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var DiagnosticsGetCmd = &cobra.Command{
 }
 
 func collectDiagnosticsGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if DiagnosticsGetCmdDiagnosticId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "diagnostic-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("diagnostic_id", "diagnostic-id", "path", parsedBody, DiagnosticsGetCmdDiagnosticId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/diagnostics_send_request.go
+++ b/soracom/generated/cmd/diagnostics_send_request.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -95,50 +92,42 @@ var DiagnosticsSendRequestCmd = &cobra.Command{
 }
 
 func collectDiagnosticsSendRequestCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForDiagnosticsSendRequestCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForDiagnosticsSendRequestCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if DiagnosticsSendRequestCmdResourceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "resource-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("resourceId", "resource-id", "body", parsedBody, DiagnosticsSendRequestCmdResourceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if DiagnosticsSendRequestCmdResourceType == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "resource-type")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("resourceType", "resource-type", "body", parsedBody, DiagnosticsSendRequestCmdResourceType)
+	if err != nil {
+		return nil, err
 	}
 
-	if DiagnosticsSendRequestCmdService == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "service")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("service", "service", "body", parsedBody, DiagnosticsSendRequestCmdService)
+	if err != nil {
+		return nil, err
 	}
 
-	if DiagnosticsSendRequestCmdFrom == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "from")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("from", "from", "body", parsedBody, DiagnosticsSendRequestCmdFrom)
+	if err != nil {
+		return nil, err
 	}
 
-	if DiagnosticsSendRequestCmdTo == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "to")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("to", "to", "body", parsedBody, DiagnosticsSendRequestCmdTo)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/emails_delete.go
+++ b/soracom/generated/cmd/emails_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var EmailsDeleteCmd = &cobra.Command{
 }
 
 func collectEmailsDeleteCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if EmailsDeleteCmdOperatorId == "" {
 		EmailsDeleteCmdOperatorId = ac.OperatorID
 	}
 
-	if EmailsDeleteCmdEmailId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "email-id")
+	err = checkIfRequiredStringParameterIsSupplied("email_id", "email-id", "path", parsedBody, EmailsDeleteCmdEmailId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/emails_get.go
+++ b/soracom/generated/cmd/emails_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var EmailsGetCmd = &cobra.Command{
 }
 
 func collectEmailsGetCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if EmailsGetCmdOperatorId == "" {
 		EmailsGetCmdOperatorId = ac.OperatorID
 	}
 
-	if EmailsGetCmdEmailId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "email-id")
+	err = checkIfRequiredStringParameterIsSupplied("email_id", "email-id", "path", parsedBody, EmailsGetCmdEmailId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/emails_issue_add_email_token.go
+++ b/soracom/generated/cmd/emails_issue_add_email_token.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,26 +77,27 @@ var EmailsIssueAddEmailTokenCmd = &cobra.Command{
 }
 
 func collectEmailsIssueAddEmailTokenCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForEmailsIssueAddEmailTokenCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForEmailsIssueAddEmailTokenCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if EmailsIssueAddEmailTokenCmdEmail == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "email")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("email", "email", "body", parsedBody, EmailsIssueAddEmailTokenCmdEmail)
+	if err != nil {
+		return nil, err
 	}
 
-	if EmailsIssueAddEmailTokenCmdPassword == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "password")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("password", "password", "body", parsedBody, EmailsIssueAddEmailTokenCmdPassword)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/emails_verify_add_email_token.go
+++ b/soracom/generated/cmd/emails_verify_add_email_token.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -70,18 +67,22 @@ var EmailsVerifyAddEmailTokenCmd = &cobra.Command{
 }
 
 func collectEmailsVerifyAddEmailTokenCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForEmailsVerifyAddEmailTokenCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForEmailsVerifyAddEmailTokenCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if EmailsVerifyAddEmailTokenCmdToken == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "token")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("token", "token", "body", parsedBody, EmailsVerifyAddEmailTokenCmdToken)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/event_handlers_create.go
+++ b/soracom/generated/cmd/event_handlers_create.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -105,18 +102,22 @@ var EventHandlersCreateCmd = &cobra.Command{
 }
 
 func collectEventHandlersCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForEventHandlersCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForEventHandlersCreateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if EventHandlersCreateCmdStatus == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "status")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("status", "status", "body", parsedBody, EventHandlersCreateCmdStatus)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/event_handlers_delete.go
+++ b/soracom/generated/cmd/event_handlers_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var EventHandlersDeleteCmd = &cobra.Command{
 }
 
 func collectEventHandlersDeleteCmdParams(ac *apiClient) (*apiParams, error) {
-	if EventHandlersDeleteCmdHandlerId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "handler-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("handler_id", "handler-id", "path", parsedBody, EventHandlersDeleteCmdHandlerId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/event_handlers_get.go
+++ b/soracom/generated/cmd/event_handlers_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var EventHandlersGetCmd = &cobra.Command{
 }
 
 func collectEventHandlersGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if EventHandlersGetCmdHandlerId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "handler-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("handler_id", "handler-id", "path", parsedBody, EventHandlersGetCmdHandlerId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/event_handlers_ignore.go
+++ b/soracom/generated/cmd/event_handlers_ignore.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var EventHandlersIgnoreCmd = &cobra.Command{
 }
 
 func collectEventHandlersIgnoreCmdParams(ac *apiClient) (*apiParams, error) {
-	if EventHandlersIgnoreCmdHandlerId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "handler-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("handler_id", "handler-id", "path", parsedBody, EventHandlersIgnoreCmdHandlerId)
+	if err != nil {
+		return nil, err
 	}
 
-	if EventHandlersIgnoreCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, EventHandlersIgnoreCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/event_handlers_list_for_subscriber.go
+++ b/soracom/generated/cmd/event_handlers_list_for_subscriber.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var EventHandlersListForSubscriberCmd = &cobra.Command{
 }
 
 func collectEventHandlersListForSubscriberCmdParams(ac *apiClient) (*apiParams, error) {
-	if EventHandlersListForSubscriberCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, EventHandlersListForSubscriberCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/event_handlers_unignore.go
+++ b/soracom/generated/cmd/event_handlers_unignore.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var EventHandlersUnignoreCmd = &cobra.Command{
 }
 
 func collectEventHandlersUnignoreCmdParams(ac *apiClient) (*apiParams, error) {
-	if EventHandlersUnignoreCmdHandlerId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "handler-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("handler_id", "handler-id", "path", parsedBody, EventHandlersUnignoreCmdHandlerId)
+	if err != nil {
+		return nil, err
 	}
 
-	if EventHandlersUnignoreCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, EventHandlersUnignoreCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/event_handlers_update.go
+++ b/soracom/generated/cmd/event_handlers_update.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -75,18 +72,22 @@ var EventHandlersUpdateCmd = &cobra.Command{
 }
 
 func collectEventHandlersUpdateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForEventHandlersUpdateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForEventHandlersUpdateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if EventHandlersUpdateCmdHandlerId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "handler-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("handler_id", "handler-id", "path", parsedBody, EventHandlersUpdateCmdHandlerId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/files_delete.go
+++ b/soracom/generated/cmd/files_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,8 +67,11 @@ var FilesDeleteCmd = &cobra.Command{
 }
 
 func collectFilesDeleteCmdParams(ac *apiClient) (*apiParams, error) {
-	if FilesDeleteCmdPath == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "path")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("path", "path", "path", parsedBody, FilesDeleteCmdPath)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/files_delete_directory.go
+++ b/soracom/generated/cmd/files_delete_directory.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,8 +67,11 @@ var FilesDeleteDirectoryCmd = &cobra.Command{
 }
 
 func collectFilesDeleteDirectoryCmdParams(ac *apiClient) (*apiParams, error) {
-	if FilesDeleteDirectoryCmdPath == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "path")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("path", "path", "path", parsedBody, FilesDeleteDirectoryCmdPath)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/files_find.go
+++ b/soracom/generated/cmd/files_find.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -84,13 +82,17 @@ var FilesFindCmd = &cobra.Command{
 }
 
 func collectFilesFindCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if FilesFindCmdPrefix == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "prefix")
+	err = checkIfRequiredStringParameterIsSupplied("prefix", "prefix", "query", parsedBody, FilesFindCmdPrefix)
+	if err != nil {
+		return nil, err
 	}
 
-	if FilesFindCmdScope == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "scope")
+	err = checkIfRequiredStringParameterIsSupplied("scope", "scope", "query", parsedBody, FilesFindCmdScope)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/files_get.go
+++ b/soracom/generated/cmd/files_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -70,8 +68,11 @@ var FilesGetCmd = &cobra.Command{
 }
 
 func collectFilesGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if FilesGetCmdPath == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "path")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("path", "path", "path", parsedBody, FilesGetCmdPath)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/files_get_exported.go
+++ b/soracom/generated/cmd/files_get_exported.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var FilesGetExportedCmd = &cobra.Command{
 }
 
 func collectFilesGetExportedCmdParams(ac *apiClient) (*apiParams, error) {
-	if FilesGetExportedCmdExportedFileId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "exported-file-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("exported_file_id", "exported-file-id", "path", parsedBody, FilesGetExportedCmdExportedFileId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/files_get_metadata.go
+++ b/soracom/generated/cmd/files_get_metadata.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,8 +67,11 @@ var FilesGetMetadataCmd = &cobra.Command{
 }
 
 func collectFilesGetMetadataCmdParams(ac *apiClient) (*apiParams, error) {
-	if FilesGetMetadataCmdPath == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "path")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("path", "path", "path", parsedBody, FilesGetMetadataCmdPath)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/files_put.go
+++ b/soracom/generated/cmd/files_put.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -83,18 +82,22 @@ var FilesPutCmd = &cobra.Command{
 }
 
 func collectFilesPutCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForFilesPutCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForFilesPutCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := FilesPutCmdContentType
 
-	if FilesPutCmdPath == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "path")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("path", "path", "path", parsedBody, FilesPutCmdPath)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/gadgets_delete_tag.go
+++ b/soracom/generated/cmd/gadgets_delete_tag.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,16 +72,21 @@ var GadgetsDeleteTagCmd = &cobra.Command{
 }
 
 func collectGadgetsDeleteTagCmdParams(ac *apiClient) (*apiParams, error) {
-	if GadgetsDeleteTagCmdProductId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "product-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("product_id", "product-id", "path", parsedBody, GadgetsDeleteTagCmdProductId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GadgetsDeleteTagCmdSerialNumber == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "serial-number")
+	err = checkIfRequiredStringParameterIsSupplied("serial_number", "serial-number", "path", parsedBody, GadgetsDeleteTagCmdSerialNumber)
+	if err != nil {
+		return nil, err
 	}
 
-	if GadgetsDeleteTagCmdTagName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "tag-name")
+	err = checkIfRequiredStringParameterIsSupplied("tag_name", "tag-name", "path", parsedBody, GadgetsDeleteTagCmdTagName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/gadgets_disable_termination.go
+++ b/soracom/generated/cmd/gadgets_disable_termination.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var GadgetsDisableTerminationCmd = &cobra.Command{
 }
 
 func collectGadgetsDisableTerminationCmdParams(ac *apiClient) (*apiParams, error) {
-	if GadgetsDisableTerminationCmdProductId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "product-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("product_id", "product-id", "path", parsedBody, GadgetsDisableTerminationCmdProductId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GadgetsDisableTerminationCmdSerialNumber == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "serial-number")
+	err = checkIfRequiredStringParameterIsSupplied("serial_number", "serial-number", "path", parsedBody, GadgetsDisableTerminationCmdSerialNumber)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/gadgets_enable_termination.go
+++ b/soracom/generated/cmd/gadgets_enable_termination.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var GadgetsEnableTerminationCmd = &cobra.Command{
 }
 
 func collectGadgetsEnableTerminationCmdParams(ac *apiClient) (*apiParams, error) {
-	if GadgetsEnableTerminationCmdProductId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "product-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("product_id", "product-id", "path", parsedBody, GadgetsEnableTerminationCmdProductId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GadgetsEnableTerminationCmdSerialNumber == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "serial-number")
+	err = checkIfRequiredStringParameterIsSupplied("serial_number", "serial-number", "path", parsedBody, GadgetsEnableTerminationCmdSerialNumber)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/gadgets_get.go
+++ b/soracom/generated/cmd/gadgets_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var GadgetsGetCmd = &cobra.Command{
 }
 
 func collectGadgetsGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if GadgetsGetCmdProductId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "product-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("product_id", "product-id", "path", parsedBody, GadgetsGetCmdProductId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GadgetsGetCmdSerialNumber == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "serial-number")
+	err = checkIfRequiredStringParameterIsSupplied("serial_number", "serial-number", "path", parsedBody, GadgetsGetCmdSerialNumber)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/gadgets_put_tags.go
+++ b/soracom/generated/cmd/gadgets_put_tags.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -78,26 +77,27 @@ var GadgetsPutTagsCmd = &cobra.Command{
 }
 
 func collectGadgetsPutTagsCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForGadgetsPutTagsCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForGadgetsPutTagsCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if GadgetsPutTagsCmdProductId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "product-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("product_id", "product-id", "path", parsedBody, GadgetsPutTagsCmdProductId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GadgetsPutTagsCmdSerialNumber == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "serial-number")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("serial_number", "serial-number", "path", parsedBody, GadgetsPutTagsCmdSerialNumber)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/gadgets_register.go
+++ b/soracom/generated/cmd/gadgets_register.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,26 +77,27 @@ var GadgetsRegisterCmd = &cobra.Command{
 }
 
 func collectGadgetsRegisterCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForGadgetsRegisterCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForGadgetsRegisterCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if GadgetsRegisterCmdProductId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "product-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("product_id", "product-id", "path", parsedBody, GadgetsRegisterCmdProductId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GadgetsRegisterCmdSerialNumber == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "serial-number")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("serial_number", "serial-number", "path", parsedBody, GadgetsRegisterCmdSerialNumber)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/gadgets_set_group.go
+++ b/soracom/generated/cmd/gadgets_set_group.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -100,26 +97,27 @@ var GadgetsSetGroupCmd = &cobra.Command{
 }
 
 func collectGadgetsSetGroupCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForGadgetsSetGroupCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForGadgetsSetGroupCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if GadgetsSetGroupCmdProductId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "product-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("product_id", "product-id", "path", parsedBody, GadgetsSetGroupCmdProductId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GadgetsSetGroupCmdSerialNumber == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "serial-number")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("serial_number", "serial-number", "path", parsedBody, GadgetsSetGroupCmdSerialNumber)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/gadgets_terminate.go
+++ b/soracom/generated/cmd/gadgets_terminate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var GadgetsTerminateCmd = &cobra.Command{
 }
 
 func collectGadgetsTerminateCmdParams(ac *apiClient) (*apiParams, error) {
-	if GadgetsTerminateCmdProductId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "product-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("product_id", "product-id", "path", parsedBody, GadgetsTerminateCmdProductId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GadgetsTerminateCmdSerialNumber == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "serial-number")
+	err = checkIfRequiredStringParameterIsSupplied("serial_number", "serial-number", "path", parsedBody, GadgetsTerminateCmdSerialNumber)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/gadgets_unset_group.go
+++ b/soracom/generated/cmd/gadgets_unset_group.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var GadgetsUnsetGroupCmd = &cobra.Command{
 }
 
 func collectGadgetsUnsetGroupCmdParams(ac *apiClient) (*apiParams, error) {
-	if GadgetsUnsetGroupCmdProductId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "product-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("product_id", "product-id", "path", parsedBody, GadgetsUnsetGroupCmdProductId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GadgetsUnsetGroupCmdSerialNumber == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "serial-number")
+	err = checkIfRequiredStringParameterIsSupplied("serial_number", "serial-number", "path", parsedBody, GadgetsUnsetGroupCmdSerialNumber)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/groups_create.go
+++ b/soracom/generated/cmd/groups_create.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -68,9 +67,16 @@ var GroupsCreateCmd = &cobra.Command{
 }
 
 func collectGroupsCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForGroupsCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForGroupsCreateCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/groups_delete.go
+++ b/soracom/generated/cmd/groups_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var GroupsDeleteCmd = &cobra.Command{
 }
 
 func collectGroupsDeleteCmdParams(ac *apiClient) (*apiParams, error) {
-	if GroupsDeleteCmdGroupId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "group-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("group_id", "group-id", "path", parsedBody, GroupsDeleteCmdGroupId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/groups_delete_config.go
+++ b/soracom/generated/cmd/groups_delete_config.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,16 +72,21 @@ var GroupsDeleteConfigCmd = &cobra.Command{
 }
 
 func collectGroupsDeleteConfigCmdParams(ac *apiClient) (*apiParams, error) {
-	if GroupsDeleteConfigCmdGroupId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "group-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("group_id", "group-id", "path", parsedBody, GroupsDeleteConfigCmdGroupId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GroupsDeleteConfigCmdName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "name")
+	err = checkIfRequiredStringParameterIsSupplied("name", "name", "path", parsedBody, GroupsDeleteConfigCmdName)
+	if err != nil {
+		return nil, err
 	}
 
-	if GroupsDeleteConfigCmdNamespace == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "namespace")
+	err = checkIfRequiredStringParameterIsSupplied("namespace", "namespace", "path", parsedBody, GroupsDeleteConfigCmdNamespace)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/groups_delete_config_namespace.go
+++ b/soracom/generated/cmd/groups_delete_config_namespace.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var GroupsDeleteConfigNamespaceCmd = &cobra.Command{
 }
 
 func collectGroupsDeleteConfigNamespaceCmdParams(ac *apiClient) (*apiParams, error) {
-	if GroupsDeleteConfigNamespaceCmdGroupId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "group-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("group_id", "group-id", "path", parsedBody, GroupsDeleteConfigNamespaceCmdGroupId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GroupsDeleteConfigNamespaceCmdNamespace == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "namespace")
+	err = checkIfRequiredStringParameterIsSupplied("namespace", "namespace", "path", parsedBody, GroupsDeleteConfigNamespaceCmdNamespace)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/groups_delete_tag.go
+++ b/soracom/generated/cmd/groups_delete_tag.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var GroupsDeleteTagCmd = &cobra.Command{
 }
 
 func collectGroupsDeleteTagCmdParams(ac *apiClient) (*apiParams, error) {
-	if GroupsDeleteTagCmdGroupId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "group-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("group_id", "group-id", "path", parsedBody, GroupsDeleteTagCmdGroupId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GroupsDeleteTagCmdTagName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "tag-name")
+	err = checkIfRequiredStringParameterIsSupplied("tag_name", "tag-name", "path", parsedBody, GroupsDeleteTagCmdTagName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/groups_get.go
+++ b/soracom/generated/cmd/groups_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var GroupsGetCmd = &cobra.Command{
 }
 
 func collectGroupsGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if GroupsGetCmdGroupId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "group-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("group_id", "group-id", "path", parsedBody, GroupsGetCmdGroupId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/groups_list_subscribers.go
+++ b/soracom/generated/cmd/groups_list_subscribers.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -79,8 +77,11 @@ var GroupsListSubscribersCmd = &cobra.Command{
 }
 
 func collectGroupsListSubscribersCmdParams(ac *apiClient) (*apiParams, error) {
-	if GroupsListSubscribersCmdGroupId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "group-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("group_id", "group-id", "path", parsedBody, GroupsListSubscribersCmdGroupId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/groups_put_config.go
+++ b/soracom/generated/cmd/groups_put_config.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -78,26 +77,27 @@ var GroupsPutConfigCmd = &cobra.Command{
 }
 
 func collectGroupsPutConfigCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForGroupsPutConfigCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForGroupsPutConfigCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if GroupsPutConfigCmdGroupId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "group-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("group_id", "group-id", "path", parsedBody, GroupsPutConfigCmdGroupId)
+	if err != nil {
+		return nil, err
 	}
 
-	if GroupsPutConfigCmdNamespace == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "namespace")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("namespace", "namespace", "path", parsedBody, GroupsPutConfigCmdNamespace)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/groups_put_tags.go
+++ b/soracom/generated/cmd/groups_put_tags.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,18 +72,22 @@ var GroupsPutTagsCmd = &cobra.Command{
 }
 
 func collectGroupsPutTagsCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForGroupsPutTagsCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForGroupsPutTagsCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if GroupsPutTagsCmdGroupId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "group-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("group_id", "group-id", "path", parsedBody, GroupsPutTagsCmdGroupId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lagoon_create_user.go
+++ b/soracom/generated/cmd/lagoon_create_user.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -83,9 +82,16 @@ var LagoonCreateUserCmd = &cobra.Command{
 }
 
 func collectLagoonCreateUserCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonCreateUserCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonCreateUserCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/lagoon_dashboards_init_permissions.go
+++ b/soracom/generated/cmd/lagoon_dashboards_init_permissions.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LagoonDashboardsInitPermissionsCmd = &cobra.Command{
 }
 
 func collectLagoonDashboardsInitPermissionsCmdParams(ac *apiClient) (*apiParams, error) {
-	if LagoonDashboardsInitPermissionsCmdDashboardId == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "dashboard-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredIntegerParameterIsSupplied("dashboard_id", "dashboard-id", "path", parsedBody, LagoonDashboardsInitPermissionsCmdDashboardId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lagoon_dashboards_update_permissions.go
+++ b/soracom/generated/cmd/lagoon_dashboards_update_permissions.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -75,18 +72,22 @@ var LagoonDashboardsUpdatePermissionsCmd = &cobra.Command{
 }
 
 func collectLagoonDashboardsUpdatePermissionsCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonDashboardsUpdatePermissionsCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonDashboardsUpdatePermissionsCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LagoonDashboardsUpdatePermissionsCmdDashboardId == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "dashboard-id")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("dashboard_id", "dashboard-id", "path", parsedBody, LagoonDashboardsUpdatePermissionsCmdDashboardId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lagoon_delete_user.go
+++ b/soracom/generated/cmd/lagoon_delete_user.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LagoonDeleteUserCmd = &cobra.Command{
 }
 
 func collectLagoonDeleteUserCmdParams(ac *apiClient) (*apiParams, error) {
-	if LagoonDeleteUserCmdLagoonUserId == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "lagoon-user-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredIntegerParameterIsSupplied("lagoon_user_id", "lagoon-user-id", "path", parsedBody, LagoonDeleteUserCmdLagoonUserId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lagoon_license_packs_update.go
+++ b/soracom/generated/cmd/lagoon_license_packs_update.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -63,9 +62,16 @@ var LagoonLicensePacksUpdateCmd = &cobra.Command{
 }
 
 func collectLagoonLicensePacksUpdateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonLicensePacksUpdateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonLicensePacksUpdateCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/lagoon_migration_get_info.go
+++ b/soracom/generated/cmd/lagoon_migration_get_info.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,9 +72,16 @@ var LagoonMigrationGetInfoCmd = &cobra.Command{
 }
 
 func collectLagoonMigrationGetInfoCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonMigrationGetInfoCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonMigrationGetInfoCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := ""
 

--- a/soracom/generated/cmd/lagoon_migration_migrate.go
+++ b/soracom/generated/cmd/lagoon_migration_migrate.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -68,9 +67,16 @@ var LagoonMigrationMigrateCmd = &cobra.Command{
 }
 
 func collectLagoonMigrationMigrateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonMigrationMigrateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonMigrationMigrateCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/lagoon_register.go
+++ b/soracom/generated/cmd/lagoon_register.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -78,9 +77,16 @@ var LagoonRegisterCmd = &cobra.Command{
 }
 
 func collectLagoonRegisterCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonRegisterCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonRegisterCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/lagoon_update_user_email.go
+++ b/soracom/generated/cmd/lagoon_update_user_email.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var LagoonUpdateUserEmailCmd = &cobra.Command{
 }
 
 func collectLagoonUpdateUserEmailCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonUpdateUserEmailCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonUpdateUserEmailCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LagoonUpdateUserEmailCmdLagoonUserId == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "lagoon-user-id")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("lagoon_user_id", "lagoon-user-id", "path", parsedBody, LagoonUpdateUserEmailCmdLagoonUserId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lagoon_update_user_password.go
+++ b/soracom/generated/cmd/lagoon_update_user_password.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var LagoonUpdateUserPasswordCmd = &cobra.Command{
 }
 
 func collectLagoonUpdateUserPasswordCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonUpdateUserPasswordCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonUpdateUserPasswordCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LagoonUpdateUserPasswordCmdLagoonUserId == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "lagoon-user-id")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("lagoon_user_id", "lagoon-user-id", "path", parsedBody, LagoonUpdateUserPasswordCmdLagoonUserId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lagoon_update_user_permission.go
+++ b/soracom/generated/cmd/lagoon_update_user_permission.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var LagoonUpdateUserPermissionCmd = &cobra.Command{
 }
 
 func collectLagoonUpdateUserPermissionCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonUpdateUserPermissionCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonUpdateUserPermissionCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LagoonUpdateUserPermissionCmdLagoonUserId == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "lagoon-user-id")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("lagoon_user_id", "lagoon-user-id", "path", parsedBody, LagoonUpdateUserPermissionCmdLagoonUserId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lagoon_updated_plan.go
+++ b/soracom/generated/cmd/lagoon_updated_plan.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -68,9 +67,16 @@ var LagoonUpdatedPlanCmd = &cobra.Command{
 }
 
 func collectLagoonUpdatedPlanCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonUpdatedPlanCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonUpdatedPlanCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/lagoon_users_create.go
+++ b/soracom/generated/cmd/lagoon_users_create.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -83,9 +82,16 @@ var LagoonUsersCreateCmd = &cobra.Command{
 }
 
 func collectLagoonUsersCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonUsersCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonUsersCreateCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/lagoon_users_delete.go
+++ b/soracom/generated/cmd/lagoon_users_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LagoonUsersDeleteCmd = &cobra.Command{
 }
 
 func collectLagoonUsersDeleteCmdParams(ac *apiClient) (*apiParams, error) {
-	if LagoonUsersDeleteCmdLagoonUserId == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "lagoon-user-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredIntegerParameterIsSupplied("lagoon_user_id", "lagoon-user-id", "path", parsedBody, LagoonUsersDeleteCmdLagoonUserId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lagoon_users_update_email.go
+++ b/soracom/generated/cmd/lagoon_users_update_email.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var LagoonUsersUpdateEmailCmd = &cobra.Command{
 }
 
 func collectLagoonUsersUpdateEmailCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonUsersUpdateEmailCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonUsersUpdateEmailCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LagoonUsersUpdateEmailCmdLagoonUserId == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "lagoon-user-id")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("lagoon_user_id", "lagoon-user-id", "path", parsedBody, LagoonUsersUpdateEmailCmdLagoonUserId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lagoon_users_update_password.go
+++ b/soracom/generated/cmd/lagoon_users_update_password.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var LagoonUsersUpdatePasswordCmd = &cobra.Command{
 }
 
 func collectLagoonUsersUpdatePasswordCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonUsersUpdatePasswordCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonUsersUpdatePasswordCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LagoonUsersUpdatePasswordCmdLagoonUserId == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "lagoon-user-id")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("lagoon_user_id", "lagoon-user-id", "path", parsedBody, LagoonUsersUpdatePasswordCmdLagoonUserId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lagoon_users_update_permission.go
+++ b/soracom/generated/cmd/lagoon_users_update_permission.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var LagoonUsersUpdatePermissionCmd = &cobra.Command{
 }
 
 func collectLagoonUsersUpdatePermissionCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLagoonUsersUpdatePermissionCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLagoonUsersUpdatePermissionCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LagoonUsersUpdatePermissionCmdLagoonUserId == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "lagoon-user-id")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("lagoon_user_id", "lagoon-user-id", "path", parsedBody, LagoonUsersUpdatePermissionCmdLagoonUserId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_devices_delete_tag.go
+++ b/soracom/generated/cmd/lora_devices_delete_tag.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var LoraDevicesDeleteTagCmd = &cobra.Command{
 }
 
 func collectLoraDevicesDeleteTagCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraDevicesDeleteTagCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, LoraDevicesDeleteTagCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if LoraDevicesDeleteTagCmdTagName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "tag-name")
+	err = checkIfRequiredStringParameterIsSupplied("tag_name", "tag-name", "path", parsedBody, LoraDevicesDeleteTagCmdTagName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_devices_disable_termination.go
+++ b/soracom/generated/cmd/lora_devices_disable_termination.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LoraDevicesDisableTerminationCmd = &cobra.Command{
 }
 
 func collectLoraDevicesDisableTerminationCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraDevicesDisableTerminationCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, LoraDevicesDisableTerminationCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_devices_enable_termination.go
+++ b/soracom/generated/cmd/lora_devices_enable_termination.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LoraDevicesEnableTerminationCmd = &cobra.Command{
 }
 
 func collectLoraDevicesEnableTerminationCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraDevicesEnableTerminationCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, LoraDevicesEnableTerminationCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_devices_get.go
+++ b/soracom/generated/cmd/lora_devices_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LoraDevicesGetCmd = &cobra.Command{
 }
 
 func collectLoraDevicesGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraDevicesGetCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, LoraDevicesGetCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_devices_get_data.go
+++ b/soracom/generated/cmd/lora_devices_get_data.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -94,8 +92,11 @@ var LoraDevicesGetDataCmd = &cobra.Command{
 }
 
 func collectLoraDevicesGetDataCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraDevicesGetDataCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, LoraDevicesGetDataCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_devices_put_tags.go
+++ b/soracom/generated/cmd/lora_devices_put_tags.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,18 +72,22 @@ var LoraDevicesPutTagsCmd = &cobra.Command{
 }
 
 func collectLoraDevicesPutTagsCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLoraDevicesPutTagsCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLoraDevicesPutTagsCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LoraDevicesPutTagsCmdDeviceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, LoraDevicesPutTagsCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_devices_register.go
+++ b/soracom/generated/cmd/lora_devices_register.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var LoraDevicesRegisterCmd = &cobra.Command{
 }
 
 func collectLoraDevicesRegisterCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLoraDevicesRegisterCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLoraDevicesRegisterCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LoraDevicesRegisterCmdDeviceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, LoraDevicesRegisterCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_devices_send_data.go
+++ b/soracom/generated/cmd/lora_devices_send_data.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var LoraDevicesSendDataCmd = &cobra.Command{
 }
 
 func collectLoraDevicesSendDataCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLoraDevicesSendDataCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLoraDevicesSendDataCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LoraDevicesSendDataCmdDeviceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, LoraDevicesSendDataCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_devices_set_group.go
+++ b/soracom/generated/cmd/lora_devices_set_group.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -95,18 +92,22 @@ var LoraDevicesSetGroupCmd = &cobra.Command{
 }
 
 func collectLoraDevicesSetGroupCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLoraDevicesSetGroupCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLoraDevicesSetGroupCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LoraDevicesSetGroupCmdDeviceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, LoraDevicesSetGroupCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_devices_terminate.go
+++ b/soracom/generated/cmd/lora_devices_terminate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LoraDevicesTerminateCmd = &cobra.Command{
 }
 
 func collectLoraDevicesTerminateCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraDevicesTerminateCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, LoraDevicesTerminateCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_devices_unset_group.go
+++ b/soracom/generated/cmd/lora_devices_unset_group.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LoraDevicesUnsetGroupCmd = &cobra.Command{
 }
 
 func collectLoraDevicesUnsetGroupCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraDevicesUnsetGroupCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, LoraDevicesUnsetGroupCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_gateways_delete_tag.go
+++ b/soracom/generated/cmd/lora_gateways_delete_tag.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var LoraGatewaysDeleteTagCmd = &cobra.Command{
 }
 
 func collectLoraGatewaysDeleteTagCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraGatewaysDeleteTagCmdGatewayId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "gateway-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("gateway_id", "gateway-id", "path", parsedBody, LoraGatewaysDeleteTagCmdGatewayId)
+	if err != nil {
+		return nil, err
 	}
 
-	if LoraGatewaysDeleteTagCmdTagName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "tag-name")
+	err = checkIfRequiredStringParameterIsSupplied("tag_name", "tag-name", "path", parsedBody, LoraGatewaysDeleteTagCmdTagName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_gateways_disable_termination.go
+++ b/soracom/generated/cmd/lora_gateways_disable_termination.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LoraGatewaysDisableTerminationCmd = &cobra.Command{
 }
 
 func collectLoraGatewaysDisableTerminationCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraGatewaysDisableTerminationCmdGatewayId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "gateway-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("gateway_id", "gateway-id", "path", parsedBody, LoraGatewaysDisableTerminationCmdGatewayId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_gateways_enable_termination.go
+++ b/soracom/generated/cmd/lora_gateways_enable_termination.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LoraGatewaysEnableTerminationCmd = &cobra.Command{
 }
 
 func collectLoraGatewaysEnableTerminationCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraGatewaysEnableTerminationCmdGatewayId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "gateway-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("gateway_id", "gateway-id", "path", parsedBody, LoraGatewaysEnableTerminationCmdGatewayId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_gateways_get.go
+++ b/soracom/generated/cmd/lora_gateways_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LoraGatewaysGetCmd = &cobra.Command{
 }
 
 func collectLoraGatewaysGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraGatewaysGetCmdGatewayId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "gateway-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("gateway_id", "gateway-id", "path", parsedBody, LoraGatewaysGetCmdGatewayId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_gateways_put_tags.go
+++ b/soracom/generated/cmd/lora_gateways_put_tags.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,18 +72,22 @@ var LoraGatewaysPutTagsCmd = &cobra.Command{
 }
 
 func collectLoraGatewaysPutTagsCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLoraGatewaysPutTagsCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLoraGatewaysPutTagsCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LoraGatewaysPutTagsCmdGatewayId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "gateway-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("gateway_id", "gateway-id", "path", parsedBody, LoraGatewaysPutTagsCmdGatewayId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_gateways_set_network_set.go
+++ b/soracom/generated/cmd/lora_gateways_set_network_set.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var LoraGatewaysSetNetworkSetCmd = &cobra.Command{
 }
 
 func collectLoraGatewaysSetNetworkSetCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLoraGatewaysSetNetworkSetCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLoraGatewaysSetNetworkSetCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LoraGatewaysSetNetworkSetCmdGatewayId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "gateway-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("gateway_id", "gateway-id", "path", parsedBody, LoraGatewaysSetNetworkSetCmdGatewayId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_gateways_terminate.go
+++ b/soracom/generated/cmd/lora_gateways_terminate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LoraGatewaysTerminateCmd = &cobra.Command{
 }
 
 func collectLoraGatewaysTerminateCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraGatewaysTerminateCmdGatewayId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "gateway-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("gateway_id", "gateway-id", "path", parsedBody, LoraGatewaysTerminateCmdGatewayId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_gateways_unset_network_set.go
+++ b/soracom/generated/cmd/lora_gateways_unset_network_set.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LoraGatewaysUnsetNetworkSetCmd = &cobra.Command{
 }
 
 func collectLoraGatewaysUnsetNetworkSetCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraGatewaysUnsetNetworkSetCmdGatewayId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "gateway-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("gateway_id", "gateway-id", "path", parsedBody, LoraGatewaysUnsetNetworkSetCmdGatewayId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_network_sets_add_permission.go
+++ b/soracom/generated/cmd/lora_network_sets_add_permission.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var LoraNetworkSetsAddPermissionCmd = &cobra.Command{
 }
 
 func collectLoraNetworkSetsAddPermissionCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLoraNetworkSetsAddPermissionCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLoraNetworkSetsAddPermissionCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LoraNetworkSetsAddPermissionCmdNsId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "ns-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("ns_id", "ns-id", "path", parsedBody, LoraNetworkSetsAddPermissionCmdNsId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_network_sets_create.go
+++ b/soracom/generated/cmd/lora_network_sets_create.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -88,9 +87,16 @@ var LoraNetworkSetsCreateCmd = &cobra.Command{
 }
 
 func collectLoraNetworkSetsCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLoraNetworkSetsCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLoraNetworkSetsCreateCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/lora_network_sets_delete.go
+++ b/soracom/generated/cmd/lora_network_sets_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LoraNetworkSetsDeleteCmd = &cobra.Command{
 }
 
 func collectLoraNetworkSetsDeleteCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraNetworkSetsDeleteCmdNsId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "ns-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("ns_id", "ns-id", "path", parsedBody, LoraNetworkSetsDeleteCmdNsId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_network_sets_delete_tag.go
+++ b/soracom/generated/cmd/lora_network_sets_delete_tag.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var LoraNetworkSetsDeleteTagCmd = &cobra.Command{
 }
 
 func collectLoraNetworkSetsDeleteTagCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraNetworkSetsDeleteTagCmdNsId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "ns-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("ns_id", "ns-id", "path", parsedBody, LoraNetworkSetsDeleteTagCmdNsId)
+	if err != nil {
+		return nil, err
 	}
 
-	if LoraNetworkSetsDeleteTagCmdTagName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "tag-name")
+	err = checkIfRequiredStringParameterIsSupplied("tag_name", "tag-name", "path", parsedBody, LoraNetworkSetsDeleteTagCmdTagName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_network_sets_get.go
+++ b/soracom/generated/cmd/lora_network_sets_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var LoraNetworkSetsGetCmd = &cobra.Command{
 }
 
 func collectLoraNetworkSetsGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if LoraNetworkSetsGetCmdNsId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "ns-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("ns_id", "ns-id", "path", parsedBody, LoraNetworkSetsGetCmdNsId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_network_sets_list_gateways.go
+++ b/soracom/generated/cmd/lora_network_sets_list_gateways.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -79,9 +77,12 @@ var LoraNetworkSetsListGatewaysCmd = &cobra.Command{
 }
 
 func collectLoraNetworkSetsListGatewaysCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if LoraNetworkSetsListGatewaysCmdNsId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "ns-id")
+	err = checkIfRequiredStringParameterIsSupplied("ns_id", "ns-id", "path", parsedBody, LoraNetworkSetsListGatewaysCmdNsId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/lora_network_sets_revoke_permission.go
+++ b/soracom/generated/cmd/lora_network_sets_revoke_permission.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var LoraNetworkSetsRevokePermissionCmd = &cobra.Command{
 }
 
 func collectLoraNetworkSetsRevokePermissionCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForLoraNetworkSetsRevokePermissionCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForLoraNetworkSetsRevokePermissionCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if LoraNetworkSetsRevokePermissionCmdNsId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "ns-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("ns_id", "ns-id", "path", parsedBody, LoraNetworkSetsRevokePermissionCmdNsId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/operator_add_contract.go
+++ b/soracom/generated/cmd/operator_add_contract.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -78,13 +77,20 @@ var OperatorAddContractCmd = &cobra.Command{
 }
 
 func collectOperatorAddContractCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if OperatorAddContractCmdOperatorId == "" {
 		OperatorAddContractCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForOperatorAddContractCmd()
+	body, err = buildBodyForOperatorAddContractCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/operator_add_coverage_type.go
+++ b/soracom/generated/cmd/operator_add_coverage_type.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var OperatorAddCoverageTypeCmd = &cobra.Command{
 }
 
 func collectOperatorAddCoverageTypeCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if OperatorAddCoverageTypeCmdOperatorId == "" {
 		OperatorAddCoverageTypeCmdOperatorId = ac.OperatorID
 	}
 
-	if OperatorAddCoverageTypeCmdCoverageType == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "coverage-type")
+	err = checkIfRequiredStringParameterIsSupplied("coverage_type", "coverage-type", "path", parsedBody, OperatorAddCoverageTypeCmdCoverageType)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/operator_auth_keys_delete.go
+++ b/soracom/generated/cmd/operator_auth_keys_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var OperatorAuthKeysDeleteCmd = &cobra.Command{
 }
 
 func collectOperatorAuthKeysDeleteCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if OperatorAuthKeysDeleteCmdOperatorId == "" {
 		OperatorAuthKeysDeleteCmdOperatorId = ac.OperatorID
 	}
 
-	if OperatorAuthKeysDeleteCmdAuthKeyId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "auth-key-id")
+	err = checkIfRequiredStringParameterIsSupplied("auth_key_id", "auth-key-id", "path", parsedBody, OperatorAuthKeysDeleteCmdAuthKeyId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/operator_create.go
+++ b/soracom/generated/cmd/operator_create.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,26 +77,27 @@ var OperatorCreateCmd = &cobra.Command{
 }
 
 func collectOperatorCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForOperatorCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForOperatorCreateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if OperatorCreateCmdEmail == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "email")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("email", "email", "body", parsedBody, OperatorCreateCmdEmail)
+	if err != nil {
+		return nil, err
 	}
 
-	if OperatorCreateCmdPassword == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "password")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("password", "password", "body", parsedBody, OperatorCreateCmdPassword)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/operator_create_company_information.go
+++ b/soracom/generated/cmd/operator_create_company_information.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -135,62 +132,51 @@ var OperatorCreateCompanyInformationCmd = &cobra.Command{
 }
 
 func collectOperatorCreateCompanyInformationCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if OperatorCreateCompanyInformationCmdOperatorId == "" {
 		OperatorCreateCompanyInformationCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForOperatorCreateCompanyInformationCmd()
+	body, err = buildBodyForOperatorCreateCompanyInformationCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if OperatorCreateCompanyInformationCmdCompanyName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "company-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("companyName", "company-name", "body", parsedBody, OperatorCreateCompanyInformationCmdCompanyName)
+	if err != nil {
+		return nil, err
 	}
 
-	if OperatorCreateCompanyInformationCmdContactPersonName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "contact-person-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("contactPersonName", "contact-person-name", "body", parsedBody, OperatorCreateCompanyInformationCmdContactPersonName)
+	if err != nil {
+		return nil, err
 	}
 
-	if OperatorCreateCompanyInformationCmdCountryCode == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "country-code")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("countryCode", "country-code", "body", parsedBody, OperatorCreateCompanyInformationCmdCountryCode)
+	if err != nil {
+		return nil, err
 	}
 
-	if OperatorCreateCompanyInformationCmdDepartment == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "department")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("department", "department", "body", parsedBody, OperatorCreateCompanyInformationCmdDepartment)
+	if err != nil {
+		return nil, err
 	}
 
-	if OperatorCreateCompanyInformationCmdPhoneNumber == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "phone-number")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("phoneNumber", "phone-number", "body", parsedBody, OperatorCreateCompanyInformationCmdPhoneNumber)
+	if err != nil {
+		return nil, err
 	}
 
-	if OperatorCreateCompanyInformationCmdZipCode == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "zip-code")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("zipCode", "zip-code", "body", parsedBody, OperatorCreateCompanyInformationCmdZipCode)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/operator_create_individual_information.go
+++ b/soracom/generated/cmd/operator_create_individual_information.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -120,22 +117,26 @@ var OperatorCreateIndividualInformationCmd = &cobra.Command{
 }
 
 func collectOperatorCreateIndividualInformationCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if OperatorCreateIndividualInformationCmdOperatorId == "" {
 		OperatorCreateIndividualInformationCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForOperatorCreateIndividualInformationCmd()
+	body, err = buildBodyForOperatorCreateIndividualInformationCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if OperatorCreateIndividualInformationCmdFullName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "full-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("fullName", "full-name", "body", parsedBody, OperatorCreateIndividualInformationCmdFullName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/operator_delete_contract.go
+++ b/soracom/generated/cmd/operator_delete_contract.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var OperatorDeleteContractCmd = &cobra.Command{
 }
 
 func collectOperatorDeleteContractCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if OperatorDeleteContractCmdOperatorId == "" {
 		OperatorDeleteContractCmdOperatorId = ac.OperatorID
 	}
 
-	if OperatorDeleteContractCmdContractName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "contract-name")
+	err = checkIfRequiredStringParameterIsSupplied("contract_name", "contract-name", "path", parsedBody, OperatorDeleteContractCmdContractName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/operator_generate_api_token.go
+++ b/soracom/generated/cmd/operator_generate_api_token.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -78,13 +77,20 @@ var OperatorGenerateApiTokenCmd = &cobra.Command{
 }
 
 func collectOperatorGenerateApiTokenCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if OperatorGenerateApiTokenCmdOperatorId == "" {
 		OperatorGenerateApiTokenCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForOperatorGenerateApiTokenCmd()
+	body, err = buildBodyForOperatorGenerateApiTokenCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/operator_issue_mfa_revoke_token.go
+++ b/soracom/generated/cmd/operator_issue_mfa_revoke_token.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,9 +72,16 @@ var OperatorIssueMfaRevokeTokenCmd = &cobra.Command{
 }
 
 func collectOperatorIssueMfaRevokeTokenCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForOperatorIssueMfaRevokeTokenCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForOperatorIssueMfaRevokeTokenCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/operator_update_company_information.go
+++ b/soracom/generated/cmd/operator_update_company_information.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -135,62 +132,51 @@ var OperatorUpdateCompanyInformationCmd = &cobra.Command{
 }
 
 func collectOperatorUpdateCompanyInformationCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if OperatorUpdateCompanyInformationCmdOperatorId == "" {
 		OperatorUpdateCompanyInformationCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForOperatorUpdateCompanyInformationCmd()
+	body, err = buildBodyForOperatorUpdateCompanyInformationCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if OperatorUpdateCompanyInformationCmdCompanyName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "company-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("companyName", "company-name", "body", parsedBody, OperatorUpdateCompanyInformationCmdCompanyName)
+	if err != nil {
+		return nil, err
 	}
 
-	if OperatorUpdateCompanyInformationCmdContactPersonName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "contact-person-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("contactPersonName", "contact-person-name", "body", parsedBody, OperatorUpdateCompanyInformationCmdContactPersonName)
+	if err != nil {
+		return nil, err
 	}
 
-	if OperatorUpdateCompanyInformationCmdCountryCode == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "country-code")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("countryCode", "country-code", "body", parsedBody, OperatorUpdateCompanyInformationCmdCountryCode)
+	if err != nil {
+		return nil, err
 	}
 
-	if OperatorUpdateCompanyInformationCmdDepartment == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "department")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("department", "department", "body", parsedBody, OperatorUpdateCompanyInformationCmdDepartment)
+	if err != nil {
+		return nil, err
 	}
 
-	if OperatorUpdateCompanyInformationCmdPhoneNumber == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "phone-number")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("phoneNumber", "phone-number", "body", parsedBody, OperatorUpdateCompanyInformationCmdPhoneNumber)
+	if err != nil {
+		return nil, err
 	}
 
-	if OperatorUpdateCompanyInformationCmdZipCode == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "zip-code")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("zipCode", "zip-code", "body", parsedBody, OperatorUpdateCompanyInformationCmdZipCode)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/operator_update_individual_information.go
+++ b/soracom/generated/cmd/operator_update_individual_information.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -120,22 +117,26 @@ var OperatorUpdateIndividualInformationCmd = &cobra.Command{
 }
 
 func collectOperatorUpdateIndividualInformationCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if OperatorUpdateIndividualInformationCmdOperatorId == "" {
 		OperatorUpdateIndividualInformationCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForOperatorUpdateIndividualInformationCmd()
+	body, err = buildBodyForOperatorUpdateIndividualInformationCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if OperatorUpdateIndividualInformationCmdFullName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "full-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("fullName", "full-name", "body", parsedBody, OperatorUpdateIndividualInformationCmdFullName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/operator_update_password.go
+++ b/soracom/generated/cmd/operator_update_password.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,30 +82,31 @@ var OperatorUpdatePasswordCmd = &cobra.Command{
 }
 
 func collectOperatorUpdatePasswordCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if OperatorUpdatePasswordCmdOperatorId == "" {
 		OperatorUpdatePasswordCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForOperatorUpdatePasswordCmd()
+	body, err = buildBodyForOperatorUpdatePasswordCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if OperatorUpdatePasswordCmdCurrentPassword == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "current-password")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("currentPassword", "current-password", "body", parsedBody, OperatorUpdatePasswordCmdCurrentPassword)
+	if err != nil {
+		return nil, err
 	}
 
-	if OperatorUpdatePasswordCmdNewPassword == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "new-password")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("newPassword", "new-password", "body", parsedBody, OperatorUpdatePasswordCmdNewPassword)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/operator_verify.go
+++ b/soracom/generated/cmd/operator_verify.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -70,18 +67,22 @@ var OperatorVerifyCmd = &cobra.Command{
 }
 
 func collectOperatorVerifyCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForOperatorVerifyCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForOperatorVerifyCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if OperatorVerifyCmdToken == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "token")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("token", "token", "body", parsedBody, OperatorVerifyCmdToken)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/operator_verify_mfa_otp.go
+++ b/soracom/generated/cmd/operator_verify_mfa_otp.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -78,13 +77,20 @@ var OperatorVerifyMfaOtpCmd = &cobra.Command{
 }
 
 func collectOperatorVerifyMfaOtpCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if OperatorVerifyMfaOtpCmdOperatorId == "" {
 		OperatorVerifyMfaOtpCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForOperatorVerifyMfaOtpCmd()
+	body, err = buildBodyForOperatorVerifyMfaOtpCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/operator_verify_mfa_revoke_token.go
+++ b/soracom/generated/cmd/operator_verify_mfa_revoke_token.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -83,9 +82,16 @@ var OperatorVerifyMfaRevokeTokenCmd = &cobra.Command{
 }
 
 func collectOperatorVerifyMfaRevokeTokenCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForOperatorVerifyMfaRevokeTokenCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForOperatorVerifyMfaRevokeTokenCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/orders_cancel.go
+++ b/soracom/generated/cmd/orders_cancel.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var OrdersCancelCmd = &cobra.Command{
 }
 
 func collectOrdersCancelCmdParams(ac *apiClient) (*apiParams, error) {
-	if OrdersCancelCmdOrderId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "order-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("order_id", "order-id", "path", parsedBody, OrdersCancelCmdOrderId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/orders_confirm.go
+++ b/soracom/generated/cmd/orders_confirm.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var OrdersConfirmCmd = &cobra.Command{
 }
 
 func collectOrdersConfirmCmdParams(ac *apiClient) (*apiParams, error) {
-	if OrdersConfirmCmdOrderId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "order-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("order_id", "order-id", "path", parsedBody, OrdersConfirmCmdOrderId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/orders_create.go
+++ b/soracom/generated/cmd/orders_create.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,9 +72,16 @@ var OrdersCreateCmd = &cobra.Command{
 }
 
 func collectOrdersCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForOrdersCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForOrdersCreateCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/orders_get.go
+++ b/soracom/generated/cmd/orders_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var OrdersGetCmd = &cobra.Command{
 }
 
 func collectOrdersGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if OrdersGetCmdOrderId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "order-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("order_id", "order-id", "path", parsedBody, OrdersGetCmdOrderId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/orders_list_subscribers.go
+++ b/soracom/generated/cmd/orders_list_subscribers.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,9 +72,12 @@ var OrdersListSubscribersCmd = &cobra.Command{
 }
 
 func collectOrdersListSubscribersCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if OrdersListSubscribersCmdOrderId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "order-id")
+	err = checkIfRequiredStringParameterIsSupplied("order_id", "order-id", "path", parsedBody, OrdersListSubscribersCmdOrderId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/orders_register_subscribers.go
+++ b/soracom/generated/cmd/orders_register_subscribers.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var OrdersRegisterSubscribersCmd = &cobra.Command{
 }
 
 func collectOrdersRegisterSubscribersCmdParams(ac *apiClient) (*apiParams, error) {
-	if OrdersRegisterSubscribersCmdOrderId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "order-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("order_id", "order-id", "path", parsedBody, OrdersRegisterSubscribersCmdOrderId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/payer_information_register.go
+++ b/soracom/generated/cmd/payer_information_register.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -83,9 +82,16 @@ var PayerInformationRegisterCmd = &cobra.Command{
 }
 
 func collectPayerInformationRegisterCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForPayerInformationRegisterCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForPayerInformationRegisterCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/payment_history_get.go
+++ b/soracom/generated/cmd/payment_history_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var PaymentHistoryGetCmd = &cobra.Command{
 }
 
 func collectPaymentHistoryGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if PaymentHistoryGetCmdPaymentTransactionId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "payment-transaction-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("payment_transaction_id", "payment-transaction-id", "path", parsedBody, PaymentHistoryGetCmdPaymentTransactionId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/payment_statements_export.go
+++ b/soracom/generated/cmd/payment_statements_export.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -70,9 +68,12 @@ var PaymentStatementsExportCmd = &cobra.Command{
 }
 
 func collectPaymentStatementsExportCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if PaymentStatementsExportCmdPaymentStatementId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "payment-statement-id")
+	err = checkIfRequiredStringParameterIsSupplied("payment_statement_id", "payment-statement-id", "path", parsedBody, PaymentStatementsExportCmdPaymentStatementId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/port_mappings_create.go
+++ b/soracom/generated/cmd/port_mappings_create.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -78,9 +77,16 @@ var PortMappingsCreateCmd = &cobra.Command{
 }
 
 func collectPortMappingsCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForPortMappingsCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForPortMappingsCreateCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/port_mappings_delete.go
+++ b/soracom/generated/cmd/port_mappings_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var PortMappingsDeleteCmd = &cobra.Command{
 }
 
 func collectPortMappingsDeleteCmdParams(ac *apiClient) (*apiParams, error) {
-	if PortMappingsDeleteCmdIpAddress == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "ip-address")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("ip_address", "ip-address", "path", parsedBody, PortMappingsDeleteCmdIpAddress)
+	if err != nil {
+		return nil, err
 	}
 
-	if PortMappingsDeleteCmdPort == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "port")
+	err = checkIfRequiredStringParameterIsSupplied("port", "port", "path", parsedBody, PortMappingsDeleteCmdPort)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/port_mappings_get.go
+++ b/soracom/generated/cmd/port_mappings_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var PortMappingsGetCmd = &cobra.Command{
 }
 
 func collectPortMappingsGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if PortMappingsGetCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, PortMappingsGetCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/query_subscribers_traffic_volume_ranking.go
+++ b/soracom/generated/cmd/query_subscribers_traffic_volume_ranking.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -79,13 +77,17 @@ var QuerySubscribersTrafficVolumeRankingCmd = &cobra.Command{
 }
 
 func collectQuerySubscribersTrafficVolumeRankingCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if QuerySubscribersTrafficVolumeRankingCmdFrom == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "from")
+	err = checkIfRequiredIntegerParameterIsSupplied("from", "from", "query", parsedBody, QuerySubscribersTrafficVolumeRankingCmdFrom)
+	if err != nil {
+		return nil, err
 	}
 
-	if QuerySubscribersTrafficVolumeRankingCmdTo == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "to")
+	err = checkIfRequiredIntegerParameterIsSupplied("to", "to", "query", parsedBody, QuerySubscribersTrafficVolumeRankingCmdTo)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/query_traffic_ranking.go
+++ b/soracom/generated/cmd/query_traffic_ranking.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -79,13 +77,17 @@ var QueryTrafficRankingCmd = &cobra.Command{
 }
 
 func collectQueryTrafficRankingCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if QueryTrafficRankingCmdFrom == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "from")
+	err = checkIfRequiredIntegerParameterIsSupplied("from", "from", "query", parsedBody, QueryTrafficRankingCmdFrom)
+	if err != nil {
+		return nil, err
 	}
 
-	if QueryTrafficRankingCmdTo == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "to")
+	err = checkIfRequiredIntegerParameterIsSupplied("to", "to", "query", parsedBody, QueryTrafficRankingCmdTo)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/roles_create.go
+++ b/soracom/generated/cmd/roles_create.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -90,30 +87,31 @@ var RolesCreateCmd = &cobra.Command{
 }
 
 func collectRolesCreateCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if RolesCreateCmdOperatorId == "" {
 		RolesCreateCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForRolesCreateCmd()
+	body, err = buildBodyForRolesCreateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if RolesCreateCmdPermission == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "permission")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("permission", "permission", "body", parsedBody, RolesCreateCmdPermission)
+	if err != nil {
+		return nil, err
 	}
 
-	if RolesCreateCmdRoleId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "role-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("role_id", "role-id", "path", parsedBody, RolesCreateCmdRoleId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/roles_delete.go
+++ b/soracom/generated/cmd/roles_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var RolesDeleteCmd = &cobra.Command{
 }
 
 func collectRolesDeleteCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if RolesDeleteCmdOperatorId == "" {
 		RolesDeleteCmdOperatorId = ac.OperatorID
 	}
 
-	if RolesDeleteCmdRoleId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "role-id")
+	err = checkIfRequiredStringParameterIsSupplied("role_id", "role-id", "path", parsedBody, RolesDeleteCmdRoleId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/roles_get.go
+++ b/soracom/generated/cmd/roles_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var RolesGetCmd = &cobra.Command{
 }
 
 func collectRolesGetCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if RolesGetCmdOperatorId == "" {
 		RolesGetCmdOperatorId = ac.OperatorID
 	}
 
-	if RolesGetCmdRoleId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "role-id")
+	err = checkIfRequiredStringParameterIsSupplied("role_id", "role-id", "path", parsedBody, RolesGetCmdRoleId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/roles_list_users.go
+++ b/soracom/generated/cmd/roles_list_users.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var RolesListUsersCmd = &cobra.Command{
 }
 
 func collectRolesListUsersCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if RolesListUsersCmdOperatorId == "" {
 		RolesListUsersCmdOperatorId = ac.OperatorID
 	}
 
-	if RolesListUsersCmdRoleId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "role-id")
+	err = checkIfRequiredStringParameterIsSupplied("role_id", "role-id", "path", parsedBody, RolesListUsersCmdRoleId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/roles_update.go
+++ b/soracom/generated/cmd/roles_update.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -90,30 +87,31 @@ var RolesUpdateCmd = &cobra.Command{
 }
 
 func collectRolesUpdateCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if RolesUpdateCmdOperatorId == "" {
 		RolesUpdateCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForRolesUpdateCmd()
+	body, err = buildBodyForRolesUpdateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if RolesUpdateCmdPermission == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "permission")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("permission", "permission", "body", parsedBody, RolesUpdateCmdPermission)
+	if err != nil {
+		return nil, err
 	}
 
-	if RolesUpdateCmdRoleId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "role-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("role_id", "role-id", "path", parsedBody, RolesUpdateCmdRoleId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sandbox_coupons_create.go
+++ b/soracom/generated/cmd/sandbox_coupons_create.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -83,9 +82,16 @@ var SandboxCouponsCreateCmd = &cobra.Command{
 }
 
 func collectSandboxCouponsCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSandboxCouponsCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSandboxCouponsCreateCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/sandbox_init.go
+++ b/soracom/generated/cmd/sandbox_init.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -90,42 +87,37 @@ var SandboxInitCmd = &cobra.Command{
 }
 
 func collectSandboxInitCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSandboxInitCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSandboxInitCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SandboxInitCmdAuthKey == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "auth-key")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("authKey", "auth-key", "body", parsedBody, SandboxInitCmdAuthKey)
+	if err != nil {
+		return nil, err
 	}
 
-	if SandboxInitCmdAuthKeyId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "auth-key-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("authKeyId", "auth-key-id", "body", parsedBody, SandboxInitCmdAuthKeyId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SandboxInitCmdEmail == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "email")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("email", "email", "body", parsedBody, SandboxInitCmdEmail)
+	if err != nil {
+		return nil, err
 	}
 
-	if SandboxInitCmdPassword == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "password")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("password", "password", "body", parsedBody, SandboxInitCmdPassword)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sandbox_operators_get_signup_token.go
+++ b/soracom/generated/cmd/sandbox_operators_get_signup_token.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var SandboxOperatorsGetSignupTokenCmd = &cobra.Command{
 }
 
 func collectSandboxOperatorsGetSignupTokenCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSandboxOperatorsGetSignupTokenCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSandboxOperatorsGetSignupTokenCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SandboxOperatorsGetSignupTokenCmdEmail == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "email")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("email", "email", "path", parsedBody, SandboxOperatorsGetSignupTokenCmdEmail)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sandbox_orders_ship.go
+++ b/soracom/generated/cmd/sandbox_orders_ship.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,22 +77,26 @@ var SandboxOrdersShipCmd = &cobra.Command{
 }
 
 func collectSandboxOrdersShipCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if SandboxOrdersShipCmdOperatorId == "" {
 		SandboxOrdersShipCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForSandboxOrdersShipCmd()
+	body, err = buildBodyForSandboxOrdersShipCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SandboxOrdersShipCmdOrderId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "order-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("orderId", "order-id", "body", parsedBody, SandboxOrdersShipCmdOrderId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sandbox_stats_air_insert.go
+++ b/soracom/generated/cmd/sandbox_stats_air_insert.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var SandboxStatsAirInsertCmd = &cobra.Command{
 }
 
 func collectSandboxStatsAirInsertCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSandboxStatsAirInsertCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSandboxStatsAirInsertCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SandboxStatsAirInsertCmdImsi == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SandboxStatsAirInsertCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sandbox_stats_beam_insert.go
+++ b/soracom/generated/cmd/sandbox_stats_beam_insert.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var SandboxStatsBeamInsertCmd = &cobra.Command{
 }
 
 func collectSandboxStatsBeamInsertCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSandboxStatsBeamInsertCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSandboxStatsBeamInsertCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SandboxStatsBeamInsertCmdImsi == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SandboxStatsBeamInsertCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sandbox_subscribers_create.go
+++ b/soracom/generated/cmd/sandbox_subscribers_create.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,9 +72,16 @@ var SandboxSubscribersCreateCmd = &cobra.Command{
 }
 
 func collectSandboxSubscribersCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSandboxSubscribersCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSandboxSubscribersCreateCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/shipping_addresses_create.go
+++ b/soracom/generated/cmd/shipping_addresses_create.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -135,46 +132,41 @@ var ShippingAddressesCreateCmd = &cobra.Command{
 }
 
 func collectShippingAddressesCreateCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if ShippingAddressesCreateCmdOperatorId == "" {
 		ShippingAddressesCreateCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForShippingAddressesCreateCmd()
+	body, err = buildBodyForShippingAddressesCreateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if ShippingAddressesCreateCmdAddressLine1 == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "address-line1")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("addressLine1", "address-line1", "body", parsedBody, ShippingAddressesCreateCmdAddressLine1)
+	if err != nil {
+		return nil, err
 	}
 
-	if ShippingAddressesCreateCmdCity == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "city")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("city", "city", "body", parsedBody, ShippingAddressesCreateCmdCity)
+	if err != nil {
+		return nil, err
 	}
 
-	if ShippingAddressesCreateCmdState == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "state")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("state", "state", "body", parsedBody, ShippingAddressesCreateCmdState)
+	if err != nil {
+		return nil, err
 	}
 
-	if ShippingAddressesCreateCmdZipCode == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "zip-code")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("zipCode", "zip-code", "body", parsedBody, ShippingAddressesCreateCmdZipCode)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/shipping_addresses_delete.go
+++ b/soracom/generated/cmd/shipping_addresses_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var ShippingAddressesDeleteCmd = &cobra.Command{
 }
 
 func collectShippingAddressesDeleteCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if ShippingAddressesDeleteCmdOperatorId == "" {
 		ShippingAddressesDeleteCmdOperatorId = ac.OperatorID
 	}
 
-	if ShippingAddressesDeleteCmdShippingAddressId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "shipping-address-id")
+	err = checkIfRequiredStringParameterIsSupplied("shipping_address_id", "shipping-address-id", "path", parsedBody, ShippingAddressesDeleteCmdShippingAddressId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/shipping_addresses_get.go
+++ b/soracom/generated/cmd/shipping_addresses_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var ShippingAddressesGetCmd = &cobra.Command{
 }
 
 func collectShippingAddressesGetCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if ShippingAddressesGetCmdOperatorId == "" {
 		ShippingAddressesGetCmdOperatorId = ac.OperatorID
 	}
 
-	if ShippingAddressesGetCmdShippingAddressId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "shipping-address-id")
+	err = checkIfRequiredStringParameterIsSupplied("shipping_address_id", "shipping-address-id", "path", parsedBody, ShippingAddressesGetCmdShippingAddressId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/shipping_addresses_update.go
+++ b/soracom/generated/cmd/shipping_addresses_update.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -140,54 +137,46 @@ var ShippingAddressesUpdateCmd = &cobra.Command{
 }
 
 func collectShippingAddressesUpdateCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if ShippingAddressesUpdateCmdOperatorId == "" {
 		ShippingAddressesUpdateCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForShippingAddressesUpdateCmd()
+	body, err = buildBodyForShippingAddressesUpdateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if ShippingAddressesUpdateCmdAddressLine1 == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "address-line1")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("addressLine1", "address-line1", "body", parsedBody, ShippingAddressesUpdateCmdAddressLine1)
+	if err != nil {
+		return nil, err
 	}
 
-	if ShippingAddressesUpdateCmdCity == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "city")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("city", "city", "body", parsedBody, ShippingAddressesUpdateCmdCity)
+	if err != nil {
+		return nil, err
 	}
 
-	if ShippingAddressesUpdateCmdShippingAddressId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "shipping-address-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("shipping_address_id", "shipping-address-id", "path", parsedBody, ShippingAddressesUpdateCmdShippingAddressId)
+	if err != nil {
+		return nil, err
 	}
 
-	if ShippingAddressesUpdateCmdState == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "state")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("state", "state", "body", parsedBody, ShippingAddressesUpdateCmdState)
+	if err != nil {
+		return nil, err
 	}
 
-	if ShippingAddressesUpdateCmdZipCode == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "zip-code")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("zipCode", "zip-code", "body", parsedBody, ShippingAddressesUpdateCmdZipCode)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sigfox_devices_delete_tag.go
+++ b/soracom/generated/cmd/sigfox_devices_delete_tag.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var SigfoxDevicesDeleteTagCmd = &cobra.Command{
 }
 
 func collectSigfoxDevicesDeleteTagCmdParams(ac *apiClient) (*apiParams, error) {
-	if SigfoxDevicesDeleteTagCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, SigfoxDevicesDeleteTagCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SigfoxDevicesDeleteTagCmdTagName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "tag-name")
+	err = checkIfRequiredStringParameterIsSupplied("tag_name", "tag-name", "path", parsedBody, SigfoxDevicesDeleteTagCmdTagName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sigfox_devices_disable_termination.go
+++ b/soracom/generated/cmd/sigfox_devices_disable_termination.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SigfoxDevicesDisableTerminationCmd = &cobra.Command{
 }
 
 func collectSigfoxDevicesDisableTerminationCmdParams(ac *apiClient) (*apiParams, error) {
-	if SigfoxDevicesDisableTerminationCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, SigfoxDevicesDisableTerminationCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sigfox_devices_enable_termination.go
+++ b/soracom/generated/cmd/sigfox_devices_enable_termination.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SigfoxDevicesEnableTerminationCmd = &cobra.Command{
 }
 
 func collectSigfoxDevicesEnableTerminationCmdParams(ac *apiClient) (*apiParams, error) {
-	if SigfoxDevicesEnableTerminationCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, SigfoxDevicesEnableTerminationCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sigfox_devices_get.go
+++ b/soracom/generated/cmd/sigfox_devices_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SigfoxDevicesGetCmd = &cobra.Command{
 }
 
 func collectSigfoxDevicesGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if SigfoxDevicesGetCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, SigfoxDevicesGetCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sigfox_devices_get_data.go
+++ b/soracom/generated/cmd/sigfox_devices_get_data.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -94,8 +92,11 @@ var SigfoxDevicesGetDataCmd = &cobra.Command{
 }
 
 func collectSigfoxDevicesGetDataCmdParams(ac *apiClient) (*apiParams, error) {
-	if SigfoxDevicesGetDataCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, SigfoxDevicesGetDataCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sigfox_devices_put_tags.go
+++ b/soracom/generated/cmd/sigfox_devices_put_tags.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,18 +72,22 @@ var SigfoxDevicesPutTagsCmd = &cobra.Command{
 }
 
 func collectSigfoxDevicesPutTagsCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSigfoxDevicesPutTagsCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSigfoxDevicesPutTagsCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SigfoxDevicesPutTagsCmdDeviceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, SigfoxDevicesPutTagsCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sigfox_devices_register.go
+++ b/soracom/generated/cmd/sigfox_devices_register.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var SigfoxDevicesRegisterCmd = &cobra.Command{
 }
 
 func collectSigfoxDevicesRegisterCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSigfoxDevicesRegisterCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSigfoxDevicesRegisterCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SigfoxDevicesRegisterCmdDeviceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, SigfoxDevicesRegisterCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sigfox_devices_send_data.go
+++ b/soracom/generated/cmd/sigfox_devices_send_data.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var SigfoxDevicesSendDataCmd = &cobra.Command{
 }
 
 func collectSigfoxDevicesSendDataCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSigfoxDevicesSendDataCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSigfoxDevicesSendDataCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SigfoxDevicesSendDataCmdDeviceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, SigfoxDevicesSendDataCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sigfox_devices_set_group.go
+++ b/soracom/generated/cmd/sigfox_devices_set_group.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -95,18 +92,22 @@ var SigfoxDevicesSetGroupCmd = &cobra.Command{
 }
 
 func collectSigfoxDevicesSetGroupCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSigfoxDevicesSetGroupCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSigfoxDevicesSetGroupCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SigfoxDevicesSetGroupCmdDeviceId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, SigfoxDevicesSetGroupCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sigfox_devices_terminate.go
+++ b/soracom/generated/cmd/sigfox_devices_terminate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,8 +67,11 @@ var SigfoxDevicesTerminateCmd = &cobra.Command{
 }
 
 func collectSigfoxDevicesTerminateCmdParams(ac *apiClient) (*apiParams, error) {
-	if SigfoxDevicesTerminateCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, SigfoxDevicesTerminateCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sigfox_devices_unset_group.go
+++ b/soracom/generated/cmd/sigfox_devices_unset_group.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SigfoxDevicesUnsetGroupCmd = &cobra.Command{
 }
 
 func collectSigfoxDevicesUnsetGroupCmdParams(ac *apiClient) (*apiParams, error) {
-	if SigfoxDevicesUnsetGroupCmdDeviceId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "device-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("device_id", "device-id", "path", parsedBody, SigfoxDevicesUnsetGroupCmdDeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_activate.go
+++ b/soracom/generated/cmd/sims_activate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsActivateCmd = &cobra.Command{
 }
 
 func collectSimsActivateCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsActivateCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsActivateCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_add_subscription.go
+++ b/soracom/generated/cmd/sims_add_subscription.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,26 +77,27 @@ var SimsAddSubscriptionCmd = &cobra.Command{
 }
 
 func collectSimsAddSubscriptionCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsAddSubscriptionCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsAddSubscriptionCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsAddSubscriptionCmdIccid == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "iccid")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("iccid", "iccid", "path", parsedBody, SimsAddSubscriptionCmdIccid)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsAddSubscriptionCmdSimId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsAddSubscriptionCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_attach_arc_credentials.go
+++ b/soracom/generated/cmd/sims_attach_arc_credentials.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var SimsAttachArcCredentialsCmd = &cobra.Command{
 }
 
 func collectSimsAttachArcCredentialsCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsAttachArcCredentialsCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsAttachArcCredentialsCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsAttachArcCredentialsCmdSimId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsAttachArcCredentialsCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_create.go
+++ b/soracom/generated/cmd/sims_create.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,26 +77,27 @@ var SimsCreateCmd = &cobra.Command{
 }
 
 func collectSimsCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsCreateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsCreateCmdSubscription == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "subscription")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("subscription", "subscription", "body", parsedBody, SimsCreateCmdSubscription)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsCreateCmdType == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "type")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("type", "type", "body", parsedBody, SimsCreateCmdType)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_create_arc_session.go
+++ b/soracom/generated/cmd/sims_create_arc_session.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsCreateArcSessionCmd = &cobra.Command{
 }
 
 func collectSimsCreateArcSessionCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsCreateArcSessionCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsCreateArcSessionCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_create_packet_capture_session.go
+++ b/soracom/generated/cmd/sims_create_packet_capture_session.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,26 +82,27 @@ var SimsCreatePacketCaptureSessionCmd = &cobra.Command{
 }
 
 func collectSimsCreatePacketCaptureSessionCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsCreatePacketCaptureSessionCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsCreatePacketCaptureSessionCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsCreatePacketCaptureSessionCmdSimId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsCreatePacketCaptureSessionCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsCreatePacketCaptureSessionCmdDuration == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "duration")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("duration", "duration", "body", parsedBody, SimsCreatePacketCaptureSessionCmdDuration)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_deactivate.go
+++ b/soracom/generated/cmd/sims_deactivate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsDeactivateCmd = &cobra.Command{
 }
 
 func collectSimsDeactivateCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsDeactivateCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsDeactivateCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_delete_country_mapping_entry.go
+++ b/soracom/generated/cmd/sims_delete_country_mapping_entry.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,16 +72,21 @@ var SimsDeleteCountryMappingEntryCmd = &cobra.Command{
 }
 
 func collectSimsDeleteCountryMappingEntryCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsDeleteCountryMappingEntryCmdIccid == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "iccid")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("iccid", "iccid", "path", parsedBody, SimsDeleteCountryMappingEntryCmdIccid)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsDeleteCountryMappingEntryCmdMcc == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "mcc")
+	err = checkIfRequiredStringParameterIsSupplied("mcc", "mcc", "path", parsedBody, SimsDeleteCountryMappingEntryCmdMcc)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsDeleteCountryMappingEntryCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsDeleteCountryMappingEntryCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_delete_packet_capture_session.go
+++ b/soracom/generated/cmd/sims_delete_packet_capture_session.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var SimsDeletePacketCaptureSessionCmd = &cobra.Command{
 }
 
 func collectSimsDeletePacketCaptureSessionCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsDeletePacketCaptureSessionCmdSessionId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "session-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("session_id", "session-id", "path", parsedBody, SimsDeletePacketCaptureSessionCmdSessionId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsDeletePacketCaptureSessionCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsDeletePacketCaptureSessionCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_delete_session.go
+++ b/soracom/generated/cmd/sims_delete_session.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsDeleteSessionCmd = &cobra.Command{
 }
 
 func collectSimsDeleteSessionCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsDeleteSessionCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsDeleteSessionCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_delete_tag.go
+++ b/soracom/generated/cmd/sims_delete_tag.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var SimsDeleteTagCmd = &cobra.Command{
 }
 
 func collectSimsDeleteTagCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsDeleteTagCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsDeleteTagCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsDeleteTagCmdTagName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "tag-name")
+	err = checkIfRequiredStringParameterIsSupplied("tag_name", "tag-name", "path", parsedBody, SimsDeleteTagCmdTagName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_disable_termination.go
+++ b/soracom/generated/cmd/sims_disable_termination.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsDisableTerminationCmd = &cobra.Command{
 }
 
 func collectSimsDisableTerminationCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsDisableTerminationCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsDisableTerminationCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_downlink_ping.go
+++ b/soracom/generated/cmd/sims_downlink_ping.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var SimsDownlinkPingCmd = &cobra.Command{
 }
 
 func collectSimsDownlinkPingCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsDownlinkPingCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsDownlinkPingCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsDownlinkPingCmdSimId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsDownlinkPingCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_enable_subscription_container.go
+++ b/soracom/generated/cmd/sims_enable_subscription_container.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,16 +72,21 @@ var SimsEnableSubscriptionContainerCmd = &cobra.Command{
 }
 
 func collectSimsEnableSubscriptionContainerCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsEnableSubscriptionContainerCmdContainerId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "container-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("containerId", "container-id", "path", parsedBody, SimsEnableSubscriptionContainerCmdContainerId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsEnableSubscriptionContainerCmdIccid == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "iccid")
+	err = checkIfRequiredStringParameterIsSupplied("iccid", "iccid", "path", parsedBody, SimsEnableSubscriptionContainerCmdIccid)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsEnableSubscriptionContainerCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsEnableSubscriptionContainerCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_enable_termination.go
+++ b/soracom/generated/cmd/sims_enable_termination.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsEnableTerminationCmd = &cobra.Command{
 }
 
 func collectSimsEnableTerminationCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsEnableTerminationCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsEnableTerminationCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_get.go
+++ b/soracom/generated/cmd/sims_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsGetCmd = &cobra.Command{
 }
 
 func collectSimsGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsGetCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsGetCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_get_data.go
+++ b/soracom/generated/cmd/sims_get_data.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -89,9 +87,12 @@ var SimsGetDataCmd = &cobra.Command{
 }
 
 func collectSimsGetDataCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if SimsGetDataCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsGetDataCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_get_packet_capture_session.go
+++ b/soracom/generated/cmd/sims_get_packet_capture_session.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var SimsGetPacketCaptureSessionCmd = &cobra.Command{
 }
 
 func collectSimsGetPacketCaptureSessionCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsGetPacketCaptureSessionCmdSessionId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "session-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("session_id", "session-id", "path", parsedBody, SimsGetPacketCaptureSessionCmdSessionId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsGetPacketCaptureSessionCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsGetPacketCaptureSessionCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_list_packet_capture_sessions.go
+++ b/soracom/generated/cmd/sims_list_packet_capture_sessions.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,9 +72,12 @@ var SimsListPacketCaptureSessionsCmd = &cobra.Command{
 }
 
 func collectSimsListPacketCaptureSessionsCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if SimsListPacketCaptureSessionsCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsListPacketCaptureSessionsCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_list_subscription_containers.go
+++ b/soracom/generated/cmd/sims_list_subscription_containers.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var SimsListSubscriptionContainersCmd = &cobra.Command{
 }
 
 func collectSimsListSubscriptionContainersCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsListSubscriptionContainersCmdIccid == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "iccid")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("iccid", "iccid", "path", parsedBody, SimsListSubscriptionContainersCmdIccid)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsListSubscriptionContainersCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsListSubscriptionContainersCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_put_country_mapping_entries.go
+++ b/soracom/generated/cmd/sims_put_country_mapping_entries.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,26 +77,27 @@ var SimsPutCountryMappingEntriesCmd = &cobra.Command{
 }
 
 func collectSimsPutCountryMappingEntriesCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsPutCountryMappingEntriesCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsPutCountryMappingEntriesCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsPutCountryMappingEntriesCmdIccid == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "iccid")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("iccid", "iccid", "path", parsedBody, SimsPutCountryMappingEntriesCmdIccid)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsPutCountryMappingEntriesCmdSimId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsPutCountryMappingEntriesCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_put_tags.go
+++ b/soracom/generated/cmd/sims_put_tags.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,18 +72,22 @@ var SimsPutTagsCmd = &cobra.Command{
 }
 
 func collectSimsPutTagsCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsPutTagsCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsPutTagsCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsPutTagsCmdSimId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsPutTagsCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_register.go
+++ b/soracom/generated/cmd/sims_register.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,26 +82,27 @@ var SimsRegisterCmd = &cobra.Command{
 }
 
 func collectSimsRegisterCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsRegisterCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsRegisterCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsRegisterCmdRegistrationSecret == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "registration-secret")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("registrationSecret", "registration-secret", "body", parsedBody, SimsRegisterCmdRegistrationSecret)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsRegisterCmdSimId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsRegisterCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_remove_arc_credentials.go
+++ b/soracom/generated/cmd/sims_remove_arc_credentials.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsRemoveArcCredentialsCmd = &cobra.Command{
 }
 
 func collectSimsRemoveArcCredentialsCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsRemoveArcCredentialsCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsRemoveArcCredentialsCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_report_local_info.go
+++ b/soracom/generated/cmd/sims_report_local_info.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsReportLocalInfoCmd = &cobra.Command{
 }
 
 func collectSimsReportLocalInfoCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsReportLocalInfoCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsReportLocalInfoCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_send_sms.go
+++ b/soracom/generated/cmd/sims_send_sms.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var SimsSendSmsCmd = &cobra.Command{
 }
 
 func collectSimsSendSmsCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsSendSmsCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsSendSmsCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsSendSmsCmdSimId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsSendSmsCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_session_events.go
+++ b/soracom/generated/cmd/sims_session_events.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -84,9 +82,12 @@ var SimsSessionEventsCmd = &cobra.Command{
 }
 
 func collectSimsSessionEventsCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if SimsSessionEventsCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsSessionEventsCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_set_expiry_time.go
+++ b/soracom/generated/cmd/sims_set_expiry_time.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,26 +82,27 @@ var SimsSetExpiryTimeCmd = &cobra.Command{
 }
 
 func collectSimsSetExpiryTimeCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsSetExpiryTimeCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsSetExpiryTimeCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsSetExpiryTimeCmdSimId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsSetExpiryTimeCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsSetExpiryTimeCmdExpiryTime == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "expiry-time")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("expiryTime", "expiry-time", "body", parsedBody, SimsSetExpiryTimeCmdExpiryTime)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_set_group.go
+++ b/soracom/generated/cmd/sims_set_group.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var SimsSetGroupCmd = &cobra.Command{
 }
 
 func collectSimsSetGroupCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsSetGroupCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsSetGroupCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsSetGroupCmdSimId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsSetGroupCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_set_imei_lock.go
+++ b/soracom/generated/cmd/sims_set_imei_lock.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var SimsSetImeiLockCmd = &cobra.Command{
 }
 
 func collectSimsSetImeiLockCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsSetImeiLockCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsSetImeiLockCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsSetImeiLockCmdSimId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsSetImeiLockCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_set_to_standby.go
+++ b/soracom/generated/cmd/sims_set_to_standby.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsSetToStandbyCmd = &cobra.Command{
 }
 
 func collectSimsSetToStandbyCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsSetToStandbyCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsSetToStandbyCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_stop_packet_capture_session.go
+++ b/soracom/generated/cmd/sims_stop_packet_capture_session.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var SimsStopPacketCaptureSessionCmd = &cobra.Command{
 }
 
 func collectSimsStopPacketCaptureSessionCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsStopPacketCaptureSessionCmdSessionId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "session-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("session_id", "session-id", "path", parsedBody, SimsStopPacketCaptureSessionCmdSessionId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsStopPacketCaptureSessionCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsStopPacketCaptureSessionCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_suspend.go
+++ b/soracom/generated/cmd/sims_suspend.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsSuspendCmd = &cobra.Command{
 }
 
 func collectSimsSuspendCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsSuspendCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsSuspendCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_terminate.go
+++ b/soracom/generated/cmd/sims_terminate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsTerminateCmd = &cobra.Command{
 }
 
 func collectSimsTerminateCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsTerminateCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsTerminateCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_terminate_subscription_container.go
+++ b/soracom/generated/cmd/sims_terminate_subscription_container.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,16 +72,21 @@ var SimsTerminateSubscriptionContainerCmd = &cobra.Command{
 }
 
 func collectSimsTerminateSubscriptionContainerCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsTerminateSubscriptionContainerCmdIccid == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "iccid")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("iccid", "iccid", "path", parsedBody, SimsTerminateSubscriptionContainerCmdIccid)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsTerminateSubscriptionContainerCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SimsTerminateSubscriptionContainerCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsTerminateSubscriptionContainerCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsTerminateSubscriptionContainerCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_unset_expiry_time.go
+++ b/soracom/generated/cmd/sims_unset_expiry_time.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsUnsetExpiryTimeCmd = &cobra.Command{
 }
 
 func collectSimsUnsetExpiryTimeCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsUnsetExpiryTimeCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsUnsetExpiryTimeCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_unset_group.go
+++ b/soracom/generated/cmd/sims_unset_group.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsUnsetGroupCmd = &cobra.Command{
 }
 
 func collectSimsUnsetGroupCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsUnsetGroupCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsUnsetGroupCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_unset_imei_lock.go
+++ b/soracom/generated/cmd/sims_unset_imei_lock.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SimsUnsetImeiLockCmd = &cobra.Command{
 }
 
 func collectSimsUnsetImeiLockCmdParams(ac *apiClient) (*apiParams, error) {
-	if SimsUnsetImeiLockCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsUnsetImeiLockCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/sims_update_speed_class.go
+++ b/soracom/generated/cmd/sims_update_speed_class.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,26 +77,27 @@ var SimsUpdateSpeedClassCmd = &cobra.Command{
 }
 
 func collectSimsUpdateSpeedClassCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSimsUpdateSpeedClassCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSimsUpdateSpeedClassCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SimsUpdateSpeedClassCmdSimId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("sim_id", "sim-id", "path", parsedBody, SimsUpdateSpeedClassCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SimsUpdateSpeedClassCmdSpeedClass == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "speed-class")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("speedClass", "speed-class", "body", parsedBody, SimsUpdateSpeedClassCmdSpeedClass)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/soralets_create.go
+++ b/soracom/generated/cmd/soralets_create.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var SoraletsCreateCmd = &cobra.Command{
 }
 
 func collectSoraletsCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSoraletsCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSoraletsCreateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SoraletsCreateCmdSoraletId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "soralet-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("soraletId", "soralet-id", "body", parsedBody, SoraletsCreateCmdSoraletId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/soralets_delete.go
+++ b/soracom/generated/cmd/soralets_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SoraletsDeleteCmd = &cobra.Command{
 }
 
 func collectSoraletsDeleteCmdParams(ac *apiClient) (*apiParams, error) {
-	if SoraletsDeleteCmdSoraletId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "soralet-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("soralet_id", "soralet-id", "path", parsedBody, SoraletsDeleteCmdSoraletId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/soralets_delete_version.go
+++ b/soracom/generated/cmd/soralets_delete_version.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var SoraletsDeleteVersionCmd = &cobra.Command{
 }
 
 func collectSoraletsDeleteVersionCmdParams(ac *apiClient) (*apiParams, error) {
-	if SoraletsDeleteVersionCmdSoraletId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "soralet-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("soralet_id", "soralet-id", "path", parsedBody, SoraletsDeleteVersionCmdSoraletId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SoraletsDeleteVersionCmdVersion == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "version")
+	err = checkIfRequiredIntegerParameterIsSupplied("version", "version", "path", parsedBody, SoraletsDeleteVersionCmdVersion)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/soralets_exec.go
+++ b/soracom/generated/cmd/soralets_exec.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -105,50 +102,42 @@ var SoraletsExecCmd = &cobra.Command{
 }
 
 func collectSoraletsExecCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSoraletsExecCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSoraletsExecCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SoraletsExecCmdContentType == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "content-type")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("contentType", "content-type", "body", parsedBody, SoraletsExecCmdContentType)
+	if err != nil {
+		return nil, err
 	}
 
-	if SoraletsExecCmdDirection == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "direction")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("direction", "direction", "body", parsedBody, SoraletsExecCmdDirection)
+	if err != nil {
+		return nil, err
 	}
 
-	if SoraletsExecCmdPayload == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "payload")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("payload", "payload", "body", parsedBody, SoraletsExecCmdPayload)
+	if err != nil {
+		return nil, err
 	}
 
-	if SoraletsExecCmdSoraletId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "soralet-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("soralet_id", "soralet-id", "path", parsedBody, SoraletsExecCmdSoraletId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SoraletsExecCmdVersion == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "version")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("version", "version", "body", parsedBody, SoraletsExecCmdVersion)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/soralets_get.go
+++ b/soracom/generated/cmd/soralets_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SoraletsGetCmd = &cobra.Command{
 }
 
 func collectSoraletsGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if SoraletsGetCmdSoraletId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "soralet-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("soralet_id", "soralet-id", "path", parsedBody, SoraletsGetCmdSoraletId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/soralets_get_logs.go
+++ b/soracom/generated/cmd/soralets_get_logs.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -84,9 +82,12 @@ var SoraletsGetLogsCmd = &cobra.Command{
 }
 
 func collectSoraletsGetLogsCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if SoraletsGetLogsCmdSoraletId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "soralet-id")
+	err = checkIfRequiredStringParameterIsSupplied("soralet_id", "soralet-id", "path", parsedBody, SoraletsGetLogsCmdSoraletId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/soralets_list_versions.go
+++ b/soracom/generated/cmd/soralets_list_versions.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -84,9 +82,12 @@ var SoraletsListVersionsCmd = &cobra.Command{
 }
 
 func collectSoraletsListVersionsCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if SoraletsListVersionsCmdSoraletId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "soralet-id")
+	err = checkIfRequiredStringParameterIsSupplied("soralet_id", "soralet-id", "path", parsedBody, SoraletsListVersionsCmdSoraletId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/soralets_test.go
+++ b/soracom/generated/cmd/soralets_test.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -105,50 +102,42 @@ var SoraletsTestCmd = &cobra.Command{
 }
 
 func collectSoraletsTestCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSoraletsTestCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSoraletsTestCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SoraletsTestCmdContentType == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "content-type")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("contentType", "content-type", "body", parsedBody, SoraletsTestCmdContentType)
+	if err != nil {
+		return nil, err
 	}
 
-	if SoraletsTestCmdDirection == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "direction")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("direction", "direction", "body", parsedBody, SoraletsTestCmdDirection)
+	if err != nil {
+		return nil, err
 	}
 
-	if SoraletsTestCmdPayload == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "payload")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("payload", "payload", "body", parsedBody, SoraletsTestCmdPayload)
+	if err != nil {
+		return nil, err
 	}
 
-	if SoraletsTestCmdSoraletId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "soralet-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("soralet_id", "soralet-id", "path", parsedBody, SoraletsTestCmdSoraletId)
+	if err != nil {
+		return nil, err
 	}
 
-	if SoraletsTestCmdVersion == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "version")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("version", "version", "body", parsedBody, SoraletsTestCmdVersion)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/soralets_upload.go
+++ b/soracom/generated/cmd/soralets_upload.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -78,18 +77,22 @@ var SoraletsUploadCmd = &cobra.Command{
 }
 
 func collectSoraletsUploadCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSoraletsUploadCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSoraletsUploadCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := SoraletsUploadCmdContentType
 
-	if SoraletsUploadCmdSoraletId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "soralet-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("soralet_id", "soralet-id", "path", parsedBody, SoraletsUploadCmdSoraletId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/stats_air_export.go
+++ b/soracom/generated/cmd/stats_air_export.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -94,13 +93,20 @@ var StatsAirExportCmd = &cobra.Command{
 }
 
 func collectStatsAirExportCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if StatsAirExportCmdOperatorId == "" {
 		StatsAirExportCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForStatsAirExportCmd()
+	body, err = buildBodyForStatsAirExportCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/stats_air_get.go
+++ b/soracom/generated/cmd/stats_air_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -79,20 +77,26 @@ var StatsAirGetCmd = &cobra.Command{
 }
 
 func collectStatsAirGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if StatsAirGetCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, StatsAirGetCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
-	if StatsAirGetCmdPeriod == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "period")
+	err = checkIfRequiredStringParameterIsSupplied("period", "period", "query", parsedBody, StatsAirGetCmdPeriod)
+	if err != nil {
+		return nil, err
 	}
 
-	if StatsAirGetCmdFrom == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "from")
+	err = checkIfRequiredIntegerParameterIsSupplied("from", "from", "query", parsedBody, StatsAirGetCmdFrom)
+	if err != nil {
+		return nil, err
 	}
 
-	if StatsAirGetCmdTo == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "to")
+	err = checkIfRequiredIntegerParameterIsSupplied("to", "to", "query", parsedBody, StatsAirGetCmdTo)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/stats_air_sims_get.go
+++ b/soracom/generated/cmd/stats_air_sims_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -79,20 +77,26 @@ var StatsAirSimsGetCmd = &cobra.Command{
 }
 
 func collectStatsAirSimsGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if StatsAirSimsGetCmdPeriod == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "period")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("period", "period", "query", parsedBody, StatsAirSimsGetCmdPeriod)
+	if err != nil {
+		return nil, err
 	}
 
-	if StatsAirSimsGetCmdSimId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "sim-id")
+	err = checkIfRequiredStringParameterIsSupplied("simId", "sim-id", "path", parsedBody, StatsAirSimsGetCmdSimId)
+	if err != nil {
+		return nil, err
 	}
 
-	if StatsAirSimsGetCmdFrom == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "from")
+	err = checkIfRequiredIntegerParameterIsSupplied("from", "from", "query", parsedBody, StatsAirSimsGetCmdFrom)
+	if err != nil {
+		return nil, err
 	}
 
-	if StatsAirSimsGetCmdTo == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "to")
+	err = checkIfRequiredIntegerParameterIsSupplied("to", "to", "query", parsedBody, StatsAirSimsGetCmdTo)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/stats_beam_export.go
+++ b/soracom/generated/cmd/stats_beam_export.go
@@ -3,9 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -94,13 +93,20 @@ var StatsBeamExportCmd = &cobra.Command{
 }
 
 func collectStatsBeamExportCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if StatsBeamExportCmdOperatorId == "" {
 		StatsBeamExportCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForStatsBeamExportCmd()
+	body, err = buildBodyForStatsBeamExportCmd()
 	if err != nil {
 		return nil, err
+	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
 	}
 	contentType := "application/json"
 

--- a/soracom/generated/cmd/stats_beam_get.go
+++ b/soracom/generated/cmd/stats_beam_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -79,20 +77,26 @@ var StatsBeamGetCmd = &cobra.Command{
 }
 
 func collectStatsBeamGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if StatsBeamGetCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, StatsBeamGetCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
-	if StatsBeamGetCmdPeriod == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "period")
+	err = checkIfRequiredStringParameterIsSupplied("period", "period", "query", parsedBody, StatsBeamGetCmdPeriod)
+	if err != nil {
+		return nil, err
 	}
 
-	if StatsBeamGetCmdFrom == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "from")
+	err = checkIfRequiredIntegerParameterIsSupplied("from", "from", "query", parsedBody, StatsBeamGetCmdFrom)
+	if err != nil {
+		return nil, err
 	}
 
-	if StatsBeamGetCmdTo == 0 {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "to")
+	err = checkIfRequiredIntegerParameterIsSupplied("to", "to", "query", parsedBody, StatsBeamGetCmdTo)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_activate.go
+++ b/soracom/generated/cmd/subscribers_activate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersActivateCmd = &cobra.Command{
 }
 
 func collectSubscribersActivateCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersActivateCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersActivateCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_deactivate.go
+++ b/soracom/generated/cmd/subscribers_deactivate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersDeactivateCmd = &cobra.Command{
 }
 
 func collectSubscribersDeactivateCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersDeactivateCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersDeactivateCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_delete_session.go
+++ b/soracom/generated/cmd/subscribers_delete_session.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersDeleteSessionCmd = &cobra.Command{
 }
 
 func collectSubscribersDeleteSessionCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersDeleteSessionCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersDeleteSessionCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_delete_tag.go
+++ b/soracom/generated/cmd/subscribers_delete_tag.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var SubscribersDeleteTagCmd = &cobra.Command{
 }
 
 func collectSubscribersDeleteTagCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersDeleteTagCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersDeleteTagCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
-	if SubscribersDeleteTagCmdTagName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "tag-name")
+	err = checkIfRequiredStringParameterIsSupplied("tag_name", "tag-name", "path", parsedBody, SubscribersDeleteTagCmdTagName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_delete_transfer_token.go
+++ b/soracom/generated/cmd/subscribers_delete_transfer_token.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersDeleteTransferTokenCmd = &cobra.Command{
 }
 
 func collectSubscribersDeleteTransferTokenCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersDeleteTransferTokenCmdToken == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "token")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("token", "token", "path", parsedBody, SubscribersDeleteTransferTokenCmdToken)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_disable_termination.go
+++ b/soracom/generated/cmd/subscribers_disable_termination.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersDisableTerminationCmd = &cobra.Command{
 }
 
 func collectSubscribersDisableTerminationCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersDisableTerminationCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersDisableTerminationCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_downlink_ping.go
+++ b/soracom/generated/cmd/subscribers_downlink_ping.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var SubscribersDownlinkPingCmd = &cobra.Command{
 }
 
 func collectSubscribersDownlinkPingCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSubscribersDownlinkPingCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSubscribersDownlinkPingCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SubscribersDownlinkPingCmdImsi == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersDownlinkPingCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_enable_termination.go
+++ b/soracom/generated/cmd/subscribers_enable_termination.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersEnableTerminationCmd = &cobra.Command{
 }
 
 func collectSubscribersEnableTerminationCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersEnableTerminationCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersEnableTerminationCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_get.go
+++ b/soracom/generated/cmd/subscribers_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersGetCmd = &cobra.Command{
 }
 
 func collectSubscribersGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersGetCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersGetCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_get_data.go
+++ b/soracom/generated/cmd/subscribers_get_data.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -94,8 +92,11 @@ var SubscribersGetDataCmd = &cobra.Command{
 }
 
 func collectSubscribersGetDataCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersGetDataCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersGetDataCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_issue_transfer_token.go
+++ b/soracom/generated/cmd/subscribers_issue_transfer_token.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,26 +77,27 @@ var SubscribersIssueTransferTokenCmd = &cobra.Command{
 }
 
 func collectSubscribersIssueTransferTokenCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSubscribersIssueTransferTokenCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSubscribersIssueTransferTokenCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SubscribersIssueTransferTokenCmdTransferDestinationOperatorEmail == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "transfer-destination-operator-email")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("transferDestinationOperatorEmail", "transfer-destination-operator-email", "body", parsedBody, SubscribersIssueTransferTokenCmdTransferDestinationOperatorEmail)
+	if err != nil {
+		return nil, err
 	}
 
-	if SubscribersIssueTransferTokenCmdTransferDestinationOperatorId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "transfer-destination-operator-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("transferDestinationOperatorId", "transfer-destination-operator-id", "body", parsedBody, SubscribersIssueTransferTokenCmdTransferDestinationOperatorId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_put_bundles.go
+++ b/soracom/generated/cmd/subscribers_put_bundles.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,18 +72,22 @@ var SubscribersPutBundlesCmd = &cobra.Command{
 }
 
 func collectSubscribersPutBundlesCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSubscribersPutBundlesCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSubscribersPutBundlesCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SubscribersPutBundlesCmdImsi == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersPutBundlesCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_put_tags.go
+++ b/soracom/generated/cmd/subscribers_put_tags.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,18 +72,22 @@ var SubscribersPutTagsCmd = &cobra.Command{
 }
 
 func collectSubscribersPutTagsCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSubscribersPutTagsCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSubscribersPutTagsCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SubscribersPutTagsCmdImsi == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersPutTagsCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_register.go
+++ b/soracom/generated/cmd/subscribers_register.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,26 +82,27 @@ var SubscribersRegisterCmd = &cobra.Command{
 }
 
 func collectSubscribersRegisterCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSubscribersRegisterCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSubscribersRegisterCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SubscribersRegisterCmdImsi == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersRegisterCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
-	if SubscribersRegisterCmdRegistrationSecret == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "registration-secret")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("registrationSecret", "registration-secret", "body", parsedBody, SubscribersRegisterCmdRegistrationSecret)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_report_local_info.go
+++ b/soracom/generated/cmd/subscribers_report_local_info.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersReportLocalInfoCmd = &cobra.Command{
 }
 
 func collectSubscribersReportLocalInfoCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersReportLocalInfoCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersReportLocalInfoCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_send_sms.go
+++ b/soracom/generated/cmd/subscribers_send_sms.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var SubscribersSendSmsCmd = &cobra.Command{
 }
 
 func collectSubscribersSendSmsCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSubscribersSendSmsCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSubscribersSendSmsCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SubscribersSendSmsCmdImsi == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersSendSmsCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_send_sms_by_msisdn.go
+++ b/soracom/generated/cmd/subscribers_send_sms_by_msisdn.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var SubscribersSendSmsByMsisdnCmd = &cobra.Command{
 }
 
 func collectSubscribersSendSmsByMsisdnCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSubscribersSendSmsByMsisdnCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSubscribersSendSmsByMsisdnCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SubscribersSendSmsByMsisdnCmdMsisdn == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "msisdn")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("msisdn", "msisdn", "path", parsedBody, SubscribersSendSmsByMsisdnCmdMsisdn)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_session_events.go
+++ b/soracom/generated/cmd/subscribers_session_events.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -89,8 +87,11 @@ var SubscribersSessionEventsCmd = &cobra.Command{
 }
 
 func collectSubscribersSessionEventsCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersSessionEventsCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersSessionEventsCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_set_expiry_time.go
+++ b/soracom/generated/cmd/subscribers_set_expiry_time.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,26 +82,27 @@ var SubscribersSetExpiryTimeCmd = &cobra.Command{
 }
 
 func collectSubscribersSetExpiryTimeCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSubscribersSetExpiryTimeCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSubscribersSetExpiryTimeCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SubscribersSetExpiryTimeCmdImsi == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersSetExpiryTimeCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
-	if SubscribersSetExpiryTimeCmdExpiryTime == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "expiry-time")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("expiryTime", "expiry-time", "body", parsedBody, SubscribersSetExpiryTimeCmdExpiryTime)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_set_group.go
+++ b/soracom/generated/cmd/subscribers_set_group.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var SubscribersSetGroupCmd = &cobra.Command{
 }
 
 func collectSubscribersSetGroupCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSubscribersSetGroupCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSubscribersSetGroupCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SubscribersSetGroupCmdImsi == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersSetGroupCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_set_imei_lock.go
+++ b/soracom/generated/cmd/subscribers_set_imei_lock.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var SubscribersSetImeiLockCmd = &cobra.Command{
 }
 
 func collectSubscribersSetImeiLockCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSubscribersSetImeiLockCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSubscribersSetImeiLockCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SubscribersSetImeiLockCmdImsi == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersSetImeiLockCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_set_to_standby.go
+++ b/soracom/generated/cmd/subscribers_set_to_standby.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersSetToStandbyCmd = &cobra.Command{
 }
 
 func collectSubscribersSetToStandbyCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersSetToStandbyCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersSetToStandbyCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_suspend.go
+++ b/soracom/generated/cmd/subscribers_suspend.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersSuspendCmd = &cobra.Command{
 }
 
 func collectSubscribersSuspendCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersSuspendCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersSuspendCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_terminate.go
+++ b/soracom/generated/cmd/subscribers_terminate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersTerminateCmd = &cobra.Command{
 }
 
 func collectSubscribersTerminateCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersTerminateCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersTerminateCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_unset_expiry_time.go
+++ b/soracom/generated/cmd/subscribers_unset_expiry_time.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersUnsetExpiryTimeCmd = &cobra.Command{
 }
 
 func collectSubscribersUnsetExpiryTimeCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersUnsetExpiryTimeCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersUnsetExpiryTimeCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_unset_group.go
+++ b/soracom/generated/cmd/subscribers_unset_group.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersUnsetGroupCmd = &cobra.Command{
 }
 
 func collectSubscribersUnsetGroupCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersUnsetGroupCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersUnsetGroupCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_unset_imei_lock.go
+++ b/soracom/generated/cmd/subscribers_unset_imei_lock.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var SubscribersUnsetImeiLockCmd = &cobra.Command{
 }
 
 func collectSubscribersUnsetImeiLockCmdParams(ac *apiClient) (*apiParams, error) {
-	if SubscribersUnsetImeiLockCmdImsi == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersUnsetImeiLockCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_update_speed_class.go
+++ b/soracom/generated/cmd/subscribers_update_speed_class.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,26 +77,27 @@ var SubscribersUpdateSpeedClassCmd = &cobra.Command{
 }
 
 func collectSubscribersUpdateSpeedClassCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSubscribersUpdateSpeedClassCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSubscribersUpdateSpeedClassCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SubscribersUpdateSpeedClassCmdImsi == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "imsi")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, SubscribersUpdateSpeedClassCmdImsi)
+	if err != nil {
+		return nil, err
 	}
 
-	if SubscribersUpdateSpeedClassCmdSpeedClass == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "speed-class")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("speedClass", "speed-class", "body", parsedBody, SubscribersUpdateSpeedClassCmdSpeedClass)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/subscribers_verify_transfer_token.go
+++ b/soracom/generated/cmd/subscribers_verify_transfer_token.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -75,18 +72,22 @@ var SubscribersVerifyTransferTokenCmd = &cobra.Command{
 }
 
 func collectSubscribersVerifyTransferTokenCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForSubscribersVerifyTransferTokenCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForSubscribersVerifyTransferTokenCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SubscribersVerifyTransferTokenCmdToken == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "token")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("token", "token", "body", parsedBody, SubscribersVerifyTransferTokenCmdToken)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/system_notifications_delete.go
+++ b/soracom/generated/cmd/system_notifications_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var SystemNotificationsDeleteCmd = &cobra.Command{
 }
 
 func collectSystemNotificationsDeleteCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if SystemNotificationsDeleteCmdOperatorId == "" {
 		SystemNotificationsDeleteCmdOperatorId = ac.OperatorID
 	}
 
-	if SystemNotificationsDeleteCmdType == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "type")
+	err = checkIfRequiredStringParameterIsSupplied("type", "type", "path", parsedBody, SystemNotificationsDeleteCmdType)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/system_notifications_get.go
+++ b/soracom/generated/cmd/system_notifications_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var SystemNotificationsGetCmd = &cobra.Command{
 }
 
 func collectSystemNotificationsGetCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if SystemNotificationsGetCmdOperatorId == "" {
 		SystemNotificationsGetCmdOperatorId = ac.OperatorID
 	}
 
-	if SystemNotificationsGetCmdType == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "type")
+	err = checkIfRequiredStringParameterIsSupplied("type", "type", "path", parsedBody, SystemNotificationsGetCmdType)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/system_notifications_set.go
+++ b/soracom/generated/cmd/system_notifications_set.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,22 +82,26 @@ var SystemNotificationsSetCmd = &cobra.Command{
 }
 
 func collectSystemNotificationsSetCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if SystemNotificationsSetCmdOperatorId == "" {
 		SystemNotificationsSetCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForSystemNotificationsSetCmd()
+	body, err = buildBodyForSystemNotificationsSetCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if SystemNotificationsSetCmdType == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "type")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("type", "type", "path", parsedBody, SystemNotificationsSetCmdType)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_attach_role.go
+++ b/soracom/generated/cmd/users_attach_role.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,22 +82,26 @@ var UsersAttachRoleCmd = &cobra.Command{
 }
 
 func collectUsersAttachRoleCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if UsersAttachRoleCmdOperatorId == "" {
 		UsersAttachRoleCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForUsersAttachRoleCmd()
+	body, err = buildBodyForUsersAttachRoleCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if UsersAttachRoleCmdUserName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersAttachRoleCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_auth_keys_delete.go
+++ b/soracom/generated/cmd/users_auth_keys_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,16 +72,20 @@ var UsersAuthKeysDeleteCmd = &cobra.Command{
 }
 
 func collectUsersAuthKeysDeleteCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersAuthKeysDeleteCmdOperatorId == "" {
 		UsersAuthKeysDeleteCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersAuthKeysDeleteCmdAuthKeyId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "auth-key-id")
+	err = checkIfRequiredStringParameterIsSupplied("auth_key_id", "auth-key-id", "path", parsedBody, UsersAuthKeysDeleteCmdAuthKeyId)
+	if err != nil {
+		return nil, err
 	}
 
-	if UsersAuthKeysDeleteCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersAuthKeysDeleteCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_auth_keys_generate.go
+++ b/soracom/generated/cmd/users_auth_keys_generate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var UsersAuthKeysGenerateCmd = &cobra.Command{
 }
 
 func collectUsersAuthKeysGenerateCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersAuthKeysGenerateCmdOperatorId == "" {
 		UsersAuthKeysGenerateCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersAuthKeysGenerateCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersAuthKeysGenerateCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_auth_keys_get.go
+++ b/soracom/generated/cmd/users_auth_keys_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,16 +72,20 @@ var UsersAuthKeysGetCmd = &cobra.Command{
 }
 
 func collectUsersAuthKeysGetCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersAuthKeysGetCmdOperatorId == "" {
 		UsersAuthKeysGetCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersAuthKeysGetCmdAuthKeyId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "auth-key-id")
+	err = checkIfRequiredStringParameterIsSupplied("auth_key_id", "auth-key-id", "path", parsedBody, UsersAuthKeysGetCmdAuthKeyId)
+	if err != nil {
+		return nil, err
 	}
 
-	if UsersAuthKeysGetCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersAuthKeysGetCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_auth_keys_list.go
+++ b/soracom/generated/cmd/users_auth_keys_list.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var UsersAuthKeysListCmd = &cobra.Command{
 }
 
 func collectUsersAuthKeysListCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersAuthKeysListCmdOperatorId == "" {
 		UsersAuthKeysListCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersAuthKeysListCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersAuthKeysListCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_create.go
+++ b/soracom/generated/cmd/users_create.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,22 +82,26 @@ var UsersCreateCmd = &cobra.Command{
 }
 
 func collectUsersCreateCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if UsersCreateCmdOperatorId == "" {
 		UsersCreateCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForUsersCreateCmd()
+	body, err = buildBodyForUsersCreateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if UsersCreateCmdUserName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersCreateCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_default_permissions_update.go
+++ b/soracom/generated/cmd/users_default_permissions_update.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,22 +77,26 @@ var UsersDefaultPermissionsUpdateCmd = &cobra.Command{
 }
 
 func collectUsersDefaultPermissionsUpdateCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if UsersDefaultPermissionsUpdateCmdOperatorId == "" {
 		UsersDefaultPermissionsUpdateCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForUsersDefaultPermissionsUpdateCmd()
+	body, err = buildBodyForUsersDefaultPermissionsUpdateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if UsersDefaultPermissionsUpdateCmdPermissions == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "permissions")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("permissions", "permissions", "body", parsedBody, UsersDefaultPermissionsUpdateCmdPermissions)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_delete.go
+++ b/soracom/generated/cmd/users_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var UsersDeleteCmd = &cobra.Command{
 }
 
 func collectUsersDeleteCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersDeleteCmdOperatorId == "" {
 		UsersDeleteCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersDeleteCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersDeleteCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_detach_role.go
+++ b/soracom/generated/cmd/users_detach_role.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,16 +72,20 @@ var UsersDetachRoleCmd = &cobra.Command{
 }
 
 func collectUsersDetachRoleCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersDetachRoleCmdOperatorId == "" {
 		UsersDetachRoleCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersDetachRoleCmdRoleId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "role-id")
+	err = checkIfRequiredStringParameterIsSupplied("role_id", "role-id", "path", parsedBody, UsersDetachRoleCmdRoleId)
+	if err != nil {
+		return nil, err
 	}
 
-	if UsersDetachRoleCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersDetachRoleCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_get.go
+++ b/soracom/generated/cmd/users_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var UsersGetCmd = &cobra.Command{
 }
 
 func collectUsersGetCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersGetCmdOperatorId == "" {
 		UsersGetCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersGetCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersGetCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_list_roles.go
+++ b/soracom/generated/cmd/users_list_roles.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var UsersListRolesCmd = &cobra.Command{
 }
 
 func collectUsersListRolesCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersListRolesCmdOperatorId == "" {
 		UsersListRolesCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersListRolesCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersListRolesCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_mfa_enable.go
+++ b/soracom/generated/cmd/users_mfa_enable.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var UsersMfaEnableCmd = &cobra.Command{
 }
 
 func collectUsersMfaEnableCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersMfaEnableCmdOperatorId == "" {
 		UsersMfaEnableCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersMfaEnableCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersMfaEnableCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_mfa_get.go
+++ b/soracom/generated/cmd/users_mfa_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var UsersMfaGetCmd = &cobra.Command{
 }
 
 func collectUsersMfaGetCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersMfaGetCmdOperatorId == "" {
 		UsersMfaGetCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersMfaGetCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersMfaGetCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_mfa_revoke.go
+++ b/soracom/generated/cmd/users_mfa_revoke.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var UsersMfaRevokeCmd = &cobra.Command{
 }
 
 func collectUsersMfaRevokeCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersMfaRevokeCmdOperatorId == "" {
 		UsersMfaRevokeCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersMfaRevokeCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersMfaRevokeCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_mfa_verify.go
+++ b/soracom/generated/cmd/users_mfa_verify.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,22 +82,26 @@ var UsersMfaVerifyCmd = &cobra.Command{
 }
 
 func collectUsersMfaVerifyCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if UsersMfaVerifyCmdOperatorId == "" {
 		UsersMfaVerifyCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForUsersMfaVerifyCmd()
+	body, err = buildBodyForUsersMfaVerifyCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if UsersMfaVerifyCmdUserName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersMfaVerifyCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_password_configured.go
+++ b/soracom/generated/cmd/users_password_configured.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var UsersPasswordConfiguredCmd = &cobra.Command{
 }
 
 func collectUsersPasswordConfiguredCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersPasswordConfiguredCmdOperatorId == "" {
 		UsersPasswordConfiguredCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersPasswordConfiguredCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersPasswordConfiguredCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_password_create.go
+++ b/soracom/generated/cmd/users_password_create.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,22 +82,26 @@ var UsersPasswordCreateCmd = &cobra.Command{
 }
 
 func collectUsersPasswordCreateCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if UsersPasswordCreateCmdOperatorId == "" {
 		UsersPasswordCreateCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForUsersPasswordCreateCmd()
+	body, err = buildBodyForUsersPasswordCreateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if UsersPasswordCreateCmdUserName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersPasswordCreateCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_password_delete.go
+++ b/soracom/generated/cmd/users_password_delete.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var UsersPasswordDeleteCmd = &cobra.Command{
 }
 
 func collectUsersPasswordDeleteCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersPasswordDeleteCmdOperatorId == "" {
 		UsersPasswordDeleteCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersPasswordDeleteCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersPasswordDeleteCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_password_update.go
+++ b/soracom/generated/cmd/users_password_update.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -90,38 +87,36 @@ var UsersPasswordUpdateCmd = &cobra.Command{
 }
 
 func collectUsersPasswordUpdateCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if UsersPasswordUpdateCmdOperatorId == "" {
 		UsersPasswordUpdateCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForUsersPasswordUpdateCmd()
+	body, err = buildBodyForUsersPasswordUpdateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if UsersPasswordUpdateCmdCurrentPassword == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "current-password")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("currentPassword", "current-password", "body", parsedBody, UsersPasswordUpdateCmdCurrentPassword)
+	if err != nil {
+		return nil, err
 	}
 
-	if UsersPasswordUpdateCmdNewPassword == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "new-password")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("newPassword", "new-password", "body", parsedBody, UsersPasswordUpdateCmdNewPassword)
+	if err != nil {
+		return nil, err
 	}
 
-	if UsersPasswordUpdateCmdUserName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersPasswordUpdateCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_permissions_get.go
+++ b/soracom/generated/cmd/users_permissions_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,15 @@ var UsersPermissionsGetCmd = &cobra.Command{
 }
 
 func collectUsersPermissionsGetCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 	if UsersPermissionsGetCmdOperatorId == "" {
 		UsersPermissionsGetCmdOperatorId = ac.OperatorID
 	}
 
-	if UsersPermissionsGetCmdUserName == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersPermissionsGetCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_permissions_update.go
+++ b/soracom/generated/cmd/users_permissions_update.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -90,30 +87,31 @@ var UsersPermissionsUpdateCmd = &cobra.Command{
 }
 
 func collectUsersPermissionsUpdateCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if UsersPermissionsUpdateCmdOperatorId == "" {
 		UsersPermissionsUpdateCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForUsersPermissionsUpdateCmd()
+	body, err = buildBodyForUsersPermissionsUpdateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if UsersPermissionsUpdateCmdPermission == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "permission")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("permission", "permission", "body", parsedBody, UsersPermissionsUpdateCmdPermission)
+	if err != nil {
+		return nil, err
 	}
 
-	if UsersPermissionsUpdateCmdUserName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersPermissionsUpdateCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/users_update.go
+++ b/soracom/generated/cmd/users_update.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,22 +82,26 @@ var UsersUpdateCmd = &cobra.Command{
 }
 
 func collectUsersUpdateCmdParams(ac *apiClient) (*apiParams, error) {
+	var body string
+	var parsedBody interface{}
+	var err error
 	if UsersUpdateCmdOperatorId == "" {
 		UsersUpdateCmdOperatorId = ac.OperatorID
 	}
 
-	body, err := buildBodyForUsersUpdateCmd()
+	body, err = buildBodyForUsersUpdateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if UsersUpdateCmdUserName == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "user-name")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("user_name", "user-name", "path", parsedBody, UsersUpdateCmdUserName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/volume_discounts_confirm.go
+++ b/soracom/generated/cmd/volume_discounts_confirm.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var VolumeDiscountsConfirmCmd = &cobra.Command{
 }
 
 func collectVolumeDiscountsConfirmCmdParams(ac *apiClient) (*apiParams, error) {
-	if VolumeDiscountsConfirmCmdOrderId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "order-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("order_id", "order-id", "path", parsedBody, VolumeDiscountsConfirmCmdOrderId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/volume_discounts_create.go
+++ b/soracom/generated/cmd/volume_discounts_create.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -95,34 +92,32 @@ var VolumeDiscountsCreateCmd = &cobra.Command{
 }
 
 func collectVolumeDiscountsCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForVolumeDiscountsCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForVolumeDiscountsCreateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if VolumeDiscountsCreateCmdVolumeDiscountPaymentType == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "volume-discount-payment-type")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("volumeDiscountPaymentType", "volume-discount-payment-type", "body", parsedBody, VolumeDiscountsCreateCmdVolumeDiscountPaymentType)
+	if err != nil {
+		return nil, err
 	}
 
-	if VolumeDiscountsCreateCmdVolumeDiscountType == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "volume-discount-type")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("volumeDiscountType", "volume-discount-type", "body", parsedBody, VolumeDiscountsCreateCmdVolumeDiscountType)
+	if err != nil {
+		return nil, err
 	}
 
-	if VolumeDiscountsCreateCmdQuantity == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "quantity")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("quantity", "quantity", "body", parsedBody, VolumeDiscountsCreateCmdQuantity)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/volume_discounts_get.go
+++ b/soracom/generated/cmd/volume_discounts_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var VolumeDiscountsGetCmd = &cobra.Command{
 }
 
 func collectVolumeDiscountsGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if VolumeDiscountsGetCmdContractId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "contract-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("contract_id", "contract-id", "path", parsedBody, VolumeDiscountsGetCmdContractId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_close_gate.go
+++ b/soracom/generated/cmd/vpg_close_gate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var VpgCloseGateCmd = &cobra.Command{
 }
 
 func collectVpgCloseGateCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgCloseGateCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgCloseGateCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_create.go
+++ b/soracom/generated/cmd/vpg_create.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var VpgCreateCmd = &cobra.Command{
 }
 
 func collectVpgCreateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForVpgCreateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForVpgCreateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if VpgCreateCmdType == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "type")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("type", "type", "body", parsedBody, VpgCreateCmdType)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_create_mirroring_peer.go
+++ b/soracom/generated/cmd/vpg_create_mirroring_peer.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -95,18 +92,22 @@ var VpgCreateMirroringPeerCmd = &cobra.Command{
 }
 
 func collectVpgCreateMirroringPeerCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForVpgCreateMirroringPeerCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForVpgCreateMirroringPeerCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if VpgCreateMirroringPeerCmdVpgId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgCreateMirroringPeerCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_create_packet_capture_session.go
+++ b/soracom/generated/cmd/vpg_create_packet_capture_session.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,26 +82,27 @@ var VpgCreatePacketCaptureSessionCmd = &cobra.Command{
 }
 
 func collectVpgCreatePacketCaptureSessionCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForVpgCreatePacketCaptureSessionCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForVpgCreatePacketCaptureSessionCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if VpgCreatePacketCaptureSessionCmdVpgId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgCreatePacketCaptureSessionCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
-	if VpgCreatePacketCaptureSessionCmdDuration == 0 {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "duration")
-		}
-
+	err = checkIfRequiredIntegerParameterIsSupplied("duration", "duration", "body", parsedBody, VpgCreatePacketCaptureSessionCmdDuration)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_create_vpc_peering_connection.go
+++ b/soracom/generated/cmd/vpg_create_vpc_peering_connection.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -95,18 +92,22 @@ var VpgCreateVpcPeeringConnectionCmd = &cobra.Command{
 }
 
 func collectVpgCreateVpcPeeringConnectionCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForVpgCreateVpcPeeringConnectionCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForVpgCreateVpcPeeringConnectionCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if VpgCreateVpcPeeringConnectionCmdVpgId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgCreateVpcPeeringConnectionCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_delete_ip_address_map_entry.go
+++ b/soracom/generated/cmd/vpg_delete_ip_address_map_entry.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var VpgDeleteIpAddressMapEntryCmd = &cobra.Command{
 }
 
 func collectVpgDeleteIpAddressMapEntryCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgDeleteIpAddressMapEntryCmdKey == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "key")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("key", "key", "path", parsedBody, VpgDeleteIpAddressMapEntryCmdKey)
+	if err != nil {
+		return nil, err
 	}
 
-	if VpgDeleteIpAddressMapEntryCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgDeleteIpAddressMapEntryCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_delete_mirroring_peer.go
+++ b/soracom/generated/cmd/vpg_delete_mirroring_peer.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var VpgDeleteMirroringPeerCmd = &cobra.Command{
 }
 
 func collectVpgDeleteMirroringPeerCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgDeleteMirroringPeerCmdIpaddr == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "ipaddr")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("ipaddr", "ipaddr", "path", parsedBody, VpgDeleteMirroringPeerCmdIpaddr)
+	if err != nil {
+		return nil, err
 	}
 
-	if VpgDeleteMirroringPeerCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgDeleteMirroringPeerCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_delete_packet_capture_session.go
+++ b/soracom/generated/cmd/vpg_delete_packet_capture_session.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var VpgDeletePacketCaptureSessionCmd = &cobra.Command{
 }
 
 func collectVpgDeletePacketCaptureSessionCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgDeletePacketCaptureSessionCmdSessionId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "session-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("session_id", "session-id", "path", parsedBody, VpgDeletePacketCaptureSessionCmdSessionId)
+	if err != nil {
+		return nil, err
 	}
 
-	if VpgDeletePacketCaptureSessionCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgDeletePacketCaptureSessionCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_delete_vpc_peering_connection.go
+++ b/soracom/generated/cmd/vpg_delete_vpc_peering_connection.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var VpgDeleteVpcPeeringConnectionCmd = &cobra.Command{
 }
 
 func collectVpgDeleteVpcPeeringConnectionCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgDeleteVpcPeeringConnectionCmdPcxId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "pcx-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("pcx_id", "pcx-id", "path", parsedBody, VpgDeleteVpcPeeringConnectionCmdPcxId)
+	if err != nil {
+		return nil, err
 	}
 
-	if VpgDeleteVpcPeeringConnectionCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgDeleteVpcPeeringConnectionCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_get.go
+++ b/soracom/generated/cmd/vpg_get.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var VpgGetCmd = &cobra.Command{
 }
 
 func collectVpgGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgGetCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgGetCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_get_packet_capture_session.go
+++ b/soracom/generated/cmd/vpg_get_packet_capture_session.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var VpgGetPacketCaptureSessionCmd = &cobra.Command{
 }
 
 func collectVpgGetPacketCaptureSessionCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgGetPacketCaptureSessionCmdSessionId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "session-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("session_id", "session-id", "path", parsedBody, VpgGetPacketCaptureSessionCmdSessionId)
+	if err != nil {
+		return nil, err
 	}
 
-	if VpgGetPacketCaptureSessionCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgGetPacketCaptureSessionCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_list_gate_peers.go
+++ b/soracom/generated/cmd/vpg_list_gate_peers.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var VpgListGatePeersCmd = &cobra.Command{
 }
 
 func collectVpgListGatePeersCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgListGatePeersCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgListGatePeersCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_list_ip_address_map_entries.go
+++ b/soracom/generated/cmd/vpg_list_ip_address_map_entries.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var VpgListIpAddressMapEntriesCmd = &cobra.Command{
 }
 
 func collectVpgListIpAddressMapEntriesCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgListIpAddressMapEntriesCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgListIpAddressMapEntriesCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_list_packet_capture_sessions.go
+++ b/soracom/generated/cmd/vpg_list_packet_capture_sessions.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -74,9 +72,12 @@ var VpgListPacketCaptureSessionsCmd = &cobra.Command{
 }
 
 func collectVpgListPacketCaptureSessionsCmdParams(ac *apiClient) (*apiParams, error) {
+	var parsedBody interface{}
+	var err error
 
-	if VpgListPacketCaptureSessionsCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgListPacketCaptureSessionsCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_open_gate.go
+++ b/soracom/generated/cmd/vpg_open_gate.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,18 +82,22 @@ var VpgOpenGateCmd = &cobra.Command{
 }
 
 func collectVpgOpenGateCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForVpgOpenGateCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForVpgOpenGateCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if VpgOpenGateCmdVpgId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgOpenGateCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_put_ip_address_map_entry.go
+++ b/soracom/generated/cmd/vpg_put_ip_address_map_entry.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,34 +82,32 @@ var VpgPutIpAddressMapEntryCmd = &cobra.Command{
 }
 
 func collectVpgPutIpAddressMapEntryCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForVpgPutIpAddressMapEntryCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForVpgPutIpAddressMapEntryCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if VpgPutIpAddressMapEntryCmdIpAddress == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "ip-address")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("ipAddress", "ip-address", "body", parsedBody, VpgPutIpAddressMapEntryCmdIpAddress)
+	if err != nil {
+		return nil, err
 	}
 
-	if VpgPutIpAddressMapEntryCmdKey == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "key")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("key", "key", "body", parsedBody, VpgPutIpAddressMapEntryCmdKey)
+	if err != nil {
+		return nil, err
 	}
 
-	if VpgPutIpAddressMapEntryCmdVpgId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgPutIpAddressMapEntryCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_register_gate_peer.go
+++ b/soracom/generated/cmd/vpg_register_gate_peer.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -85,26 +82,27 @@ var VpgRegisterGatePeerCmd = &cobra.Command{
 }
 
 func collectVpgRegisterGatePeerCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForVpgRegisterGatePeerCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForVpgRegisterGatePeerCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if VpgRegisterGatePeerCmdOuterIpAddress == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "outer-ip-address")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("outerIpAddress", "outer-ip-address", "body", parsedBody, VpgRegisterGatePeerCmdOuterIpAddress)
+	if err != nil {
+		return nil, err
 	}
 
-	if VpgRegisterGatePeerCmdVpgId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgRegisterGatePeerCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_set_inspection.go
+++ b/soracom/generated/cmd/vpg_set_inspection.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -80,18 +77,22 @@ var VpgSetInspectionCmd = &cobra.Command{
 }
 
 func collectVpgSetInspectionCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForVpgSetInspectionCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForVpgSetInspectionCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if VpgSetInspectionCmdVpgId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgSetInspectionCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_set_redirection.go
+++ b/soracom/generated/cmd/vpg_set_redirection.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"encoding/json"
-
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -90,18 +87,22 @@ var VpgSetRedirectionCmd = &cobra.Command{
 }
 
 func collectVpgSetRedirectionCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForVpgSetRedirectionCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForVpgSetRedirectionCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if VpgSetRedirectionCmdVpgId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgSetRedirectionCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_set_routing_filter.go
+++ b/soracom/generated/cmd/vpg_set_routing_filter.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -73,18 +72,22 @@ var VpgSetRoutingFilterCmd = &cobra.Command{
 }
 
 func collectVpgSetRoutingFilterCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForVpgSetRoutingFilterCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForVpgSetRoutingFilterCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if VpgSetRoutingFilterCmdVpgId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgSetRoutingFilterCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_stop_packet_capture_session.go
+++ b/soracom/generated/cmd/vpg_stop_packet_capture_session.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var VpgStopPacketCaptureSessionCmd = &cobra.Command{
 }
 
 func collectVpgStopPacketCaptureSessionCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgStopPacketCaptureSessionCmdSessionId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "session-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("session_id", "session-id", "path", parsedBody, VpgStopPacketCaptureSessionCmdSessionId)
+	if err != nil {
+		return nil, err
 	}
 
-	if VpgStopPacketCaptureSessionCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgStopPacketCaptureSessionCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_terminate.go
+++ b/soracom/generated/cmd/vpg_terminate.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var VpgTerminateCmd = &cobra.Command{
 }
 
 func collectVpgTerminateCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgTerminateCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgTerminateCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_unregister_gate_peer.go
+++ b/soracom/generated/cmd/vpg_unregister_gate_peer.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -69,12 +67,16 @@ var VpgUnregisterGatePeerCmd = &cobra.Command{
 }
 
 func collectVpgUnregisterGatePeerCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgUnregisterGatePeerCmdOuterIpAddress == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "outer-ip-address")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("outer_ip_address", "outer-ip-address", "path", parsedBody, VpgUnregisterGatePeerCmdOuterIpAddress)
+	if err != nil {
+		return nil, err
 	}
 
-	if VpgUnregisterGatePeerCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgUnregisterGatePeerCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_unset_inspection.go
+++ b/soracom/generated/cmd/vpg_unset_inspection.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var VpgUnsetInspectionCmd = &cobra.Command{
 }
 
 func collectVpgUnsetInspectionCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgUnsetInspectionCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgUnsetInspectionCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_unset_redirection.go
+++ b/soracom/generated/cmd/vpg_unset_redirection.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"net/url"
 	"os"
 
@@ -64,8 +62,11 @@ var VpgUnsetRedirectionCmd = &cobra.Command{
 }
 
 func collectVpgUnsetRedirectionCmdParams(ac *apiClient) (*apiParams, error) {
-	if VpgUnsetRedirectionCmdVpgId == "" {
-		return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgUnsetRedirectionCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/soracom/generated/cmd/vpg_update_mirroring_peer.go
+++ b/soracom/generated/cmd/vpg_update_mirroring_peer.go
@@ -2,10 +2,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-
 	"io/ioutil"
-
 	"net/url"
 	"os"
 
@@ -78,26 +77,27 @@ var VpgUpdateMirroringPeerCmd = &cobra.Command{
 }
 
 func collectVpgUpdateMirroringPeerCmdParams(ac *apiClient) (*apiParams, error) {
-	body, err := buildBodyForVpgUpdateMirroringPeerCmd()
+	var body string
+	var parsedBody interface{}
+	var err error
+	body, err = buildBodyForVpgUpdateMirroringPeerCmd()
 	if err != nil {
 		return nil, err
 	}
+	err = json.Unmarshal([]byte(body), &parsedBody)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
+	}
 	contentType := "application/json"
 
-	if VpgUpdateMirroringPeerCmdIpaddr == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "ipaddr")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("ipaddr", "ipaddr", "path", parsedBody, VpgUpdateMirroringPeerCmdIpaddr)
+	if err != nil {
+		return nil, err
 	}
 
-	if VpgUpdateMirroringPeerCmdVpgId == "" {
-		if body == "" {
-
-			return nil, fmt.Errorf("required parameter '%s' is not specified", "vpg-id")
-		}
-
+	err = checkIfRequiredStringParameterIsSupplied("vpg_id", "vpg-id", "path", parsedBody, VpgUpdateMirroringPeerCmdVpgId)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{

--- a/test/test.sh
+++ b/test/test.sh
@@ -280,6 +280,31 @@ SORACOM="$d/soracom/dist/$VERSION/soracom_${VERSION}_${OS}_${ARCH}"
     test "$numSubs" -eq 4
 }
 
+: "Check if an error is returned when required parameter is missing" && {
+    set +e
+    resp="$( env "${SORACOM_ENVS[@]}" "$SORACOM" \
+        subscribers update-speed-class \
+        --profile soracom-cli-test \
+        2>&1 )"
+    exitCode="$?"
+    set -e
+    test "$exitCode" -ne 0
+    [[ "$resp" == *"Error: required parameter 'imsi' is not specified"* ]]
+}
+
+: "Check if an error is returned when required parameter in the request body is missing" && {
+    set +e
+    resp="$( env "${SORACOM_ENVS[@]}" "$SORACOM" \
+        subscribers update-speed-class \
+        --imsi "001010000000000" \
+        --profile soracom-cli-test \
+        2>&1 )"
+    exitCode="$?"
+    set -e
+    test "$exitCode" -ne 0
+    [[ "$resp" == *"Error: required parameter 'speedClass' in body (or command line option 'speed-class') is not specified"* ]]
+}
+
 : "Checking english help text" && {
     help_en="$( env LC_ALL=en_US.UTF-8 "${SORACOM_ENVS[@]}" "$SORACOM" -h )"
     diff <( echo "$help_en" ) <( cat "$d/test/data/help_en_expected.txt" )

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 d="$( cd "$( dirname "$0" )"; cd ..; pwd -P )"
-set -e
-
 VERSION=$1
-if [ -z "$1" ]; then
+set -Eeuo pipefail
+
+if [ -z "$VERSION" ]; then
   VERSION="0.0.0"
   echo "Version number (e.g. 1.2.3) is not specified. Using $VERSION as the default version number"
 fi
@@ -59,7 +59,7 @@ fi
 
 SORACOM_PROFILE_DIR=$tmpdir/.soracom
 : "${SORACOM_ENDPOINT:=https://api-sandbox.soracom.io}"
-SORACOM_ENVS=("SORACOM_ENDPOINT=$SORACOM_ENDPOINT" "SORACOM_PROFILE_DIR=$SORACOM_PROFILE_DIR" "SORACOM_DEBUG=$SORACOM_DEBUG")
+SORACOM_ENVS=("SORACOM_ENDPOINT=$SORACOM_ENDPOINT" "SORACOM_PROFILE_DIR=$SORACOM_PROFILE_DIR" "SORACOM_DEBUG=${SORACOM_DEBUG:-}")
 EMAIL="soracom-cli-test+$(random_string)@soracom.jp"
 PASSWORD=$(random_string)
 ZIPCODE="1234567"


### PR DESCRIPTION
`required` なパラメータのチェック方法を修正しました。

本来 API リクエスト Body に JSON で指定するべき引数のうちトップレベルにあるプリミティブ型のフィールドは、わざわざ JSON を作らなくてもコマンドラインオプションに直接指定できるようにしていました（※1）が、API 定義において Body の JSON のフィールドに `required` の指定があった場合にうまく扱えていませんでした。

また、Body ではなく Path 等に指定するパラメータに `required` の指定があった場合も、その API に Body が存在する場合は正しくチェックができていませんでした。

今回の修正により、コマンドライン引数 / Body 引数いずれも `required` とされている場合はその引数が渡されているかどうかを正しく確認できるようになりました。


※1 具体例としては、以下のような API に渡す Body の JSON
```
POST /v1/subscribers/{imsi}/update_speed_class
{
   "speedClass":"s1.standard"
}
```
は、`--body '{"speedClass":"s1.standard"}'` というように指定しても良いのですが、コマンドライン上で JSON を書こうとするとダブルクオーテーション (`"..."`) の処理が面倒なので、`--speed-class s1.standard` とも指定することができるようにしています。この場合は soracom-cli 内部で JSON を作って Body に指定しています。
