### PR TITLE
fix request body for /v1/sandbox/init api

### DIFF
--- a/generators/cmd/predefined/configure_sandbox.go
+++ b/generators/cmd/predefined/configure_sandbox.go
@@ -89,7 +89,7 @@ func sandboxInit(profile *profile) (*authResult, error) {
 		ac.SetVerbose(true)
 	}
 
-	reqBodyBytes, err := json.Marshal(profile)
+	reqBodyBytes, err := json.Marshal(createSandboxInitRequest(profile))
 	if err != nil {
 		return nil, err
 	}
@@ -114,4 +114,24 @@ func sandboxInit(profile *profile) (*authResult, error) {
 	}
 
 	return &ar, err
+}
+
+type sandboxInitRequest struct {
+	AuthKey               *string  `json:"authKey,omitempty"`
+	AuthKeyID             *string  `json:"authKeyId,omitempty"`
+	CoverageTypes         []string `json:"coverageTypes"`
+	Email                 *string  `json:"email,omitempty"`
+	Password              *string  `json:"password,omitempty"`
+	RegisterPaymentMethod bool     `json:"registerPaymentMethod"`
+}
+
+func createSandboxInitRequest(profile *profile) sandboxInitRequest {
+	return sandboxInitRequest{
+		AuthKey:               profile.AuthKey,
+		AuthKeyID:             profile.AuthKeyID,
+		CoverageTypes:         []string{profile.CoverageType},
+		Email:                 profile.Email,
+		Password:              profile.Password,
+		RegisterPaymentMethod: profile.RegisterPaymentMethod,
+	}
 }

--- a/soracom/generated/cmd/configure_sandbox.go
+++ b/soracom/generated/cmd/configure_sandbox.go
@@ -89,7 +89,7 @@ func sandboxInit(profile *profile) (*authResult, error) {
 		ac.SetVerbose(true)
 	}
 
-	reqBodyBytes, err := json.Marshal(profile)
+	reqBodyBytes, err := json.Marshal(createSandboxInitRequest(profile))
 	if err != nil {
 		return nil, err
 	}
@@ -114,4 +114,24 @@ func sandboxInit(profile *profile) (*authResult, error) {
 	}
 
 	return &ar, err
+}
+
+type sandboxInitRequest struct {
+	AuthKey               *string  `json:"authKey,omitempty"`
+	AuthKeyID             *string  `json:"authKeyId,omitempty"`
+	CoverageTypes         []string `json:"coverageTypes"`
+	Email                 *string  `json:"email,omitempty"`
+	Password              *string  `json:"password,omitempty"`
+	RegisterPaymentMethod bool     `json:"registerPaymentMethod"`
+}
+
+func createSandboxInitRequest(profile *profile) sandboxInitRequest {
+	return sandboxInitRequest{
+		AuthKey:               profile.AuthKey,
+		AuthKeyID:             profile.AuthKeyID,
+		CoverageTypes:         []string{profile.CoverageType},
+		Email:                 profile.Email,
+		Password:              profile.Password,
+		RegisterPaymentMethod: profile.RegisterPaymentMethod,
+	}
 }


### PR DESCRIPTION
これまで `profile` 型をそのまま JSON にして `/v1/sandbox/init` API に渡していましたが、`profile` 型では `coverageType` という `string` 型を保持しているのに対し `/v1/sandbox/init` API は `coverageTypes` という文字列型の配列を受け取る仕様になっており、ここが食い違っていて coverageType を指定していないことになってしまっていましたので修正しました。
