### PR TITLE
update `snapcraft push` to `snapcraft upload`

### DIFF
--- a/snap/release.sh
+++ b/snap/release.sh
@@ -7,7 +7,7 @@ snapcraft login
 set -e
 set -x
 
-res="$( snapcraft push "/mnt/soracom_${VERSION}_amd64.snap" )"
+res="$( snapcraft upload "/mnt/soracom_${VERSION}_amd64.snap" )"
 rev="$( echo "$res" | sed -rn 's/.*Revision ([0-9]+) of .* created./\1/p' )"
 channels=beta,edge,candidate,stable
 snapcraft release soracom "$rev" "$channels"


### PR DESCRIPTION
`snapcraft` コマンドのサブコマンド `push` を使用しているところで `upload` に変更するようにという warning が出たのでその対応です。