### PR TITLE
fix test script to specify coverage type explicitly

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -80,6 +80,7 @@ SORACOM="$d/soracom/dist/$VERSION/soracom_${VERSION}_${OS}_${ARCH}"
         --auth-key "$SORACOM_AUTHKEY_FOR_TEST" \
         --email "$EMAIL" \
         --password "$PASSWORD" \
+        --coverage-type "jp" \
         --profile soracom-cli-test
 }
 


### PR DESCRIPTION
認証情報をコマンドラインから指定する場合は coverage type も指定しないといけなかったので修正しました。