### PR TITLE
fix to use option name

### DIFF
--- a/generators/cmd/predefined/check_param.go
+++ b/generators/cmd/predefined/check_param.go
@@ -45,7 +45,7 @@ func checkIfRequiredIntegerParameterIsSupplied(propName, optionName, in string, 
 	}
 
 	if varValue == 0 {
-		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
+		return fmt.Errorf("required parameter '%s' is not specified", optionName)
 	}
 	return nil
 }
@@ -60,7 +60,7 @@ func checkIfRequiredFloatParameterIsSupplied(propName, optionName, in string, pa
 	}
 
 	if varValue == 0.0 {
-		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
+		return fmt.Errorf("required parameter '%s' is not specified", optionName)
 	}
 	return nil
 }
@@ -76,7 +76,7 @@ func checkIfRequiredBoolParameterIsSupplied(propName, optionName, in string, par
 	}
 
 	if !varValue {
-		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
+		return fmt.Errorf("required parameter '%s' is not specified", optionName)
 	}
 	return nil
 }

--- a/soracom/generated/cmd/check_param.go
+++ b/soracom/generated/cmd/check_param.go
@@ -45,7 +45,7 @@ func checkIfRequiredIntegerParameterIsSupplied(propName, optionName, in string, 
 	}
 
 	if varValue == 0 {
-		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
+		return fmt.Errorf("required parameter '%s' is not specified", optionName)
 	}
 	return nil
 }
@@ -60,7 +60,7 @@ func checkIfRequiredFloatParameterIsSupplied(propName, optionName, in string, pa
 	}
 
 	if varValue == 0.0 {
-		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
+		return fmt.Errorf("required parameter '%s' is not specified", optionName)
 	}
 	return nil
 }
@@ -76,7 +76,7 @@ func checkIfRequiredBoolParameterIsSupplied(propName, optionName, in string, par
 	}
 
 	if !varValue {
-		return fmt.Errorf("required parameter '%s' is not specified", "{{.LongOption}}")
+		return fmt.Errorf("required parameter '%s' is not specified", optionName)
 	}
 	return nil
 }


### PR DESCRIPTION
https://soracom.slack.com/archives/C03K32D6W/p1639958820481600

こちらで makoto に指摘された件の修正です。

> SORACOM CLI でエラーメッセージに {{.LongOption}} と表示されるケースを発見しました。
> ```
> $ soracom stats air get --imsi 440103213043029 --period month
> Error: required parameter '{{.LongOption}}' is not specified
> ```
