### PR TITLE
fix text resources for cli

### DIFF
--- a/generators/assets/cli/en.yaml
+++ b/generators/assets/cli/en.yaml
@@ -50,8 +50,9 @@ cli:
     auth_key: AuthKey for the production environment. (Used to check if you have a valid account on the production environment)
     auth_key_id: AuthKeyId for the production environment. (Used to check if you have a valid account on the production environment)
     email: E-mail address for the user to be created on the sandbox environment.
+    overwrite: Overwrite if the same profile already exists.
     password: Password for the user to be created on the sandbox environment.
-    register-payment-method: Register a virtual payment method for the user if specified.
+    register_payment_method: Register a virtual payment method for the user if specified.
     profile:
       prompt: "--- SORACOM CLI setup (Sandbox) ---\nThis will create a directory %s if it does not exist yet and place '%s.json' in it."
       prod_auth:

--- a/generators/assets/cli/ja.yaml
+++ b/generators/assets/cli/ja.yaml
@@ -50,8 +50,9 @@ cli:
     auth_key: 本番環境のアカウントの AuthKey（本番環境のアカウントを持っているかどうかを確認するために使われます）
     auth_key_id: 本番環境のアカウントの AuthKeyId（本番環境のアカウントを持っているかどうかを確認するために使われます）
     email: API Sandbox 環境に作られるユーザーのメールアドレス
+    overwrite: プロファイルが既に存在する場合、それを上書きするかどうかを指定します。
     password: API Sandbox 環境に作られるユーザーのパスワード
-    register-payment-method: 仮想の支払い方法を設定するかどうか
+    register_payment_method: 仮想の支払い方法を設定するかどうかを指定します。
     profile:
       prompt: "--- SORACOM CLI セットアップ (Sandbox) ---\n%s ディレクトリがなければ作成し、そこにファイル '%s.json' を作成します。"
       prod_auth:

--- a/soracom/generated/cmd/assets/cli/en.yaml
+++ b/soracom/generated/cmd/assets/cli/en.yaml
@@ -50,8 +50,9 @@ cli:
     auth_key: AuthKey for the production environment. (Used to check if you have a valid account on the production environment)
     auth_key_id: AuthKeyId for the production environment. (Used to check if you have a valid account on the production environment)
     email: E-mail address for the user to be created on the sandbox environment.
+    overwrite: Overwrite if the same profile already exists.
     password: Password for the user to be created on the sandbox environment.
-    register-payment-method: Register a virtual payment method for the user if specified.
+    register_payment_method: Register a virtual payment method for the user if specified.
     profile:
       prompt: "--- SORACOM CLI setup (Sandbox) ---\nThis will create a directory %s if it does not exist yet and place '%s.json' in it."
       prod_auth:

--- a/soracom/generated/cmd/assets/cli/ja.yaml
+++ b/soracom/generated/cmd/assets/cli/ja.yaml
@@ -50,8 +50,9 @@ cli:
     auth_key: 本番環境のアカウントの AuthKey（本番環境のアカウントを持っているかどうかを確認するために使われます）
     auth_key_id: 本番環境のアカウントの AuthKeyId（本番環境のアカウントを持っているかどうかを確認するために使われます）
     email: API Sandbox 環境に作られるユーザーのメールアドレス
+    overwrite: プロファイルが既に存在する場合、それを上書きするかどうかを指定します。
     password: API Sandbox 環境に作られるユーザーのパスワード
-    register-payment-method: 仮想の支払い方法を設定するかどうか
+    register_payment_method: 仮想の支払い方法を設定するかどうかを指定します。
     profile:
       prompt: "--- SORACOM CLI セットアップ (Sandbox) ---\n%s ディレクトリがなければ作成し、そこにファイル '%s.json' を作成します。"
       prod_auth:


### PR DESCRIPTION
`configure-sandbox` コマンドの CLI ヘルプの文言が不足していたり識別子が誤っていて利用されていなかったので修正です。