### PR TITLE
Make the command raise the error when the unnecessary argument(s) passed

### DIFF
--- a/generators/cmd/templates/leaf.gotmpl
+++ b/generators/cmd/templates/leaf.gotmpl
@@ -2,9 +2,9 @@
 package cmd
 
 import (
+  "fmt"
 {{- if .BodyExists }}
   "encoding/json"
-  "fmt"
   "io/ioutil"
 {{- end }}
   "net/url"
@@ -100,6 +100,11 @@ var {{ $cmdvar }} = &cobra.Command{
     {{end}}
 
     {{end}}
+
+    if len(args) > 0 {
+        return fmt.Errorf("unexpected arguments passed => %v", args)
+    }
+
     opt := &apiClientOptions{
       BasePath: "{{.BasePath}}",
       Language: getSelectedLanguage(),
@@ -182,7 +187,7 @@ func collect{{$cmdvar}}Params(ac *apiClient) (*apiParams, error) {
     if err != nil {
       return nil, fmt.Errorf("invalid json format specified for `--body` parameter: %s", err)
     }
-  }  
+  }
   {{end}}
 
   {{- /* check if all required parameters are supplied */ -}}

--- a/soracom/generated/cmd/audit_logs_api_get.go
+++ b/soracom/generated/cmd/audit_logs_api_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -47,6 +48,11 @@ var AuditLogsApiGetCmd = &cobra.Command{
 	Short: TRAPI("/audit_logs/api:get:summary"),
 	Long:  TRAPI(`/audit_logs/api:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/audit_logs_napter_get.go
+++ b/soracom/generated/cmd/audit_logs_napter_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -52,6 +53,11 @@ var AuditLogsNapterGetCmd = &cobra.Command{
 	Short: TRAPI("/audit_logs/napter:get:summary"),
 	Long:  TRAPI(`/audit_logs/napter:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/auth.go
+++ b/soracom/generated/cmd/auth.go
@@ -67,6 +67,11 @@ var AuthCmd = &cobra.Command{
 	Short: TRAPI("/auth:post:summary"),
 	Long:  TRAPI(`/auth:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/auth_issue_password_reset_token.go
+++ b/soracom/generated/cmd/auth_issue_password_reset_token.go
@@ -32,6 +32,11 @@ var AuthIssuePasswordResetTokenCmd = &cobra.Command{
 	Short: TRAPI("/auth/password_reset_token/issue:post:summary"),
 	Long:  TRAPI(`/auth/password_reset_token/issue:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/auth_verify_password_reset_token.go
+++ b/soracom/generated/cmd/auth_verify_password_reset_token.go
@@ -37,6 +37,11 @@ var AuthVerifyPasswordResetTokenCmd = &cobra.Command{
 	Short: TRAPI("/auth/password_reset_token/verify:post:summary"),
 	Long:  TRAPI(`/auth/password_reset_token/verify:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/bills_export.go
+++ b/soracom/generated/cmd/bills_export.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var BillsExportCmd = &cobra.Command{
 	Short: TRAPI("/bills/{yyyyMM}/export:post:summary"),
 	Long:  TRAPI(`/bills/{yyyyMM}/export:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/bills_export_latest.go
+++ b/soracom/generated/cmd/bills_export_latest.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var BillsExportLatestCmd = &cobra.Command{
 	Short: TRAPI("/bills/latest/export:post:summary"),
 	Long:  TRAPI(`/bills/latest/export:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/bills_get.go
+++ b/soracom/generated/cmd/bills_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var BillsGetCmd = &cobra.Command{
 	Short: TRAPI("/bills/{yyyyMM}:get:summary"),
 	Long:  TRAPI(`/bills/{yyyyMM}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/bills_get_daily.go
+++ b/soracom/generated/cmd/bills_get_daily.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var BillsGetDailyCmd = &cobra.Command{
 	Short: TRAPI("/bills/{yyyyMM}/daily:get:summary"),
 	Long:  TRAPI(`/bills/{yyyyMM}/daily:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/bills_get_latest.go
+++ b/soracom/generated/cmd/bills_get_latest.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var BillsGetLatestCmd = &cobra.Command{
 	Short: TRAPI("/bills/latest:get:summary"),
 	Long:  TRAPI(`/bills/latest:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/bills_list.go
+++ b/soracom/generated/cmd/bills_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var BillsListCmd = &cobra.Command{
 	Short: TRAPI("/bills:get:summary"),
 	Long:  TRAPI(`/bills:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/cell_locations_batch_get.go
+++ b/soracom/generated/cmd/cell_locations_batch_get.go
@@ -27,6 +27,11 @@ var CellLocationsBatchGetCmd = &cobra.Command{
 	Short: TRAPI("/cell_locations:post:summary"),
 	Long:  TRAPI(`/cell_locations:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/cell_locations_get.go
+++ b/soracom/generated/cmd/cell_locations_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -52,6 +53,11 @@ var CellLocationsGetCmd = &cobra.Command{
 	Short: TRAPI("/cell_locations:get:summary"),
 	Long:  TRAPI(`/cell_locations:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/coupons_confirm.go
+++ b/soracom/generated/cmd/coupons_confirm.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var CouponsConfirmCmd = &cobra.Command{
 	Short: TRAPI("/coupons/{order_id}/confirm:put:summary"),
 	Long:  TRAPI(`/coupons/{order_id}/confirm:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/coupons_create.go
+++ b/soracom/generated/cmd/coupons_create.go
@@ -32,6 +32,11 @@ var CouponsCreateCmd = &cobra.Command{
 	Short: TRAPI("/coupons:post:summary"),
 	Long:  TRAPI(`/coupons:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/coupons_list.go
+++ b/soracom/generated/cmd/coupons_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var CouponsListCmd = &cobra.Command{
 	Short: TRAPI("/coupons:get:summary"),
 	Long:  TRAPI(`/coupons:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/coupons_register.go
+++ b/soracom/generated/cmd/coupons_register.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var CouponsRegisterCmd = &cobra.Command{
 	Short: TRAPI("/coupons/{coupon_code}/register:post:summary"),
 	Long:  TRAPI(`/coupons/{coupon_code}/register:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/credentials_create.go
+++ b/soracom/generated/cmd/credentials_create.go
@@ -42,6 +42,11 @@ var CredentialsCreateCmd = &cobra.Command{
 	Short: TRAPI("/credentials/{credentials_id}:post:summary"),
 	Long:  TRAPI(`/credentials/{credentials_id}:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/credentials_delete.go
+++ b/soracom/generated/cmd/credentials_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var CredentialsDeleteCmd = &cobra.Command{
 	Short: TRAPI("/credentials/{credentials_id}:delete:summary"),
 	Long:  TRAPI(`/credentials/{credentials_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/credentials_list.go
+++ b/soracom/generated/cmd/credentials_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var CredentialsListCmd = &cobra.Command{
 	Short: TRAPI("/credentials:get:summary"),
 	Long:  TRAPI(`/credentials:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/credentials_update.go
+++ b/soracom/generated/cmd/credentials_update.go
@@ -42,6 +42,11 @@ var CredentialsUpdateCmd = &cobra.Command{
 	Short: TRAPI("/credentials/{credentials_id}:put:summary"),
 	Long:  TRAPI(`/credentials/{credentials_id}:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/data_delete_entry.go
+++ b/soracom/generated/cmd/data_delete_entry.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var DataDeleteEntryCmd = &cobra.Command{
 	Short: TRAPI("/data/{resource_type}/{resource_id}/{time}:delete:summary"),
 	Long:  TRAPI(`/data/{resource_type}/{resource_id}/{time}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/data_get.go
+++ b/soracom/generated/cmd/data_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -52,6 +53,11 @@ var DataGetCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/data:get:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/data:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/data_get_entries.go
+++ b/soracom/generated/cmd/data_get_entries.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -57,6 +58,11 @@ var DataGetEntriesCmd = &cobra.Command{
 	Short: TRAPI("/data/{resource_type}/{resource_id}:get:summary"),
 	Long:  TRAPI(`/data/{resource_type}/{resource_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/data_get_entry.go
+++ b/soracom/generated/cmd/data_get_entry.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var DataGetEntryCmd = &cobra.Command{
 	Short: TRAPI("/data/{resource_type}/{resource_id}/{time}:get:summary"),
 	Long:  TRAPI(`/data/{resource_type}/{resource_id}/{time}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/data_list_source_resources.go
+++ b/soracom/generated/cmd/data_list_source_resources.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -37,6 +38,11 @@ var DataListSourceResourcesCmd = &cobra.Command{
 	Short: TRAPI("/data/resources:get:summary"),
 	Long:  TRAPI(`/data/resources:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_create.go
+++ b/soracom/generated/cmd/devices_create.go
@@ -97,6 +97,11 @@ var DevicesCreateCmd = &cobra.Command{
 	Short: TRAPI("/devices:post:summary"),
 	Long:  TRAPI(`/devices:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_create_object_model.go
+++ b/soracom/generated/cmd/devices_create_object_model.go
@@ -62,6 +62,11 @@ var DevicesCreateObjectModelCmd = &cobra.Command{
 	Short: TRAPI("/device_object_models:post:summary"),
 	Long:  TRAPI(`/device_object_models:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_delete.go
+++ b/soracom/generated/cmd/devices_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var DevicesDeleteCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}:delete:summary"),
 	Long:  TRAPI(`/devices/{device_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_delete_device_tag.go
+++ b/soracom/generated/cmd/devices_delete_device_tag.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var DevicesDeleteDeviceTagCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/tags/{tag_name}:delete:summary"),
 	Long:  TRAPI(`/devices/{device_id}/tags/{tag_name}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_delete_object_model.go
+++ b/soracom/generated/cmd/devices_delete_object_model.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var DevicesDeleteObjectModelCmd = &cobra.Command{
 	Short: TRAPI("/device_object_models/{model_id}:delete:summary"),
 	Long:  TRAPI(`/device_object_models/{model_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_execute_resource.go
+++ b/soracom/generated/cmd/devices_execute_resource.go
@@ -47,6 +47,11 @@ var DevicesExecuteResourceCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/{resource}/execute:post:summary"),
 	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}/execute:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_get.go
+++ b/soracom/generated/cmd/devices_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var DevicesGetCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}:get:summary"),
 	Long:  TRAPI(`/devices/{device_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_get_data.go
+++ b/soracom/generated/cmd/devices_get_data.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -52,6 +53,11 @@ var DevicesGetDataCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/data:get:summary"),
 	Long:  TRAPI(`/devices/{device_id}/data:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_get_instance.go
+++ b/soracom/generated/cmd/devices_get_instance.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -37,6 +38,11 @@ var DevicesGetInstanceCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}:get:summary"),
 	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_get_object_model.go
+++ b/soracom/generated/cmd/devices_get_object_model.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var DevicesGetObjectModelCmd = &cobra.Command{
 	Short: TRAPI("/device_object_models/{model_id}:get:summary"),
 	Long:  TRAPI(`/device_object_models/{model_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_get_resource.go
+++ b/soracom/generated/cmd/devices_get_resource.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -42,6 +43,11 @@ var DevicesGetResourceCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/{resource}:get:summary"),
 	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_list.go
+++ b/soracom/generated/cmd/devices_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -47,6 +48,11 @@ var DevicesListCmd = &cobra.Command{
 	Short: TRAPI("/devices:get:summary"),
 	Long:  TRAPI(`/devices:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_list_object_models.go
+++ b/soracom/generated/cmd/devices_list_object_models.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var DevicesListObjectModelsCmd = &cobra.Command{
 	Short: TRAPI("/device_object_models:get:summary"),
 	Long:  TRAPI(`/device_object_models:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_observe_resource.go
+++ b/soracom/generated/cmd/devices_observe_resource.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -42,6 +43,11 @@ var DevicesObserveResourceCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/{resource}/observe:post:summary"),
 	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}/observe:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_observe_resources.go
+++ b/soracom/generated/cmd/devices_observe_resources.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -37,6 +38,11 @@ var DevicesObserveResourcesCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/observe:post:summary"),
 	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/observe:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_put_device_tags.go
+++ b/soracom/generated/cmd/devices_put_device_tags.go
@@ -32,6 +32,11 @@ var DevicesPutDeviceTagsCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/tags:put:summary"),
 	Long:  TRAPI(`/devices/{device_id}/tags:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_put_resource.go
+++ b/soracom/generated/cmd/devices_put_resource.go
@@ -47,6 +47,11 @@ var DevicesPutResourceCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/{resource}:put:summary"),
 	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_set_group.go
+++ b/soracom/generated/cmd/devices_set_group.go
@@ -32,6 +32,11 @@ var DevicesSetGroupCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/set_group:post:summary"),
 	Long:  TRAPI(`/devices/{device_id}/set_group:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_set_object_model_scope.go
+++ b/soracom/generated/cmd/devices_set_object_model_scope.go
@@ -37,6 +37,11 @@ var DevicesSetObjectModelScopeCmd = &cobra.Command{
 	Short: TRAPI("/device_object_models/{model_id}/set_scope:post:summary"),
 	Long:  TRAPI(`/device_object_models/{model_id}/set_scope:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_unobserve_resource.go
+++ b/soracom/generated/cmd/devices_unobserve_resource.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -37,6 +38,11 @@ var DevicesUnobserveResourceCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/{resource}/unobserve:post:summary"),
 	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}/unobserve:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_unobserve_resources.go
+++ b/soracom/generated/cmd/devices_unobserve_resources.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var DevicesUnobserveResourcesCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/unobserve:post:summary"),
 	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/unobserve:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_unset_group.go
+++ b/soracom/generated/cmd/devices_unset_group.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var DevicesUnsetGroupCmd = &cobra.Command{
 	Short: TRAPI("/devices/{device_id}/unset_group:post:summary"),
 	Long:  TRAPI(`/devices/{device_id}/unset_group:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/devices_update_object_model.go
+++ b/soracom/generated/cmd/devices_update_object_model.go
@@ -67,6 +67,11 @@ var DevicesUpdateObjectModelCmd = &cobra.Command{
 	Short: TRAPI("/device_object_models/{model_id}:post:summary"),
 	Long:  TRAPI(`/device_object_models/{model_id}:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/diagnostics_get.go
+++ b/soracom/generated/cmd/diagnostics_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var DiagnosticsGetCmd = &cobra.Command{
 	Short: TRAPI("/diagnostics/{diagnostic_id}:get:summary"),
 	Long:  TRAPI(`/diagnostics/{diagnostic_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/diagnostics_send_request.go
+++ b/soracom/generated/cmd/diagnostics_send_request.go
@@ -52,6 +52,11 @@ var DiagnosticsSendRequestCmd = &cobra.Command{
 	Short: TRAPI("/diagnostics:post:summary"),
 	Long:  TRAPI(`/diagnostics:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/emails_delete.go
+++ b/soracom/generated/cmd/emails_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var EmailsDeleteCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/emails/{email_id}:delete:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/emails/{email_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/emails_get.go
+++ b/soracom/generated/cmd/emails_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var EmailsGetCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/emails/{email_id}:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/emails/{email_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/emails_issue_add_email_token.go
+++ b/soracom/generated/cmd/emails_issue_add_email_token.go
@@ -37,6 +37,11 @@ var EmailsIssueAddEmailTokenCmd = &cobra.Command{
 	Short: TRAPI("/operators/add_email_token/issue:post:summary"),
 	Long:  TRAPI(`/operators/add_email_token/issue:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/emails_list.go
+++ b/soracom/generated/cmd/emails_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var EmailsListCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/emails:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/emails:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/emails_verify_add_email_token.go
+++ b/soracom/generated/cmd/emails_verify_add_email_token.go
@@ -32,6 +32,11 @@ var EmailsVerifyAddEmailTokenCmd = &cobra.Command{
 	Short: TRAPI("/operators/add_email_token/verify:post:summary"),
 	Long:  TRAPI(`/operators/add_email_token/verify:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/event_handlers_create.go
+++ b/soracom/generated/cmd/event_handlers_create.go
@@ -62,6 +62,11 @@ var EventHandlersCreateCmd = &cobra.Command{
 	Short: TRAPI("/event_handlers:post:summary"),
 	Long:  TRAPI(`/event_handlers:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/event_handlers_delete.go
+++ b/soracom/generated/cmd/event_handlers_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var EventHandlersDeleteCmd = &cobra.Command{
 	Short: TRAPI("/event_handlers/{handler_id}:delete:summary"),
 	Long:  TRAPI(`/event_handlers/{handler_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/event_handlers_get.go
+++ b/soracom/generated/cmd/event_handlers_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var EventHandlersGetCmd = &cobra.Command{
 	Short: TRAPI("/event_handlers/{handler_id}:get:summary"),
 	Long:  TRAPI(`/event_handlers/{handler_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/event_handlers_ignore.go
+++ b/soracom/generated/cmd/event_handlers_ignore.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var EventHandlersIgnoreCmd = &cobra.Command{
 	Short: TRAPI("/event_handlers/{handler_id}/subscribers/{imsi}/ignore:post:summary"),
 	Long:  TRAPI(`/event_handlers/{handler_id}/subscribers/{imsi}/ignore:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/event_handlers_list.go
+++ b/soracom/generated/cmd/event_handlers_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var EventHandlersListCmd = &cobra.Command{
 	Short: TRAPI("/event_handlers:get:summary"),
 	Long:  TRAPI(`/event_handlers:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/event_handlers_list_for_subscriber.go
+++ b/soracom/generated/cmd/event_handlers_list_for_subscriber.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var EventHandlersListForSubscriberCmd = &cobra.Command{
 	Short: TRAPI("/event_handlers/subscribers/{imsi}:get:summary"),
 	Long:  TRAPI(`/event_handlers/subscribers/{imsi}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/event_handlers_unignore.go
+++ b/soracom/generated/cmd/event_handlers_unignore.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var EventHandlersUnignoreCmd = &cobra.Command{
 	Short: TRAPI("/event_handlers/{handler_id}/subscribers/{imsi}/ignore:delete:summary"),
 	Long:  TRAPI(`/event_handlers/{handler_id}/subscribers/{imsi}/ignore:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/event_handlers_update.go
+++ b/soracom/generated/cmd/event_handlers_update.go
@@ -32,6 +32,11 @@ var EventHandlersUpdateCmd = &cobra.Command{
 	Short: TRAPI("/event_handlers/{handler_id}:put:summary"),
 	Long:  TRAPI(`/event_handlers/{handler_id}:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/files_delete.go
+++ b/soracom/generated/cmd/files_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var FilesDeleteCmd = &cobra.Command{
 	Short: TRAPI("/files/{scope}/{path}:delete:summary"),
 	Long:  TRAPI(`/files/{scope}/{path}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/files_delete_directory.go
+++ b/soracom/generated/cmd/files_delete_directory.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var FilesDeleteDirectoryCmd = &cobra.Command{
 	Short: TRAPI("/files/{scope}/{path}/:delete:summary"),
 	Long:  TRAPI(`/files/{scope}/{path}/:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/files_find.go
+++ b/soracom/generated/cmd/files_find.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -42,6 +43,11 @@ var FilesFindCmd = &cobra.Command{
 	Short: TRAPI("/files:get:summary"),
 	Long:  TRAPI(`/files:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/files_get.go
+++ b/soracom/generated/cmd/files_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var FilesGetCmd = &cobra.Command{
 	Short: TRAPI("/files/{scope}/{path}:get:summary"),
 	Long:  TRAPI(`/files/{scope}/{path}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/files_get_exported.go
+++ b/soracom/generated/cmd/files_get_exported.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var FilesGetExportedCmd = &cobra.Command{
 	Short: TRAPI("/files/exported/{exported_file_id}:get:summary"),
 	Long:  TRAPI(`/files/exported/{exported_file_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/files_get_metadata.go
+++ b/soracom/generated/cmd/files_get_metadata.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var FilesGetMetadataCmd = &cobra.Command{
 	Short: TRAPI("/files/{scope}/{path}:head:summary"),
 	Long:  TRAPI(`/files/{scope}/{path}:head:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/files_list.go
+++ b/soracom/generated/cmd/files_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -42,6 +43,11 @@ var FilesListCmd = &cobra.Command{
 	Short: TRAPI("/files/{scope}/{path}/:get:summary"),
 	Long:  TRAPI(`/files/{scope}/{path}/:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/files_put.go
+++ b/soracom/generated/cmd/files_put.go
@@ -42,6 +42,11 @@ var FilesPutCmd = &cobra.Command{
 	Short: TRAPI("/files/{scope}/{path}:put:summary"),
 	Long:  TRAPI(`/files/{scope}/{path}:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/gadgets_delete_tag.go
+++ b/soracom/generated/cmd/gadgets_delete_tag.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var GadgetsDeleteTagCmd = &cobra.Command{
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/tags/{tag_name}:delete:summary"),
 	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/tags/{tag_name}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/gadgets_disable_termination.go
+++ b/soracom/generated/cmd/gadgets_disable_termination.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var GadgetsDisableTerminationCmd = &cobra.Command{
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/disable_termination:post:summary"),
 	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/disable_termination:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/gadgets_enable_termination.go
+++ b/soracom/generated/cmd/gadgets_enable_termination.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var GadgetsEnableTerminationCmd = &cobra.Command{
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/enable_termination:post:summary"),
 	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/enable_termination:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/gadgets_get.go
+++ b/soracom/generated/cmd/gadgets_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var GadgetsGetCmd = &cobra.Command{
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}:get:summary"),
 	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/gadgets_list.go
+++ b/soracom/generated/cmd/gadgets_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -52,6 +53,11 @@ var GadgetsListCmd = &cobra.Command{
 	Short: TRAPI("/gadgets:get:summary"),
 	Long:  TRAPI(`/gadgets:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/gadgets_put_tags.go
+++ b/soracom/generated/cmd/gadgets_put_tags.go
@@ -37,6 +37,11 @@ var GadgetsPutTagsCmd = &cobra.Command{
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/tags:put:summary"),
 	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/tags:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/gadgets_register.go
+++ b/soracom/generated/cmd/gadgets_register.go
@@ -37,6 +37,11 @@ var GadgetsRegisterCmd = &cobra.Command{
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/register:post:summary"),
 	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/register:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/gadgets_set_group.go
+++ b/soracom/generated/cmd/gadgets_set_group.go
@@ -57,6 +57,11 @@ var GadgetsSetGroupCmd = &cobra.Command{
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/set_group:post:summary"),
 	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/set_group:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/gadgets_terminate.go
+++ b/soracom/generated/cmd/gadgets_terminate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var GadgetsTerminateCmd = &cobra.Command{
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/terminate:post:summary"),
 	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/terminate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/gadgets_unset_group.go
+++ b/soracom/generated/cmd/gadgets_unset_group.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var GadgetsUnsetGroupCmd = &cobra.Command{
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/unset_group:post:summary"),
 	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/unset_group:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/groups_create.go
+++ b/soracom/generated/cmd/groups_create.go
@@ -27,6 +27,11 @@ var GroupsCreateCmd = &cobra.Command{
 	Short: TRAPI("/groups:post:summary"),
 	Long:  TRAPI(`/groups:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/groups_delete.go
+++ b/soracom/generated/cmd/groups_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var GroupsDeleteCmd = &cobra.Command{
 	Short: TRAPI("/groups/{group_id}:delete:summary"),
 	Long:  TRAPI(`/groups/{group_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/groups_delete_config.go
+++ b/soracom/generated/cmd/groups_delete_config.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var GroupsDeleteConfigCmd = &cobra.Command{
 	Short: TRAPI("/groups/{group_id}/configuration/{namespace}/{name}:delete:summary"),
 	Long:  TRAPI(`/groups/{group_id}/configuration/{namespace}/{name}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/groups_delete_config_namespace.go
+++ b/soracom/generated/cmd/groups_delete_config_namespace.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var GroupsDeleteConfigNamespaceCmd = &cobra.Command{
 	Short: TRAPI("/groups/{group_id}/configuration/{namespace}:delete:summary"),
 	Long:  TRAPI(`/groups/{group_id}/configuration/{namespace}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/groups_delete_tag.go
+++ b/soracom/generated/cmd/groups_delete_tag.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var GroupsDeleteTagCmd = &cobra.Command{
 	Short: TRAPI("/groups/{group_id}/tags/{tag_name}:delete:summary"),
 	Long:  TRAPI(`/groups/{group_id}/tags/{tag_name}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/groups_get.go
+++ b/soracom/generated/cmd/groups_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var GroupsGetCmd = &cobra.Command{
 	Short: TRAPI("/groups/{group_id}:get:summary"),
 	Long:  TRAPI(`/groups/{group_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/groups_list.go
+++ b/soracom/generated/cmd/groups_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -47,6 +48,11 @@ var GroupsListCmd = &cobra.Command{
 	Short: TRAPI("/groups:get:summary"),
 	Long:  TRAPI(`/groups:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/groups_list_subscribers.go
+++ b/soracom/generated/cmd/groups_list_subscribers.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -37,6 +38,11 @@ var GroupsListSubscribersCmd = &cobra.Command{
 	Short: TRAPI("/groups/{group_id}/subscribers:get:summary"),
 	Long:  TRAPI(`/groups/{group_id}/subscribers:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/groups_put_config.go
+++ b/soracom/generated/cmd/groups_put_config.go
@@ -37,6 +37,11 @@ var GroupsPutConfigCmd = &cobra.Command{
 	Short: TRAPI("/groups/{group_id}/configuration/{namespace}:put:summary"),
 	Long:  TRAPI(`/groups/{group_id}/configuration/{namespace}:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/groups_put_tags.go
+++ b/soracom/generated/cmd/groups_put_tags.go
@@ -32,6 +32,11 @@ var GroupsPutTagsCmd = &cobra.Command{
 	Short: TRAPI("/groups/{group_id}/tags:put:summary"),
 	Long:  TRAPI(`/groups/{group_id}/tags:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_create_user.go
+++ b/soracom/generated/cmd/lagoon_create_user.go
@@ -42,6 +42,11 @@ var LagoonCreateUserCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/users:post:summary"),
 	Long:  TRAPI(`/lagoon/users:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_dashboards_init_permissions.go
+++ b/soracom/generated/cmd/lagoon_dashboards_init_permissions.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var LagoonDashboardsInitPermissionsCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/dashboards/{dashboard_id}/permissions/init:post:summary"),
 	Long:  TRAPI(`/lagoon/dashboards/{dashboard_id}/permissions/init:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_dashboards_list_permissions.go
+++ b/soracom/generated/cmd/lagoon_dashboards_list_permissions.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LagoonDashboardsListPermissionsCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/dashboards/permissions:get:summary"),
 	Long:  TRAPI(`/lagoon/dashboards/permissions:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_dashboards_update_permissions.go
+++ b/soracom/generated/cmd/lagoon_dashboards_update_permissions.go
@@ -37,6 +37,11 @@ var LagoonDashboardsUpdatePermissionsCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/dashboards/{dashboard_id}/permissions:put:summary"),
 	Long:  TRAPI(`/lagoon/dashboards/{dashboard_id}/permissions:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_delete_user.go
+++ b/soracom/generated/cmd/lagoon_delete_user.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LagoonDeleteUserCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}:delete:summary"),
 	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_get_image_link.go
+++ b/soracom/generated/cmd/lagoon_get_image_link.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LagoonGetImageLinkCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/image/link:get:summary"),
 	Long:  TRAPI(`/lagoon/image/link:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_license_packs_list_status.go
+++ b/soracom/generated/cmd/lagoon_license_packs_list_status.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var LagoonLicensePacksListStatusCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/license_packs:get:summary"),
 	Long:  TRAPI(`/lagoon/license_packs:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_license_packs_update.go
+++ b/soracom/generated/cmd/lagoon_license_packs_update.go
@@ -27,6 +27,11 @@ var LagoonLicensePacksUpdateCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/license_packs:put:summary"),
 	Long:  TRAPI(`/lagoon/license_packs:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_list_users.go
+++ b/soracom/generated/cmd/lagoon_list_users.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LagoonListUsersCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/users:get:summary"),
 	Long:  TRAPI(`/lagoon/users:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_migration_get_info.go
+++ b/soracom/generated/cmd/lagoon_migration_get_info.go
@@ -32,6 +32,11 @@ var LagoonMigrationGetInfoCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/migration:get:summary"),
 	Long:  TRAPI(`/lagoon/migration:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_migration_migrate.go
+++ b/soracom/generated/cmd/lagoon_migration_migrate.go
@@ -27,6 +27,11 @@ var LagoonMigrationMigrateCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/migration:post:summary"),
 	Long:  TRAPI(`/lagoon/migration:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_register.go
+++ b/soracom/generated/cmd/lagoon_register.go
@@ -37,6 +37,11 @@ var LagoonRegisterCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/register:post:summary"),
 	Long:  TRAPI(`/lagoon/register:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_terminate.go
+++ b/soracom/generated/cmd/lagoon_terminate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var LagoonTerminateCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/terminate:post:summary"),
 	Long:  TRAPI(`/lagoon/terminate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_update_user_email.go
+++ b/soracom/generated/cmd/lagoon_update_user_email.go
@@ -37,6 +37,11 @@ var LagoonUpdateUserEmailCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}/email:put:summary"),
 	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/email:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_update_user_password.go
+++ b/soracom/generated/cmd/lagoon_update_user_password.go
@@ -42,6 +42,11 @@ var LagoonUpdateUserPasswordCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}/password:put:summary"),
 	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/password:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_update_user_permission.go
+++ b/soracom/generated/cmd/lagoon_update_user_permission.go
@@ -37,6 +37,11 @@ var LagoonUpdateUserPermissionCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}/permission:put:summary"),
 	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/permission:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_updated_plan.go
+++ b/soracom/generated/cmd/lagoon_updated_plan.go
@@ -32,6 +32,11 @@ var LagoonUpdatedPlanCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/plan:put:summary"),
 	Long:  TRAPI(`/lagoon/plan:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_users_create.go
+++ b/soracom/generated/cmd/lagoon_users_create.go
@@ -42,6 +42,11 @@ var LagoonUsersCreateCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/users:post:summary"),
 	Long:  TRAPI(`/lagoon/users:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_users_delete.go
+++ b/soracom/generated/cmd/lagoon_users_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LagoonUsersDeleteCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}:delete:summary"),
 	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_users_list.go
+++ b/soracom/generated/cmd/lagoon_users_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LagoonUsersListCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/users:get:summary"),
 	Long:  TRAPI(`/lagoon/users:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_users_update_email.go
+++ b/soracom/generated/cmd/lagoon_users_update_email.go
@@ -37,6 +37,11 @@ var LagoonUsersUpdateEmailCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}/email:put:summary"),
 	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/email:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_users_update_password.go
+++ b/soracom/generated/cmd/lagoon_users_update_password.go
@@ -42,6 +42,11 @@ var LagoonUsersUpdatePasswordCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}/password:put:summary"),
 	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/password:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lagoon_users_update_permission.go
+++ b/soracom/generated/cmd/lagoon_users_update_permission.go
@@ -37,6 +37,11 @@ var LagoonUsersUpdatePermissionCmd = &cobra.Command{
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}/permission:put:summary"),
 	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/permission:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/logs_get.go
+++ b/soracom/generated/cmd/logs_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -57,6 +58,11 @@ var LogsGetCmd = &cobra.Command{
 	Short: TRAPI("/logs:get:summary"),
 	Long:  TRAPI(`/logs:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_devices_delete_tag.go
+++ b/soracom/generated/cmd/lora_devices_delete_tag.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var LoraDevicesDeleteTagCmd = &cobra.Command{
 	Short: TRAPI("/lora_devices/{device_id}/tags/{tag_name}:delete:summary"),
 	Long:  TRAPI(`/lora_devices/{device_id}/tags/{tag_name}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_devices_disable_termination.go
+++ b/soracom/generated/cmd/lora_devices_disable_termination.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LoraDevicesDisableTerminationCmd = &cobra.Command{
 	Short: TRAPI("/lora_devices/{device_id}/disable_termination:post:summary"),
 	Long:  TRAPI(`/lora_devices/{device_id}/disable_termination:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_devices_enable_termination.go
+++ b/soracom/generated/cmd/lora_devices_enable_termination.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LoraDevicesEnableTerminationCmd = &cobra.Command{
 	Short: TRAPI("/lora_devices/{device_id}/enable_termination:post:summary"),
 	Long:  TRAPI(`/lora_devices/{device_id}/enable_termination:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_devices_get.go
+++ b/soracom/generated/cmd/lora_devices_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LoraDevicesGetCmd = &cobra.Command{
 	Short: TRAPI("/lora_devices/{device_id}:get:summary"),
 	Long:  TRAPI(`/lora_devices/{device_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_devices_get_data.go
+++ b/soracom/generated/cmd/lora_devices_get_data.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -52,6 +53,11 @@ var LoraDevicesGetDataCmd = &cobra.Command{
 	Short: TRAPI("/lora_devices/{device_id}/data:get:summary"),
 	Long:  TRAPI(`/lora_devices/{device_id}/data:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_devices_list.go
+++ b/soracom/generated/cmd/lora_devices_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -47,6 +48,11 @@ var LoraDevicesListCmd = &cobra.Command{
 	Short: TRAPI("/lora_devices:get:summary"),
 	Long:  TRAPI(`/lora_devices:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_devices_put_tags.go
+++ b/soracom/generated/cmd/lora_devices_put_tags.go
@@ -32,6 +32,11 @@ var LoraDevicesPutTagsCmd = &cobra.Command{
 	Short: TRAPI("/lora_devices/{device_id}/tags:put:summary"),
 	Long:  TRAPI(`/lora_devices/{device_id}/tags:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_devices_register.go
+++ b/soracom/generated/cmd/lora_devices_register.go
@@ -42,6 +42,11 @@ var LoraDevicesRegisterCmd = &cobra.Command{
 	Short: TRAPI("/lora_devices/{device_id}/register:post:summary"),
 	Long:  TRAPI(`/lora_devices/{device_id}/register:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_devices_send_data.go
+++ b/soracom/generated/cmd/lora_devices_send_data.go
@@ -42,6 +42,11 @@ var LoraDevicesSendDataCmd = &cobra.Command{
 	Short: TRAPI("/lora_devices/{device_id}/data:post:summary"),
 	Long:  TRAPI(`/lora_devices/{device_id}/data:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_devices_set_group.go
+++ b/soracom/generated/cmd/lora_devices_set_group.go
@@ -52,6 +52,11 @@ var LoraDevicesSetGroupCmd = &cobra.Command{
 	Short: TRAPI("/lora_devices/{device_id}/set_group:post:summary"),
 	Long:  TRAPI(`/lora_devices/{device_id}/set_group:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_devices_terminate.go
+++ b/soracom/generated/cmd/lora_devices_terminate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LoraDevicesTerminateCmd = &cobra.Command{
 	Short: TRAPI("/lora_devices/{device_id}/terminate:post:summary"),
 	Long:  TRAPI(`/lora_devices/{device_id}/terminate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_devices_unset_group.go
+++ b/soracom/generated/cmd/lora_devices_unset_group.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LoraDevicesUnsetGroupCmd = &cobra.Command{
 	Short: TRAPI("/lora_devices/{device_id}/unset_group:post:summary"),
 	Long:  TRAPI(`/lora_devices/{device_id}/unset_group:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_gateways_delete_tag.go
+++ b/soracom/generated/cmd/lora_gateways_delete_tag.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var LoraGatewaysDeleteTagCmd = &cobra.Command{
 	Short: TRAPI("/lora_gateways/{gateway_id}/tags/{tag_name}:delete:summary"),
 	Long:  TRAPI(`/lora_gateways/{gateway_id}/tags/{tag_name}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_gateways_disable_termination.go
+++ b/soracom/generated/cmd/lora_gateways_disable_termination.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LoraGatewaysDisableTerminationCmd = &cobra.Command{
 	Short: TRAPI("/lora_gateways/{gateway_id}/disable_termination:post:summary"),
 	Long:  TRAPI(`/lora_gateways/{gateway_id}/disable_termination:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_gateways_enable_termination.go
+++ b/soracom/generated/cmd/lora_gateways_enable_termination.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LoraGatewaysEnableTerminationCmd = &cobra.Command{
 	Short: TRAPI("/lora_gateways/{gateway_id}/enable_termination:post:summary"),
 	Long:  TRAPI(`/lora_gateways/{gateway_id}/enable_termination:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_gateways_get.go
+++ b/soracom/generated/cmd/lora_gateways_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LoraGatewaysGetCmd = &cobra.Command{
 	Short: TRAPI("/lora_gateways/{gateway_id}:get:summary"),
 	Long:  TRAPI(`/lora_gateways/{gateway_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_gateways_list.go
+++ b/soracom/generated/cmd/lora_gateways_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -47,6 +48,11 @@ var LoraGatewaysListCmd = &cobra.Command{
 	Short: TRAPI("/lora_gateways:get:summary"),
 	Long:  TRAPI(`/lora_gateways:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_gateways_put_tags.go
+++ b/soracom/generated/cmd/lora_gateways_put_tags.go
@@ -32,6 +32,11 @@ var LoraGatewaysPutTagsCmd = &cobra.Command{
 	Short: TRAPI("/lora_gateways/{gateway_id}/tags:put:summary"),
 	Long:  TRAPI(`/lora_gateways/{gateway_id}/tags:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_gateways_set_network_set.go
+++ b/soracom/generated/cmd/lora_gateways_set_network_set.go
@@ -37,6 +37,11 @@ var LoraGatewaysSetNetworkSetCmd = &cobra.Command{
 	Short: TRAPI("/lora_gateways/{gateway_id}/set_network_set:post:summary"),
 	Long:  TRAPI(`/lora_gateways/{gateway_id}/set_network_set:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_gateways_terminate.go
+++ b/soracom/generated/cmd/lora_gateways_terminate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LoraGatewaysTerminateCmd = &cobra.Command{
 	Short: TRAPI("/lora_gateways/{gateway_id}/terminate:post:summary"),
 	Long:  TRAPI(`/lora_gateways/{gateway_id}/terminate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_gateways_unset_network_set.go
+++ b/soracom/generated/cmd/lora_gateways_unset_network_set.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LoraGatewaysUnsetNetworkSetCmd = &cobra.Command{
 	Short: TRAPI("/lora_gateways/{gateway_id}/unset_network_set:post:summary"),
 	Long:  TRAPI(`/lora_gateways/{gateway_id}/unset_network_set:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_network_sets_add_permission.go
+++ b/soracom/generated/cmd/lora_network_sets_add_permission.go
@@ -37,6 +37,11 @@ var LoraNetworkSetsAddPermissionCmd = &cobra.Command{
 	Short: TRAPI("/lora_network_sets/{ns_id}/add_permission:post:summary"),
 	Long:  TRAPI(`/lora_network_sets/{ns_id}/add_permission:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_network_sets_create.go
+++ b/soracom/generated/cmd/lora_network_sets_create.go
@@ -47,6 +47,11 @@ var LoraNetworkSetsCreateCmd = &cobra.Command{
 	Short: TRAPI("/lora_network_sets:post:summary"),
 	Long:  TRAPI(`/lora_network_sets:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_network_sets_delete.go
+++ b/soracom/generated/cmd/lora_network_sets_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LoraNetworkSetsDeleteCmd = &cobra.Command{
 	Short: TRAPI("/lora_network_sets/{ns_id}:delete:summary"),
 	Long:  TRAPI(`/lora_network_sets/{ns_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_network_sets_delete_tag.go
+++ b/soracom/generated/cmd/lora_network_sets_delete_tag.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var LoraNetworkSetsDeleteTagCmd = &cobra.Command{
 	Short: TRAPI("/lora_network_sets/{ns_id}/tags/{tag_name}:delete:summary"),
 	Long:  TRAPI(`/lora_network_sets/{ns_id}/tags/{tag_name}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_network_sets_get.go
+++ b/soracom/generated/cmd/lora_network_sets_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var LoraNetworkSetsGetCmd = &cobra.Command{
 	Short: TRAPI("/lora_network_sets/{ns_id}:get:summary"),
 	Long:  TRAPI(`/lora_network_sets/{ns_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_network_sets_list.go
+++ b/soracom/generated/cmd/lora_network_sets_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -47,6 +48,11 @@ var LoraNetworkSetsListCmd = &cobra.Command{
 	Short: TRAPI("/lora_network_sets:get:summary"),
 	Long:  TRAPI(`/lora_network_sets:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_network_sets_list_gateways.go
+++ b/soracom/generated/cmd/lora_network_sets_list_gateways.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -37,6 +38,11 @@ var LoraNetworkSetsListGatewaysCmd = &cobra.Command{
 	Short: TRAPI("/lora_network_sets/{ns_id}/gateways:get:summary"),
 	Long:  TRAPI(`/lora_network_sets/{ns_id}/gateways:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/lora_network_sets_revoke_permission.go
+++ b/soracom/generated/cmd/lora_network_sets_revoke_permission.go
@@ -37,6 +37,11 @@ var LoraNetworkSetsRevokePermissionCmd = &cobra.Command{
 	Short: TRAPI("/lora_network_sets/{ns_id}/revoke_permission:post:summary"),
 	Long:  TRAPI(`/lora_network_sets/{ns_id}/revoke_permission:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_add_contract.go
+++ b/soracom/generated/cmd/operator_add_contract.go
@@ -37,6 +37,11 @@ var OperatorAddContractCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/contracts:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/contracts:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_add_coverage_type.go
+++ b/soracom/generated/cmd/operator_add_coverage_type.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var OperatorAddCoverageTypeCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/coverage_type/{coverage_type}:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/coverage_type/{coverage_type}:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_auth_keys_delete.go
+++ b/soracom/generated/cmd/operator_auth_keys_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var OperatorAuthKeysDeleteCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/auth_keys/{auth_key_id}:delete:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/auth_keys/{auth_key_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_auth_keys_generate.go
+++ b/soracom/generated/cmd/operator_auth_keys_generate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OperatorAuthKeysGenerateCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/auth_keys:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/auth_keys:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_auth_keys_list.go
+++ b/soracom/generated/cmd/operator_auth_keys_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OperatorAuthKeysListCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/auth_keys:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/auth_keys:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_create.go
+++ b/soracom/generated/cmd/operator_create.go
@@ -37,6 +37,11 @@ var OperatorCreateCmd = &cobra.Command{
 	Short: TRAPI("/operators:post:summary"),
 	Long:  TRAPI(`/operators:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_create_company_information.go
+++ b/soracom/generated/cmd/operator_create_company_information.go
@@ -92,6 +92,11 @@ var OperatorCreateCompanyInformationCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/company_information:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/company_information:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_create_individual_information.go
+++ b/soracom/generated/cmd/operator_create_individual_information.go
@@ -77,6 +77,11 @@ var OperatorCreateIndividualInformationCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/individual_information:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/individual_information:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_delete_contract.go
+++ b/soracom/generated/cmd/operator_delete_contract.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var OperatorDeleteContractCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/contracts/{contract_name}:delete:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/contracts/{contract_name}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_enable_mfa.go
+++ b/soracom/generated/cmd/operator_enable_mfa.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OperatorEnableMfaCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/mfa:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/mfa:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_generate_api_token.go
+++ b/soracom/generated/cmd/operator_generate_api_token.go
@@ -37,6 +37,11 @@ var OperatorGenerateApiTokenCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/token:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/token:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_get.go
+++ b/soracom/generated/cmd/operator_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OperatorGetCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_get_company_information.go
+++ b/soracom/generated/cmd/operator_get_company_information.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OperatorGetCompanyInformationCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/company_information:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/company_information:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_get_individual_information.go
+++ b/soracom/generated/cmd/operator_get_individual_information.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OperatorGetIndividualInformationCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/individual_information:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/individual_information:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_get_mfa_status.go
+++ b/soracom/generated/cmd/operator_get_mfa_status.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OperatorGetMfaStatusCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/mfa:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/mfa:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_get_support_token.go
+++ b/soracom/generated/cmd/operator_get_support_token.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OperatorGetSupportTokenCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/support/token:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/support/token:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_issue_mfa_revoke_token.go
+++ b/soracom/generated/cmd/operator_issue_mfa_revoke_token.go
@@ -37,6 +37,11 @@ var OperatorIssueMfaRevokeTokenCmd = &cobra.Command{
 	Short: TRAPI("/operators/mfa_revoke_token/issue:post:summary"),
 	Long:  TRAPI(`/operators/mfa_revoke_token/issue:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_revoke_mfa.go
+++ b/soracom/generated/cmd/operator_revoke_mfa.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OperatorRevokeMfaCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/mfa:delete:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/mfa:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_update_company_information.go
+++ b/soracom/generated/cmd/operator_update_company_information.go
@@ -92,6 +92,11 @@ var OperatorUpdateCompanyInformationCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/company_information:put:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/company_information:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_update_individual_information.go
+++ b/soracom/generated/cmd/operator_update_individual_information.go
@@ -77,6 +77,11 @@ var OperatorUpdateIndividualInformationCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/individual_information:put:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/individual_information:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_update_password.go
+++ b/soracom/generated/cmd/operator_update_password.go
@@ -42,6 +42,11 @@ var OperatorUpdatePasswordCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/password:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/password:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_verify.go
+++ b/soracom/generated/cmd/operator_verify.go
@@ -32,6 +32,11 @@ var OperatorVerifyCmd = &cobra.Command{
 	Short: TRAPI("/operators/verify:post:summary"),
 	Long:  TRAPI(`/operators/verify:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_verify_mfa_otp.go
+++ b/soracom/generated/cmd/operator_verify_mfa_otp.go
@@ -37,6 +37,11 @@ var OperatorVerifyMfaOtpCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/mfa/verify:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/mfa/verify:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/operator_verify_mfa_revoke_token.go
+++ b/soracom/generated/cmd/operator_verify_mfa_revoke_token.go
@@ -47,6 +47,11 @@ var OperatorVerifyMfaRevokeTokenCmd = &cobra.Command{
 	Short: TRAPI("/operators/mfa_revoke_token/verify:post:summary"),
 	Long:  TRAPI(`/operators/mfa_revoke_token/verify:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/orders_cancel.go
+++ b/soracom/generated/cmd/orders_cancel.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OrdersCancelCmd = &cobra.Command{
 	Short: TRAPI("/orders/{order_id}/cancel:put:summary"),
 	Long:  TRAPI(`/orders/{order_id}/cancel:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/orders_confirm.go
+++ b/soracom/generated/cmd/orders_confirm.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OrdersConfirmCmd = &cobra.Command{
 	Short: TRAPI("/orders/{order_id}/confirm:put:summary"),
 	Long:  TRAPI(`/orders/{order_id}/confirm:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/orders_create.go
+++ b/soracom/generated/cmd/orders_create.go
@@ -32,6 +32,11 @@ var OrdersCreateCmd = &cobra.Command{
 	Short: TRAPI("/orders:post:summary"),
 	Long:  TRAPI(`/orders:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/orders_get.go
+++ b/soracom/generated/cmd/orders_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OrdersGetCmd = &cobra.Command{
 	Short: TRAPI("/orders/{order_id}:get:summary"),
 	Long:  TRAPI(`/orders/{order_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/orders_list.go
+++ b/soracom/generated/cmd/orders_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var OrdersListCmd = &cobra.Command{
 	Short: TRAPI("/orders:get:summary"),
 	Long:  TRAPI(`/orders:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/orders_list_subscribers.go
+++ b/soracom/generated/cmd/orders_list_subscribers.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var OrdersListSubscribersCmd = &cobra.Command{
 	Short: TRAPI("/orders/{order_id}/subscribers:get:summary"),
 	Long:  TRAPI(`/orders/{order_id}/subscribers:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/orders_register_subscribers.go
+++ b/soracom/generated/cmd/orders_register_subscribers.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var OrdersRegisterSubscribersCmd = &cobra.Command{
 	Short: TRAPI("/orders/{order_id}/subscribers/register:post:summary"),
 	Long:  TRAPI(`/orders/{order_id}/subscribers/register:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/payer_information_get.go
+++ b/soracom/generated/cmd/payer_information_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var PayerInformationGetCmd = &cobra.Command{
 	Short: TRAPI("/payment_statements/payer_information:get:summary"),
 	Long:  TRAPI(`/payment_statements/payer_information:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/payer_information_register.go
+++ b/soracom/generated/cmd/payer_information_register.go
@@ -42,6 +42,11 @@ var PayerInformationRegisterCmd = &cobra.Command{
 	Short: TRAPI("/payment_statements/payer_information:post:summary"),
 	Long:  TRAPI(`/payment_statements/payer_information:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/payment_history_get.go
+++ b/soracom/generated/cmd/payment_history_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var PaymentHistoryGetCmd = &cobra.Command{
 	Short: TRAPI("/payment_history/transactions/{payment_transaction_id}:get:summary"),
 	Long:  TRAPI(`/payment_history/transactions/{payment_transaction_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/payment_methods_get_current.go
+++ b/soracom/generated/cmd/payment_methods_get_current.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var PaymentMethodsGetCurrentCmd = &cobra.Command{
 	Short: TRAPI("/payment_methods/current:get:summary"),
 	Long:  TRAPI(`/payment_methods/current:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/payment_methods_reactivate_current.go
+++ b/soracom/generated/cmd/payment_methods_reactivate_current.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var PaymentMethodsReactivateCurrentCmd = &cobra.Command{
 	Short: TRAPI("/payment_methods/current/activate:post:summary"),
 	Long:  TRAPI(`/payment_methods/current/activate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/payment_statements_export.go
+++ b/soracom/generated/cmd/payment_statements_export.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var PaymentStatementsExportCmd = &cobra.Command{
 	Short: TRAPI("/payment_statements/{payment_statement_id}/export:post:summary"),
 	Long:  TRAPI(`/payment_statements/{payment_statement_id}/export:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/payment_statements_list.go
+++ b/soracom/generated/cmd/payment_statements_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var PaymentStatementsListCmd = &cobra.Command{
 	Short: TRAPI("/payment_statements:get:summary"),
 	Long:  TRAPI(`/payment_statements:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/port_mappings_create.go
+++ b/soracom/generated/cmd/port_mappings_create.go
@@ -37,6 +37,11 @@ var PortMappingsCreateCmd = &cobra.Command{
 	Short: TRAPI("/port_mappings:post:summary"),
 	Long:  TRAPI(`/port_mappings:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/port_mappings_delete.go
+++ b/soracom/generated/cmd/port_mappings_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var PortMappingsDeleteCmd = &cobra.Command{
 	Short: TRAPI("/port_mappings/{ip_address}/{port}:delete:summary"),
 	Long:  TRAPI(`/port_mappings/{ip_address}/{port}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/port_mappings_get.go
+++ b/soracom/generated/cmd/port_mappings_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var PortMappingsGetCmd = &cobra.Command{
 	Short: TRAPI("/port_mappings/subscribers/{imsi}:get:summary"),
 	Long:  TRAPI(`/port_mappings/subscribers/{imsi}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/port_mappings_list.go
+++ b/soracom/generated/cmd/port_mappings_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var PortMappingsListCmd = &cobra.Command{
 	Short: TRAPI("/port_mappings:get:summary"),
 	Long:  TRAPI(`/port_mappings:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/products_list.go
+++ b/soracom/generated/cmd/products_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var ProductsListCmd = &cobra.Command{
 	Short: TRAPI("/products:get:summary"),
 	Long:  TRAPI(`/products:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/query_devices.go
+++ b/soracom/generated/cmd/query_devices.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -67,6 +68,11 @@ var QueryDevicesCmd = &cobra.Command{
 	Short: TRAPI("/query/devices:get:summary"),
 	Long:  TRAPI(`/query/devices:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/query_sigfox_devices.go
+++ b/soracom/generated/cmd/query_sigfox_devices.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -67,6 +68,11 @@ var QuerySigfoxDevicesCmd = &cobra.Command{
 	Short: TRAPI("/query/sigfox_devices:get:summary"),
 	Long:  TRAPI(`/query/sigfox_devices:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/query_sims.go
+++ b/soracom/generated/cmd/query_sims.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -87,6 +88,11 @@ var QuerySimsCmd = &cobra.Command{
 	Short: TRAPI("/query/sims:get:summary"),
 	Long:  TRAPI(`/query/sims:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/query_subscribers.go
+++ b/soracom/generated/cmd/query_subscribers.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -86,6 +87,10 @@ var QuerySubscribersCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lib.WarnfStderr(TRCLI("cli.deprecated-api") + "\n")
 		lib.WarnfStderr(TRCLI("cli.alternative-api-suggestion")+"\n", "query sims")
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
 
 		opt := &apiClientOptions{
 			BasePath: "/v1",

--- a/soracom/generated/cmd/query_subscribers_traffic_volume_ranking.go
+++ b/soracom/generated/cmd/query_subscribers_traffic_volume_ranking.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -37,6 +38,11 @@ var QuerySubscribersTrafficVolumeRankingCmd = &cobra.Command{
 	Short: TRAPI("/query/subscribers/traffic_volume/ranking:get:summary"),
 	Long:  TRAPI(`/query/subscribers/traffic_volume/ranking:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/query_traffic_ranking.go
+++ b/soracom/generated/cmd/query_traffic_ranking.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -37,6 +38,11 @@ var QueryTrafficRankingCmd = &cobra.Command{
 	Short: TRAPI("/query/subscribers/traffic_volume/ranking:get:summary"),
 	Long:  TRAPI(`/query/subscribers/traffic_volume/ranking:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/roles_create.go
+++ b/soracom/generated/cmd/roles_create.go
@@ -47,6 +47,11 @@ var RolesCreateCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/roles/{role_id}:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/roles_delete.go
+++ b/soracom/generated/cmd/roles_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var RolesDeleteCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/roles/{role_id}:delete:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/roles_get.go
+++ b/soracom/generated/cmd/roles_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var RolesGetCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/roles/{role_id}:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/roles_list.go
+++ b/soracom/generated/cmd/roles_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var RolesListCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/roles:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/roles:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/roles_list_users.go
+++ b/soracom/generated/cmd/roles_list_users.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var RolesListUsersCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/roles/{role_id}/users:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}/users:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/roles_update.go
+++ b/soracom/generated/cmd/roles_update.go
@@ -47,6 +47,11 @@ var RolesUpdateCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/roles/{role_id}:put:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sandbox_coupons_create.go
+++ b/soracom/generated/cmd/sandbox_coupons_create.go
@@ -42,6 +42,11 @@ var SandboxCouponsCreateCmd = &cobra.Command{
 	Short: TRAPI("/sandbox/coupons/create:post:summary"),
 	Long:  TRAPI(`/sandbox/coupons/create:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sandbox_init.go
+++ b/soracom/generated/cmd/sandbox_init.go
@@ -52,6 +52,11 @@ var SandboxInitCmd = &cobra.Command{
 	Short: TRAPI("/sandbox/init:post:summary"),
 	Long:  TRAPI(`/sandbox/init:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sandbox_operators_delete.go
+++ b/soracom/generated/cmd/sandbox_operators_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SandboxOperatorsDeleteCmd = &cobra.Command{
 	Short: TRAPI("/sandbox/operators/{operator_id}:delete:summary"),
 	Long:  TRAPI(`/sandbox/operators/{operator_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sandbox_operators_get_signup_token.go
+++ b/soracom/generated/cmd/sandbox_operators_get_signup_token.go
@@ -42,6 +42,11 @@ var SandboxOperatorsGetSignupTokenCmd = &cobra.Command{
 	Short: TRAPI("/sandbox/operators/token/{email}:post:summary"),
 	Long:  TRAPI(`/sandbox/operators/token/{email}:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sandbox_orders_ship.go
+++ b/soracom/generated/cmd/sandbox_orders_ship.go
@@ -37,6 +37,11 @@ var SandboxOrdersShipCmd = &cobra.Command{
 	Short: TRAPI("/sandbox/orders/ship:post:summary"),
 	Long:  TRAPI(`/sandbox/orders/ship:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sandbox_stats_air_insert.go
+++ b/soracom/generated/cmd/sandbox_stats_air_insert.go
@@ -37,6 +37,11 @@ var SandboxStatsAirInsertCmd = &cobra.Command{
 	Short: TRAPI("/sandbox/stats/air/subscribers/{imsi}:post:summary"),
 	Long:  TRAPI(`/sandbox/stats/air/subscribers/{imsi}:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sandbox_stats_beam_insert.go
+++ b/soracom/generated/cmd/sandbox_stats_beam_insert.go
@@ -37,6 +37,11 @@ var SandboxStatsBeamInsertCmd = &cobra.Command{
 	Short: TRAPI("/sandbox/stats/beam/subscribers/{imsi}:post:summary"),
 	Long:  TRAPI(`/sandbox/stats/beam/subscribers/{imsi}:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sandbox_subscribers_create.go
+++ b/soracom/generated/cmd/sandbox_subscribers_create.go
@@ -32,6 +32,11 @@ var SandboxSubscribersCreateCmd = &cobra.Command{
 	Short: TRAPI("/sandbox/subscribers/create:post:summary"),
 	Long:  TRAPI(`/sandbox/subscribers/create:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/shipping_addresses_create.go
+++ b/soracom/generated/cmd/shipping_addresses_create.go
@@ -92,6 +92,11 @@ var ShippingAddressesCreateCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/shipping_addresses:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/shipping_addresses_delete.go
+++ b/soracom/generated/cmd/shipping_addresses_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var ShippingAddressesDeleteCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/shipping_addresses/{shipping_address_id}:delete:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses/{shipping_address_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/shipping_addresses_get.go
+++ b/soracom/generated/cmd/shipping_addresses_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var ShippingAddressesGetCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/shipping_addresses/{shipping_address_id}:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses/{shipping_address_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/shipping_addresses_list.go
+++ b/soracom/generated/cmd/shipping_addresses_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var ShippingAddressesListCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/shipping_addresses:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/shipping_addresses_update.go
+++ b/soracom/generated/cmd/shipping_addresses_update.go
@@ -97,6 +97,11 @@ var ShippingAddressesUpdateCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/shipping_addresses/{shipping_address_id}:put:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses/{shipping_address_id}:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sigfox_devices_delete_tag.go
+++ b/soracom/generated/cmd/sigfox_devices_delete_tag.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var SigfoxDevicesDeleteTagCmd = &cobra.Command{
 	Short: TRAPI("/sigfox_devices/{device_id}/tags/{tag_name}:delete:summary"),
 	Long:  TRAPI(`/sigfox_devices/{device_id}/tags/{tag_name}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sigfox_devices_disable_termination.go
+++ b/soracom/generated/cmd/sigfox_devices_disable_termination.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SigfoxDevicesDisableTerminationCmd = &cobra.Command{
 	Short: TRAPI("/sigfox_devices/{device_id}/disable_termination:post:summary"),
 	Long:  TRAPI(`/sigfox_devices/{device_id}/disable_termination:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sigfox_devices_enable_termination.go
+++ b/soracom/generated/cmd/sigfox_devices_enable_termination.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SigfoxDevicesEnableTerminationCmd = &cobra.Command{
 	Short: TRAPI("/sigfox_devices/{device_id}/enable_termination:post:summary"),
 	Long:  TRAPI(`/sigfox_devices/{device_id}/enable_termination:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sigfox_devices_get.go
+++ b/soracom/generated/cmd/sigfox_devices_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SigfoxDevicesGetCmd = &cobra.Command{
 	Short: TRAPI("/sigfox_devices/{device_id}:get:summary"),
 	Long:  TRAPI(`/sigfox_devices/{device_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sigfox_devices_get_data.go
+++ b/soracom/generated/cmd/sigfox_devices_get_data.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -52,6 +53,11 @@ var SigfoxDevicesGetDataCmd = &cobra.Command{
 	Short: TRAPI("/sigfox_devices/{device_id}/data:get:summary"),
 	Long:  TRAPI(`/sigfox_devices/{device_id}/data:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sigfox_devices_list.go
+++ b/soracom/generated/cmd/sigfox_devices_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -47,6 +48,11 @@ var SigfoxDevicesListCmd = &cobra.Command{
 	Short: TRAPI("/sigfox_devices:get:summary"),
 	Long:  TRAPI(`/sigfox_devices:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sigfox_devices_put_tags.go
+++ b/soracom/generated/cmd/sigfox_devices_put_tags.go
@@ -32,6 +32,11 @@ var SigfoxDevicesPutTagsCmd = &cobra.Command{
 	Short: TRAPI("/sigfox_devices/{device_id}/tags:put:summary"),
 	Long:  TRAPI(`/sigfox_devices/{device_id}/tags:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sigfox_devices_register.go
+++ b/soracom/generated/cmd/sigfox_devices_register.go
@@ -37,6 +37,11 @@ var SigfoxDevicesRegisterCmd = &cobra.Command{
 	Short: TRAPI("/sigfox_devices/{device_id}/register:post:summary"),
 	Long:  TRAPI(`/sigfox_devices/{device_id}/register:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sigfox_devices_send_data.go
+++ b/soracom/generated/cmd/sigfox_devices_send_data.go
@@ -37,6 +37,11 @@ var SigfoxDevicesSendDataCmd = &cobra.Command{
 	Short: TRAPI("/sigfox_devices/{device_id}/data:post:summary"),
 	Long:  TRAPI(`/sigfox_devices/{device_id}/data:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sigfox_devices_set_group.go
+++ b/soracom/generated/cmd/sigfox_devices_set_group.go
@@ -52,6 +52,11 @@ var SigfoxDevicesSetGroupCmd = &cobra.Command{
 	Short: TRAPI("/sigfox_devices/{device_id}/set_group:post:summary"),
 	Long:  TRAPI(`/sigfox_devices/{device_id}/set_group:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sigfox_devices_terminate.go
+++ b/soracom/generated/cmd/sigfox_devices_terminate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var SigfoxDevicesTerminateCmd = &cobra.Command{
 	Short: TRAPI("/sigfox_devices/{device_id}/terminate:post:summary"),
 	Long:  TRAPI(`/sigfox_devices/{device_id}/terminate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sigfox_devices_unset_group.go
+++ b/soracom/generated/cmd/sigfox_devices_unset_group.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SigfoxDevicesUnsetGroupCmd = &cobra.Command{
 	Short: TRAPI("/sigfox_devices/{device_id}/unset_group:post:summary"),
 	Long:  TRAPI(`/sigfox_devices/{device_id}/unset_group:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_activate.go
+++ b/soracom/generated/cmd/sims_activate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsActivateCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/activate:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/activate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_add_subscription.go
+++ b/soracom/generated/cmd/sims_add_subscription.go
@@ -37,6 +37,11 @@ var SimsAddSubscriptionCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/add_subscription:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/add_subscription:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_attach_arc_credentials.go
+++ b/soracom/generated/cmd/sims_attach_arc_credentials.go
@@ -41,6 +41,10 @@ var SimsAttachArcCredentialsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lib.WarnfStderr(TRCLI("cli.deprecated-api") + "\n")
 
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_cancel_subscription_container_download.go
+++ b/soracom/generated/cmd/sims_cancel_subscription_container_download.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var SimsCancelSubscriptionContainerDownloadCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/subscribers/{imsi}/cancel_download:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscribers/{imsi}/cancel_download:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_create.go
+++ b/soracom/generated/cmd/sims_create.go
@@ -37,6 +37,11 @@ var SimsCreateCmd = &cobra.Command{
 	Short: TRAPI("/sims:post:summary"),
 	Long:  TRAPI(`/sims:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_create_arc_session.go
+++ b/soracom/generated/cmd/sims_create_arc_session.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsCreateArcSessionCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/sessions/arc:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/sessions/arc:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_create_packet_capture_session.go
+++ b/soracom/generated/cmd/sims_create_packet_capture_session.go
@@ -42,6 +42,11 @@ var SimsCreatePacketCaptureSessionCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/packet_capture_sessions:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_deactivate.go
+++ b/soracom/generated/cmd/sims_deactivate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsDeactivateCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/deactivate:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/deactivate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_delete_country_mapping_entry.go
+++ b/soracom/generated/cmd/sims_delete_country_mapping_entry.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var SimsDeleteCountryMappingEntryCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/subscription_containers/country_mapping/{mcc}:delete:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscription_containers/country_mapping/{mcc}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_delete_packet_capture_session.go
+++ b/soracom/generated/cmd/sims_delete_packet_capture_session.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var SimsDeletePacketCaptureSessionCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/packet_capture_sessions/{session_id}:delete:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions/{session_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_delete_session.go
+++ b/soracom/generated/cmd/sims_delete_session.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsDeleteSessionCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/delete_session:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/delete_session:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_delete_tag.go
+++ b/soracom/generated/cmd/sims_delete_tag.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var SimsDeleteTagCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/tags/{tag_name}:delete:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/tags/{tag_name}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_disable_termination.go
+++ b/soracom/generated/cmd/sims_disable_termination.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsDisableTerminationCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/disable_termination:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/disable_termination:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_downlink_ping.go
+++ b/soracom/generated/cmd/sims_downlink_ping.go
@@ -42,6 +42,11 @@ var SimsDownlinkPingCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/downlink/ping:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/downlink/ping:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_enable_subscription_container.go
+++ b/soracom/generated/cmd/sims_enable_subscription_container.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var SimsEnableSubscriptionContainerCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/subscription_containers/{containerId}/enable:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscription_containers/{containerId}/enable:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_enable_termination.go
+++ b/soracom/generated/cmd/sims_enable_termination.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsEnableTerminationCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/enable_termination:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/enable_termination:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_get.go
+++ b/soracom/generated/cmd/sims_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsGetCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}:get:summary"),
 	Long:  TRAPI(`/sims/{sim_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_get_data.go
+++ b/soracom/generated/cmd/sims_get_data.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -47,6 +48,11 @@ var SimsGetDataCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/data:get:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/data:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_get_packet_capture_session.go
+++ b/soracom/generated/cmd/sims_get_packet_capture_session.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var SimsGetPacketCaptureSessionCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/packet_capture_sessions/{session_id}:get:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions/{session_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_list.go
+++ b/soracom/generated/cmd/sims_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var SimsListCmd = &cobra.Command{
 	Short: TRAPI("/sims:get:summary"),
 	Long:  TRAPI(`/sims:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_list_packet_capture_sessions.go
+++ b/soracom/generated/cmd/sims_list_packet_capture_sessions.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var SimsListPacketCaptureSessionsCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/packet_capture_sessions:get:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_list_subscription_containers.go
+++ b/soracom/generated/cmd/sims_list_subscription_containers.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var SimsListSubscriptionContainersCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/subscription_containers:get:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscription_containers:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_put_country_mapping_entries.go
+++ b/soracom/generated/cmd/sims_put_country_mapping_entries.go
@@ -37,6 +37,11 @@ var SimsPutCountryMappingEntriesCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/subscription_containers/country_mapping:put:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscription_containers/country_mapping:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_put_tags.go
+++ b/soracom/generated/cmd/sims_put_tags.go
@@ -32,6 +32,11 @@ var SimsPutTagsCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/tags:put:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/tags:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_register.go
+++ b/soracom/generated/cmd/sims_register.go
@@ -42,6 +42,11 @@ var SimsRegisterCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/register:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/register:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_remove_arc_credentials.go
+++ b/soracom/generated/cmd/sims_remove_arc_credentials.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -25,6 +26,10 @@ var SimsRemoveArcCredentialsCmd = &cobra.Command{
 	Long:  TRAPI(`/sims/{sim_id}/credentials/arc:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lib.WarnfStderr(TRCLI("cli.deprecated-api") + "\n")
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
 
 		opt := &apiClientOptions{
 			BasePath: "/v1",

--- a/soracom/generated/cmd/sims_renew_arc_credentials.go
+++ b/soracom/generated/cmd/sims_renew_arc_credentials.go
@@ -37,6 +37,11 @@ var SimsRenewArcCredentialsCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/credentials/arc:put:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/credentials/arc:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_report_local_info.go
+++ b/soracom/generated/cmd/sims_report_local_info.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsReportLocalInfoCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/report_local_info:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/report_local_info:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_send_sms.go
+++ b/soracom/generated/cmd/sims_send_sms.go
@@ -42,6 +42,11 @@ var SimsSendSmsCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/send_sms:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/send_sms:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_session_events.go
+++ b/soracom/generated/cmd/sims_session_events.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -42,6 +43,11 @@ var SimsSessionEventsCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/events/sessions:get:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/events/sessions:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_set_expiry_time.go
+++ b/soracom/generated/cmd/sims_set_expiry_time.go
@@ -42,6 +42,11 @@ var SimsSetExpiryTimeCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/set_expiry_time:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/set_expiry_time:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_set_group.go
+++ b/soracom/generated/cmd/sims_set_group.go
@@ -37,6 +37,11 @@ var SimsSetGroupCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/set_group:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/set_group:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_set_imei_lock.go
+++ b/soracom/generated/cmd/sims_set_imei_lock.go
@@ -37,6 +37,11 @@ var SimsSetImeiLockCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/set_imei_lock:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/set_imei_lock:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_set_to_standby.go
+++ b/soracom/generated/cmd/sims_set_to_standby.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsSetToStandbyCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/set_to_standby:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/set_to_standby:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_stop_packet_capture_session.go
+++ b/soracom/generated/cmd/sims_stop_packet_capture_session.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var SimsStopPacketCaptureSessionCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/packet_capture_sessions/{session_id}/stop:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions/{session_id}/stop:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_suspend.go
+++ b/soracom/generated/cmd/sims_suspend.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsSuspendCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/suspend:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/suspend:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_terminate.go
+++ b/soracom/generated/cmd/sims_terminate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsTerminateCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/terminate:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/terminate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_terminate_subscription_container.go
+++ b/soracom/generated/cmd/sims_terminate_subscription_container.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var SimsTerminateSubscriptionContainerCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/subscribers/{imsi}/terminate:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscribers/{imsi}/terminate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_unset_expiry_time.go
+++ b/soracom/generated/cmd/sims_unset_expiry_time.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsUnsetExpiryTimeCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/unset_expiry_time:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/unset_expiry_time:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_unset_group.go
+++ b/soracom/generated/cmd/sims_unset_group.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsUnsetGroupCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/unset_group:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/unset_group:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_unset_imei_lock.go
+++ b/soracom/generated/cmd/sims_unset_imei_lock.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SimsUnsetImeiLockCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/unset_imei_lock:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/unset_imei_lock:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/sims_update_speed_class.go
+++ b/soracom/generated/cmd/sims_update_speed_class.go
@@ -37,6 +37,11 @@ var SimsUpdateSpeedClassCmd = &cobra.Command{
 	Short: TRAPI("/sims/{sim_id}/update_speed_class:post:summary"),
 	Long:  TRAPI(`/sims/{sim_id}/update_speed_class:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/soralets_create.go
+++ b/soracom/generated/cmd/soralets_create.go
@@ -37,6 +37,11 @@ var SoraletsCreateCmd = &cobra.Command{
 	Short: TRAPI("/soralets:post:summary"),
 	Long:  TRAPI(`/soralets:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/soralets_delete.go
+++ b/soracom/generated/cmd/soralets_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SoraletsDeleteCmd = &cobra.Command{
 	Short: TRAPI("/soralets/{soralet_id}:delete:summary"),
 	Long:  TRAPI(`/soralets/{soralet_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/soralets_delete_version.go
+++ b/soracom/generated/cmd/soralets_delete_version.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var SoraletsDeleteVersionCmd = &cobra.Command{
 	Short: TRAPI("/soralets/{soralet_id}/versions/{version}:delete:summary"),
 	Long:  TRAPI(`/soralets/{soralet_id}/versions/{version}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/soralets_exec.go
+++ b/soracom/generated/cmd/soralets_exec.go
@@ -62,6 +62,11 @@ var SoraletsExecCmd = &cobra.Command{
 	Short: TRAPI("/soralets/{soralet_id}/test:post:summary"),
 	Long:  TRAPI(`/soralets/{soralet_id}/test:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/soralets_get.go
+++ b/soracom/generated/cmd/soralets_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SoraletsGetCmd = &cobra.Command{
 	Short: TRAPI("/soralets/{soralet_id}:get:summary"),
 	Long:  TRAPI(`/soralets/{soralet_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/soralets_get_logs.go
+++ b/soracom/generated/cmd/soralets_get_logs.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -42,6 +43,11 @@ var SoraletsGetLogsCmd = &cobra.Command{
 	Short: TRAPI("/soralets/{soralet_id}/logs:get:summary"),
 	Long:  TRAPI(`/soralets/{soralet_id}/logs:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/soralets_list.go
+++ b/soracom/generated/cmd/soralets_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -37,6 +38,11 @@ var SoraletsListCmd = &cobra.Command{
 	Short: TRAPI("/soralets:get:summary"),
 	Long:  TRAPI(`/soralets:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/soralets_list_versions.go
+++ b/soracom/generated/cmd/soralets_list_versions.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -42,6 +43,11 @@ var SoraletsListVersionsCmd = &cobra.Command{
 	Short: TRAPI("/soralets/{soralet_id}/versions:get:summary"),
 	Long:  TRAPI(`/soralets/{soralet_id}/versions:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/soralets_test.go
+++ b/soracom/generated/cmd/soralets_test.go
@@ -62,6 +62,11 @@ var SoraletsTestCmd = &cobra.Command{
 	Short: TRAPI("/soralets/{soralet_id}/test:post:summary"),
 	Long:  TRAPI(`/soralets/{soralet_id}/test:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/soralets_upload.go
+++ b/soracom/generated/cmd/soralets_upload.go
@@ -37,6 +37,11 @@ var SoraletsUploadCmd = &cobra.Command{
 	Short: TRAPI("/soralets/{soralet_id}/versions:post:summary"),
 	Long:  TRAPI(`/soralets/{soralet_id}/versions:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/stats_air_export.go
+++ b/soracom/generated/cmd/stats_air_export.go
@@ -52,6 +52,11 @@ var StatsAirExportCmd = &cobra.Command{
 	Short: TRAPI("/stats/air/operators/{operator_id}/export:post:summary"),
 	Long:  TRAPI(`/stats/air/operators/{operator_id}/export:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/stats_air_get.go
+++ b/soracom/generated/cmd/stats_air_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -37,6 +38,11 @@ var StatsAirGetCmd = &cobra.Command{
 	Short: TRAPI("/stats/air/subscribers/{imsi}:get:summary"),
 	Long:  TRAPI(`/stats/air/subscribers/{imsi}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/stats_air_sims_get.go
+++ b/soracom/generated/cmd/stats_air_sims_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -37,6 +38,11 @@ var StatsAirSimsGetCmd = &cobra.Command{
 	Short: TRAPI("/stats/air/sims/{simId}:get:summary"),
 	Long:  TRAPI(`/stats/air/sims/{simId}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/stats_beam_export.go
+++ b/soracom/generated/cmd/stats_beam_export.go
@@ -52,6 +52,11 @@ var StatsBeamExportCmd = &cobra.Command{
 	Short: TRAPI("/stats/beam/operators/{operator_id}/export:post:summary"),
 	Long:  TRAPI(`/stats/beam/operators/{operator_id}/export:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/stats_beam_get.go
+++ b/soracom/generated/cmd/stats_beam_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -37,6 +38,11 @@ var StatsBeamGetCmd = &cobra.Command{
 	Short: TRAPI("/stats/beam/subscribers/{imsi}:get:summary"),
 	Long:  TRAPI(`/stats/beam/subscribers/{imsi}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/stats_harvest_get.go
+++ b/soracom/generated/cmd/stats_harvest_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var StatsHarvestGetCmd = &cobra.Command{
 	Short: TRAPI("/stats/harvest/operators/{operator_id}:get:summary"),
 	Long:  TRAPI(`/stats/harvest/operators/{operator_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/stats_napter_audit_logs_get.go
+++ b/soracom/generated/cmd/stats_napter_audit_logs_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var StatsNapterAuditLogsGetCmd = &cobra.Command{
 	Short: TRAPI("/stats/napter/audit_logs:get:summary"),
 	Long:  TRAPI(`/stats/napter/audit_logs:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_activate.go
+++ b/soracom/generated/cmd/subscribers_activate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersActivateCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/activate:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/activate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_deactivate.go
+++ b/soracom/generated/cmd/subscribers_deactivate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersDeactivateCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/deactivate:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/deactivate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_delete_session.go
+++ b/soracom/generated/cmd/subscribers_delete_session.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersDeleteSessionCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/delete_session:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/delete_session:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_delete_tag.go
+++ b/soracom/generated/cmd/subscribers_delete_tag.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var SubscribersDeleteTagCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/tags/{tag_name}:delete:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/tags/{tag_name}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_delete_transfer_token.go
+++ b/soracom/generated/cmd/subscribers_delete_transfer_token.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersDeleteTransferTokenCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/transfer_token/{token}:delete:summary"),
 	Long:  TRAPI(`/subscribers/transfer_token/{token}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_disable_termination.go
+++ b/soracom/generated/cmd/subscribers_disable_termination.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersDisableTerminationCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/disable_termination:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/disable_termination:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_downlink_ping.go
+++ b/soracom/generated/cmd/subscribers_downlink_ping.go
@@ -42,6 +42,11 @@ var SubscribersDownlinkPingCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/downlink/ping:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/downlink/ping:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_enable_termination.go
+++ b/soracom/generated/cmd/subscribers_enable_termination.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersEnableTerminationCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/enable_termination:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/enable_termination:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_export.go
+++ b/soracom/generated/cmd/subscribers_export.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersExportCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/export:post:summary"),
 	Long:  TRAPI(`/subscribers/export:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_get.go
+++ b/soracom/generated/cmd/subscribers_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersGetCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}:get:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_get_data.go
+++ b/soracom/generated/cmd/subscribers_get_data.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -52,6 +53,11 @@ var SubscribersGetDataCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/data:get:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/data:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_issue_transfer_token.go
+++ b/soracom/generated/cmd/subscribers_issue_transfer_token.go
@@ -37,6 +37,11 @@ var SubscribersIssueTransferTokenCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/transfer_token/issue:post:summary"),
 	Long:  TRAPI(`/subscribers/transfer_token/issue:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_list.go
+++ b/soracom/generated/cmd/subscribers_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -62,6 +63,11 @@ var SubscribersListCmd = &cobra.Command{
 	Short: TRAPI("/subscribers:get:summary"),
 	Long:  TRAPI(`/subscribers:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_put_bundles.go
+++ b/soracom/generated/cmd/subscribers_put_bundles.go
@@ -32,6 +32,11 @@ var SubscribersPutBundlesCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/bundles:put:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/bundles:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_put_tags.go
+++ b/soracom/generated/cmd/subscribers_put_tags.go
@@ -32,6 +32,11 @@ var SubscribersPutTagsCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/tags:put:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/tags:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_register.go
+++ b/soracom/generated/cmd/subscribers_register.go
@@ -42,6 +42,11 @@ var SubscribersRegisterCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/register:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/register:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_report_local_info.go
+++ b/soracom/generated/cmd/subscribers_report_local_info.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersReportLocalInfoCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/report_local_info:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/report_local_info:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_send_sms.go
+++ b/soracom/generated/cmd/subscribers_send_sms.go
@@ -42,6 +42,11 @@ var SubscribersSendSmsCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/send_sms:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/send_sms:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_send_sms_by_msisdn.go
+++ b/soracom/generated/cmd/subscribers_send_sms_by_msisdn.go
@@ -42,6 +42,11 @@ var SubscribersSendSmsByMsisdnCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/msisdn/{msisdn}/send_sms:post:summary"),
 	Long:  TRAPI(`/subscribers/msisdn/{msisdn}/send_sms:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_session_events.go
+++ b/soracom/generated/cmd/subscribers_session_events.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -47,6 +48,11 @@ var SubscribersSessionEventsCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/events/sessions:get:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/events/sessions:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_set_expiry_time.go
+++ b/soracom/generated/cmd/subscribers_set_expiry_time.go
@@ -42,6 +42,11 @@ var SubscribersSetExpiryTimeCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/set_expiry_time:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/set_expiry_time:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_set_group.go
+++ b/soracom/generated/cmd/subscribers_set_group.go
@@ -37,6 +37,11 @@ var SubscribersSetGroupCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/set_group:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/set_group:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_set_imei_lock.go
+++ b/soracom/generated/cmd/subscribers_set_imei_lock.go
@@ -37,6 +37,11 @@ var SubscribersSetImeiLockCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/set_imei_lock:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/set_imei_lock:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_set_to_standby.go
+++ b/soracom/generated/cmd/subscribers_set_to_standby.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersSetToStandbyCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/set_to_standby:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/set_to_standby:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_suspend.go
+++ b/soracom/generated/cmd/subscribers_suspend.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersSuspendCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/suspend:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/suspend:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_terminate.go
+++ b/soracom/generated/cmd/subscribers_terminate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersTerminateCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/terminate:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/terminate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_unset_expiry_time.go
+++ b/soracom/generated/cmd/subscribers_unset_expiry_time.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersUnsetExpiryTimeCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/unset_expiry_time:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/unset_expiry_time:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_unset_group.go
+++ b/soracom/generated/cmd/subscribers_unset_group.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersUnsetGroupCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/unset_group:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/unset_group:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_unset_imei_lock.go
+++ b/soracom/generated/cmd/subscribers_unset_imei_lock.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SubscribersUnsetImeiLockCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/unset_imei_lock:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/unset_imei_lock:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_update_speed_class.go
+++ b/soracom/generated/cmd/subscribers_update_speed_class.go
@@ -37,6 +37,11 @@ var SubscribersUpdateSpeedClassCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/{imsi}/update_speed_class:post:summary"),
 	Long:  TRAPI(`/subscribers/{imsi}/update_speed_class:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/subscribers_verify_transfer_token.go
+++ b/soracom/generated/cmd/subscribers_verify_transfer_token.go
@@ -32,6 +32,11 @@ var SubscribersVerifyTransferTokenCmd = &cobra.Command{
 	Short: TRAPI("/subscribers/transfer_token/verify:post:summary"),
 	Long:  TRAPI(`/subscribers/transfer_token/verify:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/system_notifications_delete.go
+++ b/soracom/generated/cmd/system_notifications_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var SystemNotificationsDeleteCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/system_notifications/{type}:delete:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/system_notifications/{type}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/system_notifications_get.go
+++ b/soracom/generated/cmd/system_notifications_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var SystemNotificationsGetCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/system_notifications/{type}:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/system_notifications/{type}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/system_notifications_list.go
+++ b/soracom/generated/cmd/system_notifications_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var SystemNotificationsListCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/system_notifications:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/system_notifications:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/system_notifications_set.go
+++ b/soracom/generated/cmd/system_notifications_set.go
@@ -42,6 +42,11 @@ var SystemNotificationsSetCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/system_notifications/{type}:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/system_notifications/{type}:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_attach_role.go
+++ b/soracom/generated/cmd/users_attach_role.go
@@ -42,6 +42,11 @@ var UsersAttachRoleCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/roles:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/roles:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_auth_keys_delete.go
+++ b/soracom/generated/cmd/users_auth_keys_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var UsersAuthKeysDeleteCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/auth_keys/{auth_key_id}:delete:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/auth_keys/{auth_key_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_auth_keys_generate.go
+++ b/soracom/generated/cmd/users_auth_keys_generate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var UsersAuthKeysGenerateCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/auth_keys:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/auth_keys:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_auth_keys_get.go
+++ b/soracom/generated/cmd/users_auth_keys_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var UsersAuthKeysGetCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/auth_keys/{auth_key_id}:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/auth_keys/{auth_key_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_auth_keys_list.go
+++ b/soracom/generated/cmd/users_auth_keys_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var UsersAuthKeysListCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/auth_keys:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/auth_keys:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_create.go
+++ b/soracom/generated/cmd/users_create.go
@@ -42,6 +42,11 @@ var UsersCreateCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_default_permissions_get.go
+++ b/soracom/generated/cmd/users_default_permissions_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var UsersDefaultPermissionsGetCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/default_permissions:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/default_permissions:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_default_permissions_update.go
+++ b/soracom/generated/cmd/users_default_permissions_update.go
@@ -37,6 +37,11 @@ var UsersDefaultPermissionsUpdateCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/default_permissions:put:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/default_permissions:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_delete.go
+++ b/soracom/generated/cmd/users_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var UsersDeleteCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}:delete:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_detach_role.go
+++ b/soracom/generated/cmd/users_detach_role.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var UsersDetachRoleCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/roles/{role_id}:delete:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/roles/{role_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_get.go
+++ b/soracom/generated/cmd/users_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var UsersGetCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_list.go
+++ b/soracom/generated/cmd/users_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var UsersListCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_list_roles.go
+++ b/soracom/generated/cmd/users_list_roles.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var UsersListRolesCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/roles:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/roles:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_mfa_enable.go
+++ b/soracom/generated/cmd/users_mfa_enable.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var UsersMfaEnableCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/mfa:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/mfa:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_mfa_get.go
+++ b/soracom/generated/cmd/users_mfa_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var UsersMfaGetCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/mfa:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/mfa:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_mfa_revoke.go
+++ b/soracom/generated/cmd/users_mfa_revoke.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var UsersMfaRevokeCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/mfa:delete:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/mfa:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_mfa_verify.go
+++ b/soracom/generated/cmd/users_mfa_verify.go
@@ -42,6 +42,11 @@ var UsersMfaVerifyCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/mfa/verify:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/mfa/verify:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_password_configured.go
+++ b/soracom/generated/cmd/users_password_configured.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var UsersPasswordConfiguredCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/password:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/password:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_password_create.go
+++ b/soracom/generated/cmd/users_password_create.go
@@ -42,6 +42,11 @@ var UsersPasswordCreateCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/password:post:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/password:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_password_delete.go
+++ b/soracom/generated/cmd/users_password_delete.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var UsersPasswordDeleteCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/password:delete:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/password:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_password_update.go
+++ b/soracom/generated/cmd/users_password_update.go
@@ -47,6 +47,11 @@ var UsersPasswordUpdateCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/password:put:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/password:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_permissions_get.go
+++ b/soracom/generated/cmd/users_permissions_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var UsersPermissionsGetCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/permission:get:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/permission:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_permissions_update.go
+++ b/soracom/generated/cmd/users_permissions_update.go
@@ -47,6 +47,11 @@ var UsersPermissionsUpdateCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/permission:put:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/permission:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/users_update.go
+++ b/soracom/generated/cmd/users_update.go
@@ -42,6 +42,11 @@ var UsersUpdateCmd = &cobra.Command{
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}:put:summary"),
 	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/volume_discounts_available_discounts.go
+++ b/soracom/generated/cmd/volume_discounts_available_discounts.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var VolumeDiscountsAvailableDiscountsCmd = &cobra.Command{
 	Short: TRAPI("/volume_discounts/available_discounts:get:summary"),
 	Long:  TRAPI(`/volume_discounts/available_discounts:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/volume_discounts_confirm.go
+++ b/soracom/generated/cmd/volume_discounts_confirm.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var VolumeDiscountsConfirmCmd = &cobra.Command{
 	Short: TRAPI("/volume_discounts/{order_id}/confirm:put:summary"),
 	Long:  TRAPI(`/volume_discounts/{order_id}/confirm:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/volume_discounts_create.go
+++ b/soracom/generated/cmd/volume_discounts_create.go
@@ -52,6 +52,11 @@ var VolumeDiscountsCreateCmd = &cobra.Command{
 	Short: TRAPI("/volume_discounts:post:summary"),
 	Long:  TRAPI(`/volume_discounts:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/volume_discounts_get.go
+++ b/soracom/generated/cmd/volume_discounts_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var VolumeDiscountsGetCmd = &cobra.Command{
 	Short: TRAPI("/volume_discounts/{contract_id}:get:summary"),
 	Long:  TRAPI(`/volume_discounts/{contract_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/volume_discounts_list.go
+++ b/soracom/generated/cmd/volume_discounts_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -18,6 +19,11 @@ var VolumeDiscountsListCmd = &cobra.Command{
 	Short: TRAPI("/volume_discounts:get:summary"),
 	Long:  TRAPI(`/volume_discounts:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_close_gate.go
+++ b/soracom/generated/cmd/vpg_close_gate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var VpgCloseGateCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/gate/close:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/close:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_create.go
+++ b/soracom/generated/cmd/vpg_create.go
@@ -42,6 +42,11 @@ var VpgCreateCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_create_mirroring_peer.go
+++ b/soracom/generated/cmd/vpg_create_mirroring_peer.go
@@ -52,6 +52,11 @@ var VpgCreateMirroringPeerCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/mirroring/peers:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/mirroring/peers:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_create_packet_capture_session.go
+++ b/soracom/generated/cmd/vpg_create_packet_capture_session.go
@@ -42,6 +42,11 @@ var VpgCreatePacketCaptureSessionCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/packet_capture_sessions:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_create_vpc_peering_connection.go
+++ b/soracom/generated/cmd/vpg_create_vpc_peering_connection.go
@@ -52,6 +52,11 @@ var VpgCreateVpcPeeringConnectionCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/vpc_peering_connections:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/vpc_peering_connections:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_delete_ip_address_map_entry.go
+++ b/soracom/generated/cmd/vpg_delete_ip_address_map_entry.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var VpgDeleteIpAddressMapEntryCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/ip_address_map/{key}:delete:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/ip_address_map/{key}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_delete_mirroring_peer.go
+++ b/soracom/generated/cmd/vpg_delete_mirroring_peer.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var VpgDeleteMirroringPeerCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/mirroring/peers/{ipaddr}:delete:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/mirroring/peers/{ipaddr}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_delete_packet_capture_session.go
+++ b/soracom/generated/cmd/vpg_delete_packet_capture_session.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var VpgDeletePacketCaptureSessionCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}:delete:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_delete_vpc_peering_connection.go
+++ b/soracom/generated/cmd/vpg_delete_vpc_peering_connection.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var VpgDeleteVpcPeeringConnectionCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/vpc_peering_connections/{pcx_id}:delete:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/vpc_peering_connections/{pcx_id}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_get.go
+++ b/soracom/generated/cmd/vpg_get.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var VpgGetCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}:get:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_get_packet_capture_session.go
+++ b/soracom/generated/cmd/vpg_get_packet_capture_session.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var VpgGetPacketCaptureSessionCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}:get:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_list.go
+++ b/soracom/generated/cmd/vpg_list.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -47,6 +48,11 @@ var VpgListCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways:get:summary"),
 	Long:  TRAPI(`/virtual_private_gateways:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_list_gate_peers.go
+++ b/soracom/generated/cmd/vpg_list_gate_peers.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var VpgListGatePeersCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/gate/peers:get:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/peers:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_list_ip_address_map_entries.go
+++ b/soracom/generated/cmd/vpg_list_ip_address_map_entries.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var VpgListIpAddressMapEntriesCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/ip_address_map:get:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/ip_address_map:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_list_packet_capture_sessions.go
+++ b/soracom/generated/cmd/vpg_list_packet_capture_sessions.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -32,6 +33,11 @@ var VpgListPacketCaptureSessionsCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/packet_capture_sessions:get:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions:get:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_open_gate.go
+++ b/soracom/generated/cmd/vpg_open_gate.go
@@ -42,6 +42,11 @@ var VpgOpenGateCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/gate/open:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/open:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_put_ip_address_map_entry.go
+++ b/soracom/generated/cmd/vpg_put_ip_address_map_entry.go
@@ -42,6 +42,11 @@ var VpgPutIpAddressMapEntryCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/ip_address_map:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/ip_address_map:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_register_gate_peer.go
+++ b/soracom/generated/cmd/vpg_register_gate_peer.go
@@ -42,6 +42,11 @@ var VpgRegisterGatePeerCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/gate/peers:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/peers:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_set_inspection.go
+++ b/soracom/generated/cmd/vpg_set_inspection.go
@@ -37,6 +37,11 @@ var VpgSetInspectionCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/set_inspection:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/set_inspection:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_set_redirection.go
+++ b/soracom/generated/cmd/vpg_set_redirection.go
@@ -47,6 +47,11 @@ var VpgSetRedirectionCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/set_redirection:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/set_redirection:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_set_routing_filter.go
+++ b/soracom/generated/cmd/vpg_set_routing_filter.go
@@ -32,6 +32,11 @@ var VpgSetRoutingFilterCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/set_routing_filter:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/set_routing_filter:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_stop_packet_capture_session.go
+++ b/soracom/generated/cmd/vpg_stop_packet_capture_session.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var VpgStopPacketCaptureSessionCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}/stop:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}/stop:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_terminate.go
+++ b/soracom/generated/cmd/vpg_terminate.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var VpgTerminateCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/terminate:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/terminate:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_unregister_gate_peer.go
+++ b/soracom/generated/cmd/vpg_unregister_gate_peer.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -27,6 +28,11 @@ var VpgUnregisterGatePeerCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/gate/peers/{outer_ip_address}:delete:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/peers/{outer_ip_address}:delete:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_unset_inspection.go
+++ b/soracom/generated/cmd/vpg_unset_inspection.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var VpgUnsetInspectionCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/unset_inspection:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/unset_inspection:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_unset_redirection.go
+++ b/soracom/generated/cmd/vpg_unset_redirection.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 
@@ -22,6 +23,11 @@ var VpgUnsetRedirectionCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/unset_redirection:post:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/unset_redirection:post:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),

--- a/soracom/generated/cmd/vpg_update_mirroring_peer.go
+++ b/soracom/generated/cmd/vpg_update_mirroring_peer.go
@@ -37,6 +37,11 @@ var VpgUpdateMirroringPeerCmd = &cobra.Command{
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/mirroring/peers/{ipaddr}:put:summary"),
 	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/mirroring/peers/{ipaddr}:put:description`),
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected arguments passed => %v", args)
+		}
+
 		opt := &apiClientOptions{
 			BasePath: "/v1",
 			Language: getSelectedLanguage(),


### PR DESCRIPTION
Currently, if it gave the command the unneeded arguments, that ignores the args and goes forward; for example:

```
$ soracom audit-logs api get __UNNEEDED__ __ARGUMENTS__
[
  ...
]
$ echo $?
0
```

This behavior could confuse the users if someone used the command in the wrong way.
For example: `soracom groups put-config --group-id ${snip} --namespace --coverage-type g --body '[]'`
In this case, the command recognizes the parameters as follows: `--group-id=${snip}`, `--namespace=--coverage-type`, `--body=[]`, and `g` as an argument. Then the command lookups something from the default coverage type even if the user intended the global coverage, but the command keeps silent. In a situation like that, it would be useful if the command detects the unnecessary arguments (i.e. `g` in this case) and exits.

This patch makes the command reject it when the needless arguments are passed.

```
$ sorcom audit-logs api get __UNNEEDED__ __ARGUMENTS__
Error: unexpected arguments passed => [__UNNEEDED__ __ARGUMENTS__]
Usage:
...
$ echo $?
255
```

However, my concern is this change might break the backward compatibility... What do you think about this?