### PR TITLE
add a script to install soracom-cli to /usr/local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,52 @@ $ brew install bash-completion
 $ sudo snap install soracom
 ```
 
+In this case, you may want to connect the snap to `dot-soracom` interface which is for reading / writing profile files in `$HOME/.soracom`:
+
+```
+$ snap connect soracom:dot-soracom
+```
+
+You may also want to have the following line in your `.bashrc` etc. to use `$HOME/.soracom` as the profiles directory instead of `$SNAP_USER_DATA/.soracom` (i.e. `~/snap/soracom/<revision>/.soracom`)
+
+```
+export SORACOM_PROFILE=$HOME/.soracom
+```
+
 ## In other cases
 
-By running the following command, the latest version of `soracom` command will be installed in `/usr/local/bin`.
+By running one of the following commands, the latest version of `soracom` command will be installed.
+
+If you have a permission to write a file into `/usr/local/bin` directory, please run the command below:
 
 ```
 curl -fsSL https://raw.githubusercontent.com/soracom/soracom-cli/master/install.sh | bash
 ```
 
-If you want to upgrade the `soracom` command, you can just run the command again.
-If you want to uninstall the `soracom` command, you can just remove `/usr/local/bin/soracom`. (You may want to remove `$HOME/.soracom/` directory which contains profiles for the `soracom` command.)
+If you do not have a permission to write a file into `/usr/local/bin` directory, please run the command either of the following commands:
 
-If the command above didn't work well, or if you want to install older version of `soracom` command, you can download a package file that match the environment of the target from [Releases page](https://github.com/soracom/soracom-cli/releases), unpack it, and place the executable file in the directory where included in PATH.
+(If you are in sudoers and want to install `soracom` command to `/usr/local/bin`)
+
+```
+curl -fsSL https://raw.githubusercontent.com/soracom/soracom-cli/master/install.sh | sudo bash
+```
+
+or
+
+(If you are not in sudoers or want to install `soracom` command to other directory e.g. `$HOME/bin`)
+
+```
+mkdir -p "$HOME/bin"
+curl -fsSL https://raw.githubusercontent.com/soracom/soracom-cli/master/install.sh | BINDIR="$HOME/bin" bash
+```
+
+You can change `"$HOME/bin"` in the command above to wherever you want.
+
+If you want to upgrade the `soracom` command, you can just run the same command you used to install `soracom` again.
+
+If you want to uninstall the `soracom` command, you can just remove `soracom` executable file you have installed. (You may want to remove `$HOME/.soracom/` directory which contains profiles for the `soracom` command.)
+
+If the commands above did not work well, or if you want to install older version of `soracom` command, you can download a package file that match the environment of the target from [Releases page](https://github.com/soracom/soracom-cli/releases), unpack it, and place the executable file in the directory where included in `PATH`.
 
 
 # How to use

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The `soracom` command:
 
 # How to install
 
-## Using Mac (macOS), installing by homebrew
+## Using Mac (macOS) or Linux, installing by homebrew
 
 ```
 $ brew tap soracom/soracom-cli
@@ -51,8 +51,24 @@ $ brew install soracom-cli
 $ brew install bash-completion
 ```
 
+## Using Ubuntu Linux, installing with snap
+
+```
+$ sudo snap install soracom-cli
+```
+
 ## In other cases
-Download a package file that match the environment of the target from [Releases page](https://github.com/soracom/soracom-cli/releases), unpack it, and place the executable file in the directory where included in PATH.
+
+By running the following command, the latest version of `soracom` command will be installed in `/usr/local/bin`.
+
+```
+curl -fsSL https://raw.githubusercontent.com/soracom/soracom-cli/master/install.sh | bash
+```
+
+If you want to upgrade the `soracom` command, you can just run the command again.
+If you want to uninstall the `soracom` command, you can just remove `/usr/local/bin/soracom`. (You may want to remove `$HOME/.soracom/` directory which contains profiles for the `soracom` command.)
+
+If the command above didn't work well, or if you want to install older version of `soracom` command, you can download a package file that match the environment of the target from [Releases page](https://github.com/soracom/soracom-cli/releases), unpack it, and place the executable file in the directory where included in PATH.
 
 
 # How to use

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ brew install bash-completion
 ## Using Ubuntu Linux, installing with snap
 
 ```
-$ sudo snap install soracom-cli
+$ sudo snap install soracom
 ```
 
 ## In other cases

--- a/README_ja.md
+++ b/README_ja.md
@@ -55,7 +55,7 @@ $ brew install bash-completion
 ## Ubuntu Linux をお使いで、snap によりインストールする場合
 
 ```
-$ sudo snap soracom/soracom
+$ sudo snap install soracom
 ```
 
 ## それ以外の場合

--- a/README_ja.md
+++ b/README_ja.md
@@ -44,7 +44,7 @@ soracom コマンドは以下のような特徴を備えています。
 
 # インストール方法
 
-## macOS をお使いで、homebrew によりインストールする場合
+## macOS もしくは Linux をお使いで、homebrew によりインストールする場合
 
 ```
 $ brew tap soracom/soracom-cli
@@ -52,8 +52,24 @@ $ brew install soracom-cli
 $ brew install bash-completion
 ```
 
+## Ubuntu Linux をお使いで、snap によりインストールする場合
+
+```
+$ sudo snap soracom/soracom-cli
+```
+
 ## それ以外の場合
-[Releases のページ](https://github.com/soracom/soracom-cli/releases) からターゲットの環境に合ったパッケージファイルをダウンロードして展開し、実行形式ファイルを PATH の通ったディレクトリに配置します。
+
+以下のコマンドを実行することで、最新版の `soracom` コマンドがダウンロードされて `/usr/local/bin` にインストールされます。
+
+```
+curl -fsSL https://raw.githubusercontent.com/soracom/soracom-cli/master/install.sh | bash
+```
+
+この方法でインストールした `soracom` コマンドをバージョンアップしたい場合は、このコマンドを再度実行してください。
+この方法でインストールした `soracom` コマンドをアンインストールしたい場合は、`/usr/local/bin/soracom` を削除してください。（プロファイル情報も含めて完全に削除したい場合は `$HOME/.soracom/` ディレクトリも削除してください）
+
+上記のコマンドがうまく行かない場合、もしくは古いバージョンの `soracom` コマンドをインストールしたい場合は、[Releases のページ](https://github.com/soracom/soracom-cli/releases) からターゲットの環境に合ったパッケージファイルをダウンロードして展開し、実行形式ファイルを PATH の通ったディレクトリに配置してください。
 
 
 # 使用方法

--- a/README_ja.md
+++ b/README_ja.md
@@ -55,7 +55,7 @@ $ brew install bash-completion
 ## Ubuntu Linux をお使いで、snap によりインストールする場合
 
 ```
-$ sudo snap soracom/soracom-cli
+$ sudo snap soracom/soracom
 ```
 
 ## それ以外の場合

--- a/README_ja.md
+++ b/README_ja.md
@@ -58,18 +58,51 @@ $ brew install bash-completion
 $ sudo snap install soracom
 ```
 
+snap を使って `soracom` コマンドをインストールし、`$HOME/.soracom` ディレクトリに保存されたプロファイル情報を利用したい場合は `dot-soracom` インターフェースを `soracom` の snap パッケージに connect してください。
+
+```
+snap connect soracom:dot-soracom
+```
+
+さらに、snap でインストールした場合のデフォルトのプロファイルディレクトリ `$SNAP_USER_DATA/.soracom`（すなわち `$HOME/snap/soracom/<revision>/.soracom`）の代わりに `$HOME/.soracom` を利用するために以下のような行を `.bashrc` などに追加してください。
+
+```
+export SORACOM_PROFILE=$HOME/.soracom
+```
+
 ## それ以外の場合
 
-以下のコマンドを実行することで、最新版の `soracom` コマンドがダウンロードされて `/usr/local/bin` にインストールされます。
+以下に紹介するいずれかのコマンドを実行することで、最新版の `soracom` コマンドがダウンロードされてインストールされます。
+
+
+もし `/usr/local/bin` にファイルを書き込む権限のあるユーザー（root など）でインストールする場合はいかのコマンドを実行してください。
 
 ```
 curl -fsSL https://raw.githubusercontent.com/soracom/soracom-cli/master/install.sh | bash
 ```
 
-この方法でインストールした `soracom` コマンドをバージョンアップしたい場合は、このコマンドを再度実行してください。
-この方法でインストールした `soracom` コマンドをアンインストールしたい場合は、`/usr/local/bin/soracom` を削除してください。（プロファイル情報も含めて完全に削除したい場合は `$HOME/.soracom/` ディレクトリも削除してください）
+`/usr/local/bin` に書き込む権限がない場合は以下のいずれかのコマンドを実行してください。
 
-上記のコマンドがうまく行かない場合、もしくは古いバージョンの `soracom` コマンドをインストールしたい場合は、[Releases のページ](https://github.com/soracom/soracom-cli/releases) からターゲットの環境に合ったパッケージファイルをダウンロードして展開し、実行形式ファイルを PATH の通ったディレクトリに配置してください。
+sudo コマンドを実行可能（ユーザーが sudoers に入っている）で、`soracom` コマンドを `/usr/local/bin` にインストールしたい場合：
+
+```
+curl -fsSL https://raw.githubusercontent.com/soracom/soracom-cli/master/install.sh | sudo bash
+```
+
+もしくは sudo コマンドを利用できないか、`soracom` コマンドを `$HOME/bin` など `/usr/local/bin` 以外の場所にインストールしたい場合：
+
+```
+mkdir -p "$HOME/bin"
+curl -fsSL https://raw.githubusercontent.com/soracom/soracom-cli/master/install.sh | BINDIR="$HOME/bin" bash
+```
+
+`"$HOME/bin"` の部分はお好きなディレクトリに変更してください。
+
+上記いずれかの方法でインストールした `soracom` コマンドをバージョンアップしたい場合は、同じコマンドを再度実行してください。
+
+インストールした `soracom` コマンドをアンインストールしたい場合は、インストールした `soracom` コマンドの実行ファイルを手動で削除してください。（プロファイル情報も含めて完全に削除したい場合は `$HOME/.soracom/` ディレクトリも削除してください）
+
+上記のコマンドがいずれもうまく行かない場合、もしくは古いバージョンの `soracom` コマンドをインストールしたい場合は、[Releases のページ](https://github.com/soracom/soracom-cli/releases) からターゲットの環境に合ったパッケージファイルをダウンロードして展開し、実行形式ファイルを PATH の通ったディレクトリに配置してください。
 
 
 # 使用方法

--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,7 @@ extract() {
       tar -C "$dir" -xf "$path"
       ;;
     ".zip")
-      unzip "$path" -d "$dir"
+      unzip -q "$path" -d "$dir"
       ;;
     *)
       echo "unknown archive extension: $ext"

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+BINDIR="${BINDIR:-/usr/local/bin}"
+if [ ! -d "$BINDIR" ]; then
+  echo "It seems that the installation target directory $BINDIR does not exist or is not a directory." 2>&1
+  echo "Please make sure the directory $BINDIR exists." 2>&1
+  exit 1
+fi
+if [ ! -w "$BINDIR" ]; then
+  echo "It seems you do not have a permission to install 'soracom' executable file to $BINDIR." 2>&1
+  echo "Please run this script again with appropriate permissions." 2>&1
+  exit 1
+fi
+
 if \soracom > /dev/null 2>&1; then
-  if [[ "$( \command -v soracom )" != "/usr/local/bin/soracom" ]] || [ -L "/usr/local/bin/soracom" ]; then
+  if [[ "$( \command -v soracom )" != "$BINDIR/soracom" ]] || [ -L "$BINDIR/soracom" ]; then
     echo 'soracom-cli is already installed by using another method (brew, snap, dpkg etc.).' 2>&1
     echo 'Please use the same method if you want to update soracom-cli.' 2>&1
     exit 1
@@ -141,6 +153,6 @@ echo "done."
 
 echo -n "Installing ... "
 dirname="${fname%"${ext}"}"
-sudo mv "$tmpdir/$dirname/soracom" /usr/local/bin
-sudo chmod +x /usr/local/bin/soracom
+mv "$tmpdir/$dirname/soracom" "$BINDIR"
+chmod +x "$BINDIR/soracom"
 echo "done."

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if \soracom > /dev/null 2>&1; then
+  if [[ "$( \command -v soracom )" != "/usr/local/bin/soracom" ]]; then
+    echo 'soracom-cli is already installed by using another method (brew, snap, apt etc.).' 2>&1
+    echo 'Please use the same method if you want to update soracom-cli.' 2>&1
+    exit 1
+  fi
+fi
+
+if ! \curl --version > /dev/null 2>&1; then
+  echo '"curl" command is required to install soracom-cli' 2>&1
+  echo 'Please install "curl" command before proceeding.' 2>&1
+  exit
+fi
+
+get_goos() {
+  case "$( uname -s )" in
+    "Linux")
+      echo "linux"
+      ;;
+    "Darwin")
+      echo "darwin"
+      ;;
+    "FreeBSD")
+      echo "freebsd"
+      ;;
+    "Windows"*)
+      echo "windows"
+      ;;
+    *)
+      echo "unknown system: $( uname -s )" 2>&1
+      exit 1
+      ;;
+  esac
+}
+
+get_goarch() {
+  case "$( uname -m )" in
+    "amd64" | "x86_64")
+      echo "amd64"
+      ;;
+    "i386" | "i686")
+      echo "386"
+      ;;
+    "armv"*)
+      echo "arm"
+      ;;
+    "arm64" | "aarch64")
+      echo "arm64"
+      ;;
+    *)
+      echo "unknown architecture: $( uname -m )" 2>&1
+      exit 1
+      ;;
+  esac
+}
+
+get_ext_regexp() {
+  local goos=$1
+  case "$goos" in
+    "linux" | "freebsd")
+      echo "\.tar\.gz"
+      ;;
+    "darwin" | "windows")
+      echo "\.zip"
+      ;;
+    *)
+      echo "unknown goos: $goos" 2>&1
+      exit 1
+      ;;
+  esac
+}
+
+get_ext() {
+  local goos=$1
+  case "$goos" in
+    "linux" | "freebsd")
+      echo ".tar.gz"
+      ;;
+    "darwin" | "windows")
+      echo ".zip"
+      ;;
+    *)
+      echo "unknown goos: $goos" 2>&1
+      exit 1
+      ;;
+  esac
+}
+
+extract() {
+  local path=$1
+  local dir=$2
+  local ext=$3
+  case "$ext" in
+    ".tar.gz")
+      tar -C "$dir" -xf "$path"
+      ;;
+    ".zip")
+      unzip "$path"
+      ;;
+    *)
+      echo "unknown archive extension: $ext"
+      exit 1
+      ;;
+  esac
+}
+
+goos="$( get_goos )"
+goarch="$( get_goarch )"
+ext_regexp="$( get_ext_regexp "$goos" )"
+ext="$( get_ext "$goos" )"
+
+url="$( \curl -fsSL https://api.github.com/repos/soracom/soracom-cli/releases/latest | \
+  grep 'browser_download_url' | \
+  grep "${goos}_${goarch}.*${ext_regexp}" | \
+  cut -d : -f 2-3 | \
+  tr -d '"'
+)"
+url="$(echo $url)" # trim spaces
+fname=${url##*/}   # removes longest matching series of the pattern from the front (string after the last / will be left)
+
+tmpdir=$(mktemp -d -t soracom.XXXXXXXX)
+#trap 'tear_down' 0
+
+tear_down() {
+    : "Clean up tmpdir" && {
+        [[ $tmpdir ]] && rm -rf "$tmpdir"
+    }
+}
+
+echo -n "Downloading ... "
+curl -fsSL --output "$tmpdir/$fname" "$url"
+echo "done."
+
+echo -n "Extracting ... "
+extract "$tmpdir/$fname" "$tmpdir" "$ext"
+echo "done."
+
+echo -n "Installing ... "
+dirname="${fname%"${ext}"}"
+sudo mv "$tmpdir/$dirname/soracom" /usr/local/bin
+sudo chmod +x /usr/local/bin/soracom
+echo "done."

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ goarch="$( get_goarch )"
 ext_regexp="$( get_ext_regexp "$goos" )"
 ext="$( get_ext "$goos" )"
 
-url="$( \curl -fsSL https://api.github.com/repos/soracom/soracom-cli/releases/latest | \
+url="$( \curl -fSL# https://api.github.com/repos/soracom/soracom-cli/releases/latest | \
   \grep 'browser_download_url' | \
   \grep "${goos}_${goarch}${ext_regexp}" | \
   cut -d : -f 2-3 | \

--- a/install.sh
+++ b/install.sh
@@ -135,7 +135,7 @@ url="${url##+( )}" # removes longest matching series of spaces from the front (`
 fname=${url##*/}   # removes longest matching series of the pattern from the front (string after the last / will be left)
 
 tmpdir=$(mktemp -d -t soracom.XXXXXXXX)
-#trap 'tear_down' 0
+trap 'tear_down' 0
 
 tear_down() {
     : "Clean up tmpdir" && {

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 if \soracom > /dev/null 2>&1; then
   if [[ "$( \command -v soracom )" != "/usr/local/bin/soracom" ]] || [ -L "/usr/local/bin/soracom" ]; then
-    echo 'soracom-cli is already installed by using another method (brew, snap, apt etc.).' 2>&1
+    echo 'soracom-cli is already installed by using another method (brew, snap, dpkg etc.).' 2>&1
     echo 'Please use the same method if you want to update soracom-cli.' 2>&1
     exit 1
   fi

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ goarch="$( get_goarch )"
 ext_regexp="$( get_ext_regexp "$goos" )"
 ext="$( get_ext "$goos" )"
 
-url="$( \curl -fSL# https://api.github.com/repos/soracom/soracom-cli/releases/latest | \
+url="$( \curl -fsSL https://api.github.com/repos/soracom/soracom-cli/releases/latest | \
   \grep 'browser_download_url' | \
   \grep "${goos}_${goarch}${ext_regexp}" | \
   cut -d : -f 2-3 | \
@@ -143,8 +143,8 @@ tear_down() {
     }
 }
 
-echo -n "Downloading ... "
-curl -fsSL --output "$tmpdir/$fname" "$url"
+echo "Downloading ... "
+curl -fSL# --output "$tmpdir/$fname" "$url"
 echo "done."
 
 echo -n "Extracting ... "

--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ ext="$( get_ext "$goos" )"
 
 url="$( \curl -fsSL https://api.github.com/repos/soracom/soracom-cli/releases/latest | \
   grep 'browser_download_url' | \
-  grep "${goos}_${goarch}.*${ext_regexp}" | \
+  grep "${goos}_${goarch}${ext_regexp}" | \
   cut -d : -f 2-3 | \
   tr -d '"'
 )"

--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,7 @@ extract() {
       tar -C "$dir" -xf "$path"
       ;;
     ".zip")
-      unzip "$path"
+      unzip "$path" -d "$dir"
       ;;
     *)
       echo "unknown archive extension: $ext"

--- a/install.sh
+++ b/install.sh
@@ -113,12 +113,13 @@ ext_regexp="$( get_ext_regexp "$goos" )"
 ext="$( get_ext "$goos" )"
 
 url="$( \curl -fsSL https://api.github.com/repos/soracom/soracom-cli/releases/latest | \
-  grep 'browser_download_url' | \
-  grep "${goos}_${goarch}${ext_regexp}" | \
+  \grep 'browser_download_url' | \
+  \grep "${goos}_${goarch}${ext_regexp}" | \
   cut -d : -f 2-3 | \
   tr -d '"'
 )"
-url="$(echo $url)" # trim spaces
+shopt -s extglob
+url="${url##+( )}" # removes longest matching series of spaces from the front (`shopt -s extglob` is required)
 fname=${url##*/}   # removes longest matching series of the pattern from the front (string after the last / will be left)
 
 tmpdir=$(mktemp -d -t soracom.XXXXXXXX)

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 if \soracom > /dev/null 2>&1; then
-  if [[ "$( \command -v soracom )" != "/usr/local/bin/soracom" ]]; then
+  if [[ "$( \command -v soracom )" != "/usr/local/bin/soracom" ]] || [ -L "/usr/local/bin/soracom" ]; then
     echo 'soracom-cli is already installed by using another method (brew, snap, apt etc.).' 2>&1
     echo 'Please use the same method if you want to update soracom-cli.' 2>&1
     exit 1


### PR DESCRIPTION
According to the discussions, we came to the conclusions that we should provide a one-liner command to install soracom-cli without package managers.

After merging this PR to master, users can install soracom-cli by executing the following command:

```
curl -fsSL https://raw.githubusercontent.com/soracom/soracom-cli/master/install.sh | bash
```
