### PR TITLE
support --jsonl option for APIs with array response

### DIFF
--- a/generators/assets/cli/en.yaml
+++ b/generators/assets/cli/en.yaml
@@ -18,6 +18,8 @@ cli:
   common_params:
     body:
       short_help: JSON string or @filename for API request body.
+    jsonl:
+      short_help: Output array response with JSONL (JSON Lines) format.
     paginate:
       short_help: Do pagination automatically.
   completion:

--- a/generators/assets/cli/ja.yaml
+++ b/generators/assets/cli/ja.yaml
@@ -18,6 +18,8 @@ cli:
   common_params:
     body:
       short_help: リクエストの Body に指定する JSON です。@filename もしくは JSON 文字列で指定します。
+    jsonl:
+      short_help: 配列型のレスポンスを JSONL (JSON Lines) フォーマットで出力します。
     paginate:
       short_help: 自動的にページネーションします。
   completion:

--- a/generators/cmd/predefined/configure_get.go
+++ b/generators/cmd/predefined/configure_get.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
 
 func init() {
 	ConfigureCmd.AddCommand(ConfigureGetCmd)
@@ -22,6 +26,6 @@ var ConfigureGetCmd = &cobra.Command{
 			return err
 		}
 
-		return prettyPrintObjectAsJSON(p)
+		return prettyPrintObjectAsJSON(p, os.Stdout)
 	},
 }

--- a/generators/cmd/predefined/pretty_print_json.go
+++ b/generators/cmd/predefined/pretty_print_json.go
@@ -33,3 +33,38 @@ func prettyPrintObjectAsJSON(obj interface{}) error {
 	fmt.Println()
 	return nil
 }
+
+func printStringAsJSONL(rawJSON string) error {
+	var arr []interface{}
+
+	d := json.NewDecoder(strings.NewReader(rawJSON))
+	d.UseNumber()
+	err := d.Decode(&arr)
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range arr {
+		err = printObjectOneLine(obj)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func printObjectOneLine(obj interface{}) error {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = os.Stdout.Write(b)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	return nil
+}

--- a/generators/cmd/predefined/pretty_print_json.go
+++ b/generators/cmd/predefined/pretty_print_json.go
@@ -2,12 +2,16 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
+	"io"
 	"os"
 	"strings"
 )
 
 func prettyPrintStringAsJSON(rawJSON string) error {
+	return prettyPrintStringAsJSONToWriter(rawJSON, os.Stdout)
+}
+
+func prettyPrintStringAsJSONToWriter(rawJSON string, w io.Writer) error {
 	var obj interface{}
 
 	d := json.NewDecoder(strings.NewReader(rawJSON))
@@ -16,25 +20,29 @@ func prettyPrintStringAsJSON(rawJSON string) error {
 	if err != nil {
 		return err
 	}
-	return prettyPrintObjectAsJSON(obj)
+	return prettyPrintObjectAsJSON(obj, w)
 }
 
-func prettyPrintObjectAsJSON(obj interface{}) error {
+func prettyPrintObjectAsJSON(obj interface{}, w io.Writer) error {
 	b, err := json.MarshalIndent(obj, "", "\t")
 	if err != nil {
 		return err
 	}
 
-	_, err = os.Stdout.Write(b)
+	_, err = w.Write(b)
 	if err != nil {
 		return err
 	}
 
-	fmt.Println()
+	w.Write([]byte{'\n'})
 	return nil
 }
 
 func printStringAsJSONL(rawJSON string) error {
+	return printStringAsJSONLToWriter(rawJSON, os.Stdout)
+}
+
+func printStringAsJSONLToWriter(rawJSON string, w io.Writer) error {
 	var arr []interface{}
 
 	d := json.NewDecoder(strings.NewReader(rawJSON))
@@ -45,7 +53,7 @@ func printStringAsJSONL(rawJSON string) error {
 	}
 
 	for _, obj := range arr {
-		err = printObjectOneLine(obj)
+		err = printObjectOneLine(obj, w)
 		if err != nil {
 			return err
 		}
@@ -54,17 +62,17 @@ func printStringAsJSONL(rawJSON string) error {
 	return nil
 }
 
-func printObjectOneLine(obj interface{}) error {
+func printObjectOneLine(obj interface{}, w io.Writer) error {
 	b, err := json.Marshal(obj)
 	if err != nil {
 		return err
 	}
 
-	_, err = os.Stdout.Write(b)
+	_, err = w.Write(b)
 	if err != nil {
 		return err
 	}
 
-	fmt.Println()
+	w.Write([]byte{'\n'})
 	return nil
 }

--- a/generators/cmd/predefined/pretty_print_json_test.go
+++ b/generators/cmd/predefined/pretty_print_json_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tj/assert"
+)
+
+func TestPrintStringAsJSONL(t *testing.T) {
+	data1 := `[{"a":1},{"b":2},{"c":3}]`
+	expected := `{"a":1}
+{"b":2}
+{"c":3}
+`
+	out1 := new(bytes.Buffer)
+	err := printStringAsJSONLToWriter(data1, out1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out1.String())
+
+	noArray1 := `{"a":1,"b":2}`
+	out2 := new(bytes.Buffer)
+	err = printStringAsJSONLToWriter(noArray1, out2)
+	assert.Error(t, err)
+}

--- a/generators/cmd/src/gen_leaf_cmd.go
+++ b/generators/cmd/src/gen_leaf_cmd.go
@@ -72,6 +72,7 @@ func generateCommandFiles(apiDef *lib.APIDefinitions, m lib.APIMethod, tmpl *tem
 			PaginationRequestParameterInQuery: getPaginationRequestparameterInQuery(m.Pagination),
 			Deprecated:                        m.Deprecated,
 			AlternativeCommand:                m.AlternativeCommand,
+			HasArrayResponse:                  hasArrayResponse(m),
 		}
 		if a.Method == "POST" || a.Method == "PUT" {
 			if doesContentTypeParamExist(m.Parameters) {
@@ -174,6 +175,16 @@ func isResponseBodyRaw(m lib.APIMethod) bool {
 	// response contains signed URL, which should not be modified while Go json serializer prettifies '&' to '\u0026'
 	if strings.ToUpper(m.Method) == "POST" && strings.HasSuffix(m.Path, "/export") {
 		return true
+	}
+
+	return false
+}
+
+func hasArrayResponse(m lib.APIMethod) bool {
+	for _, res := range m.Responses {
+		if res.Schema != nil && res.Schema.Type == "array" {
+			return true
+		}
 	}
 
 	return false

--- a/generators/cmd/src/types.go
+++ b/generators/cmd/src/types.go
@@ -136,4 +136,5 @@ type commandArgs struct {
 	PaginationRequestParameterInQuery string
 	Deprecated                        bool
 	AlternativeCommand                string
+	HasArrayResponse                  bool
 }

--- a/generators/cmd/templates/leaf.gotmpl
+++ b/generators/cmd/templates/leaf.gotmpl
@@ -50,6 +50,11 @@ var {{$prefix}}{{.VarName}} bool
 var {{$prefix}}Paginate bool
 {{end}}
 
+{{- if .HasArrayResponse}}
+// {{$prefix}}OutputJSONL indicates to output with jsonl format
+var {{$prefix}}OutputJSONL bool
+{{end}}
+
 {{- if .BodyExists }}
 // {{$prefix}}Body holds contents of request body to be sent
 var {{$prefix}}Body string
@@ -78,6 +83,10 @@ func init() {
 
 {{- if .PaginationAvailable}}
   {{$cmdvar}}.Flags().BoolVar(&{{$prefix}}Paginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+{{end}}
+
+{{- if .HasArrayResponse}}
+  {{$cmdvar}}.Flags().BoolVar(&{{$prefix}}OutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 {{end}}
 
 {{- if .BodyExists }}
@@ -145,6 +154,11 @@ var {{ $cmdvar }} = &cobra.Command{
     if rawOutput {
       _, err = os.Stdout.Write([]byte(body))
     } else {
+      {{- if .HasArrayResponse}}
+      if {{$prefix}}OutputJSONL {
+        return printStringAsJSONL(body)
+      }
+      {{end}}
       return prettyPrintStringAsJSON(body)
     }
     return err

--- a/go.sum
+++ b/go.sum
@@ -404,8 +404,6 @@ golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a h1:ppl5mZgokTT8uPkmYOyEUmPTr3ypaKkg5eFOGrAmxxE=
-golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7 h1:8IVLkfbr2cLhv0a/vKq4UFUcJym8RmDoDboxCFWEjYE=
 golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/soracom/generated/cmd/assets/cli/en.yaml
+++ b/soracom/generated/cmd/assets/cli/en.yaml
@@ -18,6 +18,8 @@ cli:
   common_params:
     body:
       short_help: JSON string or @filename for API request body.
+    jsonl:
+      short_help: Output array response with JSONL (JSON Lines) format.
     paginate:
       short_help: Do pagination automatically.
   completion:

--- a/soracom/generated/cmd/assets/cli/ja.yaml
+++ b/soracom/generated/cmd/assets/cli/ja.yaml
@@ -18,6 +18,8 @@ cli:
   common_params:
     body:
       short_help: リクエストの Body に指定する JSON です。@filename もしくは JSON 文字列で指定します。
+    jsonl:
+      short_help: 配列型のレスポンスを JSONL (JSON Lines) フォーマットで出力します。
     paginate:
       short_help: 自動的にページネーションします。
   completion:

--- a/soracom/generated/cmd/audit_logs_api_get.go
+++ b/soracom/generated/cmd/audit_logs_api_get.go
@@ -27,6 +27,9 @@ var AuditLogsApiGetCmdToEpochMs int64
 // AuditLogsApiGetCmdPaginate indicates to do pagination or not
 var AuditLogsApiGetCmdPaginate bool
 
+// AuditLogsApiGetCmdOutputJSONL indicates to output with jsonl format
+var AuditLogsApiGetCmdOutputJSONL bool
+
 func init() {
 	AuditLogsApiGetCmd.Flags().StringVar(&AuditLogsApiGetCmdApiKind, "api-kind", "", TRAPI("Filter item for audit log retrieval by API kind (e.g. `/v1/auth`)."))
 
@@ -39,6 +42,8 @@ func init() {
 	AuditLogsApiGetCmd.Flags().Int64Var(&AuditLogsApiGetCmdToEpochMs, "to-epoch-ms", 0, TRAPI("End time for the log search range (unixtime milliseconds)."))
 
 	AuditLogsApiGetCmd.Flags().BoolVar(&AuditLogsApiGetCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	AuditLogsApiGetCmd.Flags().BoolVar(&AuditLogsApiGetCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	AuditLogsApiCmd.AddCommand(AuditLogsApiGetCmd)
 }
 
@@ -86,6 +91,10 @@ var AuditLogsApiGetCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if AuditLogsApiGetCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/audit_logs_napter_get.go
+++ b/soracom/generated/cmd/audit_logs_napter_get.go
@@ -30,6 +30,9 @@ var AuditLogsNapterGetCmdTo int64
 // AuditLogsNapterGetCmdPaginate indicates to do pagination or not
 var AuditLogsNapterGetCmdPaginate bool
 
+// AuditLogsNapterGetCmdOutputJSONL indicates to output with jsonl format
+var AuditLogsNapterGetCmdOutputJSONL bool
+
 func init() {
 	AuditLogsNapterGetCmd.Flags().StringVar(&AuditLogsNapterGetCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
@@ -44,6 +47,8 @@ func init() {
 	AuditLogsNapterGetCmd.Flags().Int64Var(&AuditLogsNapterGetCmdTo, "to", 0, TRAPI("End time for the log search range (unixtime milliseconds)."))
 
 	AuditLogsNapterGetCmd.Flags().BoolVar(&AuditLogsNapterGetCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	AuditLogsNapterGetCmd.Flags().BoolVar(&AuditLogsNapterGetCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	AuditLogsNapterCmd.AddCommand(AuditLogsNapterGetCmd)
 }
 
@@ -91,6 +96,10 @@ var AuditLogsNapterGetCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if AuditLogsNapterGetCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/cell_locations_batch_get.go
+++ b/soracom/generated/cmd/cell_locations_batch_get.go
@@ -13,10 +13,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// CellLocationsBatchGetCmdOutputJSONL indicates to output with jsonl format
+var CellLocationsBatchGetCmdOutputJSONL bool
+
 // CellLocationsBatchGetCmdBody holds contents of request body to be sent
 var CellLocationsBatchGetCmdBody string
 
 func init() {
+	CellLocationsBatchGetCmd.Flags().BoolVar(&CellLocationsBatchGetCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
+
 	CellLocationsBatchGetCmd.Flags().StringVar(&CellLocationsBatchGetCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	CellLocationsCmd.AddCommand(CellLocationsBatchGetCmd)
 }
@@ -65,6 +70,10 @@ var CellLocationsBatchGetCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if CellLocationsBatchGetCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/configure_get.go
+++ b/soracom/generated/cmd/configure_get.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
 
 func init() {
 	ConfigureCmd.AddCommand(ConfigureGetCmd)
@@ -22,6 +26,6 @@ var ConfigureGetCmd = &cobra.Command{
 			return err
 		}
 
-		return prettyPrintObjectAsJSON(p)
+		return prettyPrintObjectAsJSON(p, os.Stdout)
 	},
 }

--- a/soracom/generated/cmd/credentials_list.go
+++ b/soracom/generated/cmd/credentials_list.go
@@ -9,7 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// CredentialsListCmdOutputJSONL indicates to output with jsonl format
+var CredentialsListCmdOutputJSONL bool
+
 func init() {
+	CredentialsListCmd.Flags().BoolVar(&CredentialsListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	CredentialsCmd.AddCommand(CredentialsListCmd)
 }
 
@@ -57,6 +61,10 @@ var CredentialsListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if CredentialsListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/data_get.go
+++ b/soracom/generated/cmd/data_get.go
@@ -30,6 +30,9 @@ var DataGetCmdTo int64
 // DataGetCmdPaginate indicates to do pagination or not
 var DataGetCmdPaginate bool
 
+// DataGetCmdOutputJSONL indicates to output with jsonl format
+var DataGetCmdOutputJSONL bool
+
 func init() {
 	DataGetCmd.Flags().StringVar(&DataGetCmdImsi, "imsi", "", TRAPI("IMSI of the target subscriber that generated data entries."))
 
@@ -44,6 +47,8 @@ func init() {
 	DataGetCmd.Flags().Int64Var(&DataGetCmdTo, "to", 0, TRAPI("End time for the data entries search range (unixtime in milliseconds)."))
 
 	DataGetCmd.Flags().BoolVar(&DataGetCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	DataGetCmd.Flags().BoolVar(&DataGetCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	DataCmd.AddCommand(DataGetCmd)
 }
 
@@ -91,6 +96,10 @@ var DataGetCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if DataGetCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/data_get_entries.go
+++ b/soracom/generated/cmd/data_get_entries.go
@@ -33,6 +33,9 @@ var DataGetEntriesCmdTo int64
 // DataGetEntriesCmdPaginate indicates to do pagination or not
 var DataGetEntriesCmdPaginate bool
 
+// DataGetEntriesCmdOutputJSONL indicates to output with jsonl format
+var DataGetEntriesCmdOutputJSONL bool
+
 func init() {
 	DataGetEntriesCmd.Flags().StringVar(&DataGetEntriesCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
@@ -49,6 +52,8 @@ func init() {
 	DataGetEntriesCmd.Flags().Int64Var(&DataGetEntriesCmdTo, "to", 0, TRAPI("End time for the data entries search range (unixtime in milliseconds)."))
 
 	DataGetEntriesCmd.Flags().BoolVar(&DataGetEntriesCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	DataGetEntriesCmd.Flags().BoolVar(&DataGetEntriesCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	DataCmd.AddCommand(DataGetEntriesCmd)
 }
 
@@ -96,6 +101,10 @@ var DataGetEntriesCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if DataGetEntriesCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/data_list_source_resources.go
+++ b/soracom/generated/cmd/data_list_source_resources.go
@@ -21,6 +21,9 @@ var DataListSourceResourcesCmdLimit int64
 // DataListSourceResourcesCmdPaginate indicates to do pagination or not
 var DataListSourceResourcesCmdPaginate bool
 
+// DataListSourceResourcesCmdOutputJSONL indicates to output with jsonl format
+var DataListSourceResourcesCmdOutputJSONL bool
+
 func init() {
 	DataListSourceResourcesCmd.Flags().StringVar(&DataListSourceResourcesCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `resourceId` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
@@ -29,6 +32,8 @@ func init() {
 	DataListSourceResourcesCmd.Flags().Int64Var(&DataListSourceResourcesCmdLimit, "limit", 0, TRAPI("Maximum number of data entries to retrieve."))
 
 	DataListSourceResourcesCmd.Flags().BoolVar(&DataListSourceResourcesCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	DataListSourceResourcesCmd.Flags().BoolVar(&DataListSourceResourcesCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	DataCmd.AddCommand(DataListSourceResourcesCmd)
 }
 
@@ -76,6 +81,10 @@ var DataListSourceResourcesCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if DataListSourceResourcesCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/devices_get_data.go
+++ b/soracom/generated/cmd/devices_get_data.go
@@ -30,6 +30,9 @@ var DevicesGetDataCmdTo int64
 // DevicesGetDataCmdPaginate indicates to do pagination or not
 var DevicesGetDataCmdPaginate bool
 
+// DevicesGetDataCmdOutputJSONL indicates to output with jsonl format
+var DevicesGetDataCmdOutputJSONL bool
+
 func init() {
 	DevicesGetDataCmd.Flags().StringVar(&DevicesGetDataCmdDeviceId, "device-id", "", TRAPI("Device ID of the target subscriber that generated data entries."))
 
@@ -44,6 +47,8 @@ func init() {
 	DevicesGetDataCmd.Flags().Int64Var(&DevicesGetDataCmdTo, "to", 0, TRAPI("End time for the data entries search range (unixtime in milliseconds)."))
 
 	DevicesGetDataCmd.Flags().BoolVar(&DevicesGetDataCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	DevicesGetDataCmd.Flags().BoolVar(&DevicesGetDataCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	DevicesCmd.AddCommand(DevicesGetDataCmd)
 }
 
@@ -91,6 +96,10 @@ var DevicesGetDataCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if DevicesGetDataCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/devices_list.go
+++ b/soracom/generated/cmd/devices_list.go
@@ -27,6 +27,9 @@ var DevicesListCmdLimit int64
 // DevicesListCmdPaginate indicates to do pagination or not
 var DevicesListCmdPaginate bool
 
+// DevicesListCmdOutputJSONL indicates to output with jsonl format
+var DevicesListCmdOutputJSONL bool
+
 func init() {
 	DevicesListCmd.Flags().StringVar(&DevicesListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("ID of the last Device in the previous page"))
 
@@ -39,6 +42,8 @@ func init() {
 	DevicesListCmd.Flags().Int64Var(&DevicesListCmdLimit, "limit", -1, TRAPI("Max number of Devices in a response"))
 
 	DevicesListCmd.Flags().BoolVar(&DevicesListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	DevicesListCmd.Flags().BoolVar(&DevicesListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	DevicesCmd.AddCommand(DevicesListCmd)
 }
 
@@ -86,6 +91,10 @@ var DevicesListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if DevicesListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/devices_list_object_models.go
+++ b/soracom/generated/cmd/devices_list_object_models.go
@@ -18,12 +18,17 @@ var DevicesListObjectModelsCmdLimit int64
 // DevicesListObjectModelsCmdPaginate indicates to do pagination or not
 var DevicesListObjectModelsCmdPaginate bool
 
+// DevicesListObjectModelsCmdOutputJSONL indicates to output with jsonl format
+var DevicesListObjectModelsCmdOutputJSONL bool
+
 func init() {
 	DevicesListObjectModelsCmd.Flags().StringVar(&DevicesListObjectModelsCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("ID of the last device object model in the previous page"))
 
 	DevicesListObjectModelsCmd.Flags().Int64Var(&DevicesListObjectModelsCmdLimit, "limit", -1, TRAPI("Max number of device object models in a response"))
 
 	DevicesListObjectModelsCmd.Flags().BoolVar(&DevicesListObjectModelsCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	DevicesListObjectModelsCmd.Flags().BoolVar(&DevicesListObjectModelsCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	DevicesCmd.AddCommand(DevicesListObjectModelsCmd)
 }
 
@@ -71,6 +76,10 @@ var DevicesListObjectModelsCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if DevicesListObjectModelsCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/diagnostics_send_request.go
+++ b/soracom/generated/cmd/diagnostics_send_request.go
@@ -28,6 +28,9 @@ var DiagnosticsSendRequestCmdFrom int64
 // DiagnosticsSendRequestCmdTo holds value of 'to' option
 var DiagnosticsSendRequestCmdTo int64
 
+// DiagnosticsSendRequestCmdOutputJSONL indicates to output with jsonl format
+var DiagnosticsSendRequestCmdOutputJSONL bool
+
 // DiagnosticsSendRequestCmdBody holds contents of request body to be sent
 var DiagnosticsSendRequestCmdBody string
 
@@ -41,6 +44,8 @@ func init() {
 	DiagnosticsSendRequestCmd.Flags().Int64Var(&DiagnosticsSendRequestCmdFrom, "from", 0, TRAPI(""))
 
 	DiagnosticsSendRequestCmd.Flags().Int64Var(&DiagnosticsSendRequestCmdTo, "to", 0, TRAPI(""))
+
+	DiagnosticsSendRequestCmd.Flags().BoolVar(&DiagnosticsSendRequestCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 
 	DiagnosticsSendRequestCmd.Flags().StringVar(&DiagnosticsSendRequestCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	DiagnosticsCmd.AddCommand(DiagnosticsSendRequestCmd)
@@ -90,6 +95,10 @@ var DiagnosticsSendRequestCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if DiagnosticsSendRequestCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/emails_list.go
+++ b/soracom/generated/cmd/emails_list.go
@@ -12,8 +12,13 @@ import (
 // EmailsListCmdOperatorId holds value of 'operator_id' option
 var EmailsListCmdOperatorId string
 
+// EmailsListCmdOutputJSONL indicates to output with jsonl format
+var EmailsListCmdOutputJSONL bool
+
 func init() {
 	EmailsListCmd.Flags().StringVar(&EmailsListCmdOperatorId, "operator-id", "", TRAPI("operator_id"))
+
+	EmailsListCmd.Flags().BoolVar(&EmailsListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	EmailsCmd.AddCommand(EmailsListCmd)
 }
 
@@ -61,6 +66,10 @@ var EmailsListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if EmailsListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/event_handlers_list.go
+++ b/soracom/generated/cmd/event_handlers_list.go
@@ -12,8 +12,13 @@ import (
 // EventHandlersListCmdTarget holds value of 'target' option
 var EventHandlersListCmdTarget string
 
+// EventHandlersListCmdOutputJSONL indicates to output with jsonl format
+var EventHandlersListCmdOutputJSONL bool
+
 func init() {
 	EventHandlersListCmd.Flags().StringVar(&EventHandlersListCmdTarget, "target", "", TRAPI("target"))
+
+	EventHandlersListCmd.Flags().BoolVar(&EventHandlersListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	EventHandlersCmd.AddCommand(EventHandlersListCmd)
 }
 
@@ -61,6 +66,10 @@ var EventHandlersListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if EventHandlersListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/event_handlers_list_for_subscriber.go
+++ b/soracom/generated/cmd/event_handlers_list_for_subscriber.go
@@ -12,8 +12,13 @@ import (
 // EventHandlersListForSubscriberCmdImsi holds value of 'imsi' option
 var EventHandlersListForSubscriberCmdImsi string
 
+// EventHandlersListForSubscriberCmdOutputJSONL indicates to output with jsonl format
+var EventHandlersListForSubscriberCmdOutputJSONL bool
+
 func init() {
 	EventHandlersListForSubscriberCmd.Flags().StringVar(&EventHandlersListForSubscriberCmdImsi, "imsi", "", TRAPI("imsi"))
+
+	EventHandlersListForSubscriberCmd.Flags().BoolVar(&EventHandlersListForSubscriberCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	EventHandlersCmd.AddCommand(EventHandlersListForSubscriberCmd)
 }
 
@@ -61,6 +66,10 @@ var EventHandlersListForSubscriberCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if EventHandlersListForSubscriberCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/files_find.go
+++ b/soracom/generated/cmd/files_find.go
@@ -24,6 +24,9 @@ var FilesFindCmdScope string
 // FilesFindCmdPaginate indicates to do pagination or not
 var FilesFindCmdPaginate bool
 
+// FilesFindCmdOutputJSONL indicates to output with jsonl format
+var FilesFindCmdOutputJSONL bool
+
 func init() {
 	FilesFindCmd.Flags().StringVar(&FilesFindCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The filePath of the last file entry retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next file entry onward."))
 
@@ -34,6 +37,8 @@ func init() {
 	FilesFindCmd.Flags().StringVar(&FilesFindCmdScope, "scope", "", TRAPI("Scope of the request"))
 
 	FilesFindCmd.Flags().BoolVar(&FilesFindCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	FilesFindCmd.Flags().BoolVar(&FilesFindCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	FilesCmd.AddCommand(FilesFindCmd)
 }
 
@@ -81,6 +86,10 @@ var FilesFindCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if FilesFindCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/files_list.go
+++ b/soracom/generated/cmd/files_list.go
@@ -24,6 +24,9 @@ var FilesListCmdScope string
 // FilesListCmdPaginate indicates to do pagination or not
 var FilesListCmdPaginate bool
 
+// FilesListCmdOutputJSONL indicates to output with jsonl format
+var FilesListCmdOutputJSONL bool
+
 func init() {
 	FilesListCmd.Flags().StringVar(&FilesListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The filename  of the last file entry retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next file entry onward."))
 
@@ -34,6 +37,8 @@ func init() {
 	FilesListCmd.Flags().StringVar(&FilesListCmdScope, "scope", "private", TRAPI("Scope of the request"))
 
 	FilesListCmd.Flags().BoolVar(&FilesListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	FilesListCmd.Flags().BoolVar(&FilesListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	FilesCmd.AddCommand(FilesListCmd)
 }
 
@@ -81,6 +86,10 @@ var FilesListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if FilesListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/gadgets_list.go
+++ b/soracom/generated/cmd/gadgets_list.go
@@ -30,6 +30,9 @@ var GadgetsListCmdLimit int64
 // GadgetsListCmdPaginate indicates to do pagination or not
 var GadgetsListCmdPaginate bool
 
+// GadgetsListCmdOutputJSONL indicates to output with jsonl format
+var GadgetsListCmdOutputJSONL bool
+
 func init() {
 	GadgetsListCmd.Flags().StringVar(&GadgetsListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The ID ({product_id}/{serial_number}) of the last gadget retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next device onward."))
 
@@ -44,6 +47,8 @@ func init() {
 	GadgetsListCmd.Flags().Int64Var(&GadgetsListCmdLimit, "limit", 0, TRAPI("Maximum number of gadgets to retrieve."))
 
 	GadgetsListCmd.Flags().BoolVar(&GadgetsListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	GadgetsListCmd.Flags().BoolVar(&GadgetsListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	GadgetsCmd.AddCommand(GadgetsListCmd)
 }
 
@@ -91,6 +96,10 @@ var GadgetsListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if GadgetsListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/groups_list.go
+++ b/soracom/generated/cmd/groups_list.go
@@ -27,6 +27,9 @@ var GroupsListCmdLimit int64
 // GroupsListCmdPaginate indicates to do pagination or not
 var GroupsListCmdPaginate bool
 
+// GroupsListCmdOutputJSONL indicates to output with jsonl format
+var GroupsListCmdOutputJSONL bool
+
 func init() {
 	GroupsListCmd.Flags().StringVar(&GroupsListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The last Group ID retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next group onward."))
 
@@ -39,6 +42,8 @@ func init() {
 	GroupsListCmd.Flags().Int64Var(&GroupsListCmdLimit, "limit", 0, TRAPI("Maximum number of results per response page."))
 
 	GroupsListCmd.Flags().BoolVar(&GroupsListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	GroupsListCmd.Flags().BoolVar(&GroupsListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	GroupsCmd.AddCommand(GroupsListCmd)
 }
 
@@ -86,6 +91,10 @@ var GroupsListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if GroupsListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/lagoon_dashboards_list_permissions.go
+++ b/soracom/generated/cmd/lagoon_dashboards_list_permissions.go
@@ -12,8 +12,13 @@ import (
 // LagoonDashboardsListPermissionsCmdClassic holds value of 'classic' option
 var LagoonDashboardsListPermissionsCmdClassic bool
 
+// LagoonDashboardsListPermissionsCmdOutputJSONL indicates to output with jsonl format
+var LagoonDashboardsListPermissionsCmdOutputJSONL bool
+
 func init() {
 	LagoonDashboardsListPermissionsCmd.Flags().BoolVar(&LagoonDashboardsListPermissionsCmdClassic, "classic", false, TRAPI("If the value is true, a request will be issued to Lagoon Classic. This is only valid if both Lagoon and Lagoon Classic are enabled."))
+
+	LagoonDashboardsListPermissionsCmd.Flags().BoolVar(&LagoonDashboardsListPermissionsCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	LagoonDashboardsCmd.AddCommand(LagoonDashboardsListPermissionsCmd)
 }
 
@@ -61,6 +66,10 @@ var LagoonDashboardsListPermissionsCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if LagoonDashboardsListPermissionsCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/lagoon_license_packs_list_status.go
+++ b/soracom/generated/cmd/lagoon_license_packs_list_status.go
@@ -9,7 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// LagoonLicensePacksListStatusCmdOutputJSONL indicates to output with jsonl format
+var LagoonLicensePacksListStatusCmdOutputJSONL bool
+
 func init() {
+	LagoonLicensePacksListStatusCmd.Flags().BoolVar(&LagoonLicensePacksListStatusCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	LagoonLicensePacksCmd.AddCommand(LagoonLicensePacksListStatusCmd)
 }
 
@@ -52,6 +56,10 @@ var LagoonLicensePacksListStatusCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if LagoonLicensePacksListStatusCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/lagoon_list_users.go
+++ b/soracom/generated/cmd/lagoon_list_users.go
@@ -12,8 +12,13 @@ import (
 // LagoonListUsersCmdClassic holds value of 'classic' option
 var LagoonListUsersCmdClassic bool
 
+// LagoonListUsersCmdOutputJSONL indicates to output with jsonl format
+var LagoonListUsersCmdOutputJSONL bool
+
 func init() {
 	LagoonListUsersCmd.Flags().BoolVar(&LagoonListUsersCmdClassic, "classic", false, TRAPI("If the value is true, a request will be issued to Lagoon Classic. This is only valid if both Lagoon and Lagoon Classic are enabled."))
+
+	LagoonListUsersCmd.Flags().BoolVar(&LagoonListUsersCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	LagoonCmd.AddCommand(LagoonListUsersCmd)
 }
 
@@ -61,6 +66,10 @@ var LagoonListUsersCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if LagoonListUsersCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/lagoon_users_list.go
+++ b/soracom/generated/cmd/lagoon_users_list.go
@@ -12,8 +12,13 @@ import (
 // LagoonUsersListCmdClassic holds value of 'classic' option
 var LagoonUsersListCmdClassic bool
 
+// LagoonUsersListCmdOutputJSONL indicates to output with jsonl format
+var LagoonUsersListCmdOutputJSONL bool
+
 func init() {
 	LagoonUsersListCmd.Flags().BoolVar(&LagoonUsersListCmdClassic, "classic", false, TRAPI("If the value is true, a request will be issued to Lagoon Classic. This is only valid if both Lagoon and Lagoon Classic are enabled."))
+
+	LagoonUsersListCmd.Flags().BoolVar(&LagoonUsersListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	LagoonUsersCmd.AddCommand(LagoonUsersListCmd)
 }
 
@@ -61,6 +66,10 @@ var LagoonUsersListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if LagoonUsersListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/logs_get.go
+++ b/soracom/generated/cmd/logs_get.go
@@ -33,6 +33,9 @@ var LogsGetCmdTo int64
 // LogsGetCmdPaginate indicates to do pagination or not
 var LogsGetCmdPaginate bool
 
+// LogsGetCmdOutputJSONL indicates to output with jsonl format
+var LogsGetCmdOutputJSONL bool
+
 func init() {
 	LogsGetCmd.Flags().StringVar(&LogsGetCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
@@ -49,6 +52,8 @@ func init() {
 	LogsGetCmd.Flags().Int64Var(&LogsGetCmdTo, "to", 0, TRAPI("End time for the log search range (unixtime)."))
 
 	LogsGetCmd.Flags().BoolVar(&LogsGetCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	LogsGetCmd.Flags().BoolVar(&LogsGetCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	LogsCmd.AddCommand(LogsGetCmd)
 }
 
@@ -96,6 +101,10 @@ var LogsGetCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if LogsGetCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/lora_devices_get_data.go
+++ b/soracom/generated/cmd/lora_devices_get_data.go
@@ -30,6 +30,9 @@ var LoraDevicesGetDataCmdTo int64
 // LoraDevicesGetDataCmdPaginate indicates to do pagination or not
 var LoraDevicesGetDataCmdPaginate bool
 
+// LoraDevicesGetDataCmdOutputJSONL indicates to output with jsonl format
+var LoraDevicesGetDataCmdOutputJSONL bool
+
 func init() {
 	LoraDevicesGetDataCmd.Flags().StringVar(&LoraDevicesGetDataCmdDeviceId, "device-id", "", TRAPI("Device ID of the target subscriber that generated data entries."))
 
@@ -44,6 +47,8 @@ func init() {
 	LoraDevicesGetDataCmd.Flags().Int64Var(&LoraDevicesGetDataCmdTo, "to", 0, TRAPI("End time for the data entries search range (unixtime in milliseconds)."))
 
 	LoraDevicesGetDataCmd.Flags().BoolVar(&LoraDevicesGetDataCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	LoraDevicesGetDataCmd.Flags().BoolVar(&LoraDevicesGetDataCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	LoraDevicesCmd.AddCommand(LoraDevicesGetDataCmd)
 }
 
@@ -91,6 +96,10 @@ var LoraDevicesGetDataCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if LoraDevicesGetDataCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/lora_devices_list.go
+++ b/soracom/generated/cmd/lora_devices_list.go
@@ -27,6 +27,9 @@ var LoraDevicesListCmdLimit int64
 // LoraDevicesListCmdPaginate indicates to do pagination or not
 var LoraDevicesListCmdPaginate bool
 
+// LoraDevicesListCmdOutputJSONL indicates to output with jsonl format
+var LoraDevicesListCmdOutputJSONL bool
+
 func init() {
 	LoraDevicesListCmd.Flags().StringVar(&LoraDevicesListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The device ID of the last device retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next device onward."))
 
@@ -39,6 +42,8 @@ func init() {
 	LoraDevicesListCmd.Flags().Int64Var(&LoraDevicesListCmdLimit, "limit", 0, TRAPI("Maximum number of LoRa devices to retrieve."))
 
 	LoraDevicesListCmd.Flags().BoolVar(&LoraDevicesListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	LoraDevicesListCmd.Flags().BoolVar(&LoraDevicesListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	LoraDevicesCmd.AddCommand(LoraDevicesListCmd)
 }
 
@@ -86,6 +91,10 @@ var LoraDevicesListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if LoraDevicesListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/lora_gateways_list.go
+++ b/soracom/generated/cmd/lora_gateways_list.go
@@ -27,6 +27,9 @@ var LoraGatewaysListCmdLimit int64
 // LoraGatewaysListCmdPaginate indicates to do pagination or not
 var LoraGatewaysListCmdPaginate bool
 
+// LoraGatewaysListCmdOutputJSONL indicates to output with jsonl format
+var LoraGatewaysListCmdOutputJSONL bool
+
 func init() {
 	LoraGatewaysListCmd.Flags().StringVar(&LoraGatewaysListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The device ID of the last device retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next device onward."))
 
@@ -39,6 +42,8 @@ func init() {
 	LoraGatewaysListCmd.Flags().Int64Var(&LoraGatewaysListCmdLimit, "limit", 0, TRAPI("Maximum number of LoRa devices to retrieve."))
 
 	LoraGatewaysListCmd.Flags().BoolVar(&LoraGatewaysListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	LoraGatewaysListCmd.Flags().BoolVar(&LoraGatewaysListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	LoraGatewaysCmd.AddCommand(LoraGatewaysListCmd)
 }
 
@@ -86,6 +91,10 @@ var LoraGatewaysListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if LoraGatewaysListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/lora_network_sets_list.go
+++ b/soracom/generated/cmd/lora_network_sets_list.go
@@ -27,6 +27,9 @@ var LoraNetworkSetsListCmdLimit int64
 // LoraNetworkSetsListCmdPaginate indicates to do pagination or not
 var LoraNetworkSetsListCmdPaginate bool
 
+// LoraNetworkSetsListCmdOutputJSONL indicates to output with jsonl format
+var LoraNetworkSetsListCmdOutputJSONL bool
+
 func init() {
 	LoraNetworkSetsListCmd.Flags().StringVar(&LoraNetworkSetsListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The ID of the last network set retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next device onward."))
 
@@ -39,6 +42,8 @@ func init() {
 	LoraNetworkSetsListCmd.Flags().Int64Var(&LoraNetworkSetsListCmdLimit, "limit", 0, TRAPI("Maximum number of LoRa devices to retrieve."))
 
 	LoraNetworkSetsListCmd.Flags().BoolVar(&LoraNetworkSetsListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	LoraNetworkSetsListCmd.Flags().BoolVar(&LoraNetworkSetsListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	LoraNetworkSetsCmd.AddCommand(LoraNetworkSetsListCmd)
 }
 
@@ -86,6 +91,10 @@ var LoraNetworkSetsListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if LoraNetworkSetsListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/lora_network_sets_list_gateways.go
+++ b/soracom/generated/cmd/lora_network_sets_list_gateways.go
@@ -21,6 +21,9 @@ var LoraNetworkSetsListGatewaysCmdLimit int64
 // LoraNetworkSetsListGatewaysCmdPaginate indicates to do pagination or not
 var LoraNetworkSetsListGatewaysCmdPaginate bool
 
+// LoraNetworkSetsListGatewaysCmdOutputJSONL indicates to output with jsonl format
+var LoraNetworkSetsListGatewaysCmdOutputJSONL bool
+
 func init() {
 	LoraNetworkSetsListGatewaysCmd.Flags().StringVar(&LoraNetworkSetsListGatewaysCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The ID of the last gateway retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next device onward."))
 
@@ -29,6 +32,8 @@ func init() {
 	LoraNetworkSetsListGatewaysCmd.Flags().Int64Var(&LoraNetworkSetsListGatewaysCmdLimit, "limit", 0, TRAPI("Maximum number of LoRa gateways to retrieve."))
 
 	LoraNetworkSetsListGatewaysCmd.Flags().BoolVar(&LoraNetworkSetsListGatewaysCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	LoraNetworkSetsListGatewaysCmd.Flags().BoolVar(&LoraNetworkSetsListGatewaysCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	LoraNetworkSetsCmd.AddCommand(LoraNetworkSetsListGatewaysCmd)
 }
 
@@ -76,6 +81,10 @@ var LoraNetworkSetsListGatewaysCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if LoraNetworkSetsListGatewaysCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/operator_auth_keys_list.go
+++ b/soracom/generated/cmd/operator_auth_keys_list.go
@@ -12,8 +12,13 @@ import (
 // OperatorAuthKeysListCmdOperatorId holds value of 'operator_id' option
 var OperatorAuthKeysListCmdOperatorId string
 
+// OperatorAuthKeysListCmdOutputJSONL indicates to output with jsonl format
+var OperatorAuthKeysListCmdOutputJSONL bool
+
 func init() {
 	OperatorAuthKeysListCmd.Flags().StringVar(&OperatorAuthKeysListCmdOperatorId, "operator-id", "", TRAPI("operator_id"))
+
+	OperatorAuthKeysListCmd.Flags().BoolVar(&OperatorAuthKeysListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	OperatorAuthKeysCmd.AddCommand(OperatorAuthKeysListCmd)
 }
 
@@ -61,6 +66,10 @@ var OperatorAuthKeysListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if OperatorAuthKeysListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/port_mappings_list.go
+++ b/soracom/generated/cmd/port_mappings_list.go
@@ -18,12 +18,17 @@ var PortMappingsListCmdLimit int64
 // PortMappingsListCmdPaginate indicates to do pagination or not
 var PortMappingsListCmdPaginate bool
 
+// PortMappingsListCmdOutputJSONL indicates to output with jsonl format
+var PortMappingsListCmdOutputJSONL bool
+
 func init() {
 	PortMappingsListCmd.Flags().StringVar(&PortMappingsListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The last Port Mapping ID retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next group onward."))
 
 	PortMappingsListCmd.Flags().Int64Var(&PortMappingsListCmdLimit, "limit", 0, TRAPI("Maximum number of results per response page."))
 
 	PortMappingsListCmd.Flags().BoolVar(&PortMappingsListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	PortMappingsListCmd.Flags().BoolVar(&PortMappingsListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	PortMappingsCmd.AddCommand(PortMappingsListCmd)
 }
 
@@ -71,6 +76,10 @@ var PortMappingsListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if PortMappingsListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/pretty_print_json.go
+++ b/soracom/generated/cmd/pretty_print_json.go
@@ -33,3 +33,38 @@ func prettyPrintObjectAsJSON(obj interface{}) error {
 	fmt.Println()
 	return nil
 }
+
+func printStringAsJSONL(rawJSON string) error {
+	var arr []interface{}
+
+	d := json.NewDecoder(strings.NewReader(rawJSON))
+	d.UseNumber()
+	err := d.Decode(&arr)
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range arr {
+		err = printObjectOneLine(obj)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func printObjectOneLine(obj interface{}) error {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = os.Stdout.Write(b)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	return nil
+}

--- a/soracom/generated/cmd/pretty_print_json.go
+++ b/soracom/generated/cmd/pretty_print_json.go
@@ -2,12 +2,16 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
+	"io"
 	"os"
 	"strings"
 )
 
 func prettyPrintStringAsJSON(rawJSON string) error {
+	return prettyPrintStringAsJSONToWriter(rawJSON, os.Stdout)
+}
+
+func prettyPrintStringAsJSONToWriter(rawJSON string, w io.Writer) error {
 	var obj interface{}
 
 	d := json.NewDecoder(strings.NewReader(rawJSON))
@@ -16,25 +20,29 @@ func prettyPrintStringAsJSON(rawJSON string) error {
 	if err != nil {
 		return err
 	}
-	return prettyPrintObjectAsJSON(obj)
+	return prettyPrintObjectAsJSON(obj, w)
 }
 
-func prettyPrintObjectAsJSON(obj interface{}) error {
+func prettyPrintObjectAsJSON(obj interface{}, w io.Writer) error {
 	b, err := json.MarshalIndent(obj, "", "\t")
 	if err != nil {
 		return err
 	}
 
-	_, err = os.Stdout.Write(b)
+	_, err = w.Write(b)
 	if err != nil {
 		return err
 	}
 
-	fmt.Println()
+	w.Write([]byte{'\n'})
 	return nil
 }
 
 func printStringAsJSONL(rawJSON string) error {
+	return printStringAsJSONLToWriter(rawJSON, os.Stdout)
+}
+
+func printStringAsJSONLToWriter(rawJSON string, w io.Writer) error {
 	var arr []interface{}
 
 	d := json.NewDecoder(strings.NewReader(rawJSON))
@@ -45,7 +53,7 @@ func printStringAsJSONL(rawJSON string) error {
 	}
 
 	for _, obj := range arr {
-		err = printObjectOneLine(obj)
+		err = printObjectOneLine(obj, w)
 		if err != nil {
 			return err
 		}
@@ -54,17 +62,17 @@ func printStringAsJSONL(rawJSON string) error {
 	return nil
 }
 
-func printObjectOneLine(obj interface{}) error {
+func printObjectOneLine(obj interface{}, w io.Writer) error {
 	b, err := json.Marshal(obj)
 	if err != nil {
 		return err
 	}
 
-	_, err = os.Stdout.Write(b)
+	_, err = w.Write(b)
 	if err != nil {
 		return err
 	}
 
-	fmt.Println()
+	w.Write([]byte{'\n'})
 	return nil
 }

--- a/soracom/generated/cmd/pretty_print_json_test.go
+++ b/soracom/generated/cmd/pretty_print_json_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tj/assert"
+)
+
+func TestPrintStringAsJSONL(t *testing.T) {
+	data1 := `[{"a":1},{"b":2},{"c":3}]`
+	expected := `{"a":1}
+{"b":2}
+{"c":3}
+`
+	out1 := new(bytes.Buffer)
+	err := printStringAsJSONLToWriter(data1, out1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out1.String())
+
+	noArray1 := `{"a":1,"b":2}`
+	out2 := new(bytes.Buffer)
+	err = printStringAsJSONLToWriter(noArray1, out2)
+	assert.Error(t, err)
+}

--- a/soracom/generated/cmd/query_devices.go
+++ b/soracom/generated/cmd/query_devices.go
@@ -39,6 +39,9 @@ var QueryDevicesCmdLimit int64
 // QueryDevicesCmdPaginate indicates to do pagination or not
 var QueryDevicesCmdPaginate bool
 
+// QueryDevicesCmdOutputJSONL indicates to output with jsonl format
+var QueryDevicesCmdOutputJSONL bool
+
 func init() {
 	QueryDevicesCmd.Flags().StringVar(&QueryDevicesCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The SORACOM Inventory device ID of the last Inventory device retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next Inventory device onward."))
 
@@ -59,6 +62,8 @@ func init() {
 	QueryDevicesCmd.Flags().Int64Var(&QueryDevicesCmdLimit, "limit", 10, TRAPI("The maximum number of item to retrieve"))
 
 	QueryDevicesCmd.Flags().BoolVar(&QueryDevicesCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	QueryDevicesCmd.Flags().BoolVar(&QueryDevicesCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	QueryCmd.AddCommand(QueryDevicesCmd)
 }
 
@@ -106,6 +111,10 @@ var QueryDevicesCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if QueryDevicesCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/query_sigfox_devices.go
+++ b/soracom/generated/cmd/query_sigfox_devices.go
@@ -39,6 +39,9 @@ var QuerySigfoxDevicesCmdLimit int64
 // QuerySigfoxDevicesCmdPaginate indicates to do pagination or not
 var QuerySigfoxDevicesCmdPaginate bool
 
+// QuerySigfoxDevicesCmdOutputJSONL indicates to output with jsonl format
+var QuerySigfoxDevicesCmdOutputJSONL bool
+
 func init() {
 	QuerySigfoxDevicesCmd.Flags().StringVar(&QuerySigfoxDevicesCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The Sigfox device ID of the last Sigfox device retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next Sigfox device onward."))
 
@@ -59,6 +62,8 @@ func init() {
 	QuerySigfoxDevicesCmd.Flags().Int64Var(&QuerySigfoxDevicesCmdLimit, "limit", 10, TRAPI("The maximum number of item to retrieve"))
 
 	QuerySigfoxDevicesCmd.Flags().BoolVar(&QuerySigfoxDevicesCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	QuerySigfoxDevicesCmd.Flags().BoolVar(&QuerySigfoxDevicesCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	QueryCmd.AddCommand(QuerySigfoxDevicesCmd)
 }
 
@@ -106,6 +111,10 @@ var QuerySigfoxDevicesCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if QuerySigfoxDevicesCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/query_sims.go
+++ b/soracom/generated/cmd/query_sims.go
@@ -51,6 +51,9 @@ var QuerySimsCmdLimit int64
 // QuerySimsCmdPaginate indicates to do pagination or not
 var QuerySimsCmdPaginate bool
 
+// QuerySimsCmdOutputJSONL indicates to output with jsonl format
+var QuerySimsCmdOutputJSONL bool
+
 func init() {
 	QuerySimsCmd.Flags().StringVar(&QuerySimsCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The SIM ID of the last SIM retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next SIM onward."))
 
@@ -79,6 +82,8 @@ func init() {
 	QuerySimsCmd.Flags().Int64Var(&QuerySimsCmdLimit, "limit", 10, TRAPI("The maximum number of item to retrieve"))
 
 	QuerySimsCmd.Flags().BoolVar(&QuerySimsCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	QuerySimsCmd.Flags().BoolVar(&QuerySimsCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	QueryCmd.AddCommand(QuerySimsCmd)
 }
 
@@ -126,6 +131,10 @@ var QuerySimsCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if QuerySimsCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/query_subscribers.go
+++ b/soracom/generated/cmd/query_subscribers.go
@@ -50,6 +50,9 @@ var QuerySubscribersCmdLimit int64
 // QuerySubscribersCmdPaginate indicates to do pagination or not
 var QuerySubscribersCmdPaginate bool
 
+// QuerySubscribersCmdOutputJSONL indicates to output with jsonl format
+var QuerySubscribersCmdOutputJSONL bool
+
 func init() {
 	QuerySubscribersCmd.Flags().StringVar(&QuerySubscribersCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The IMSI of the last subscriber retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next subscriber onward."))
 
@@ -76,6 +79,8 @@ func init() {
 	QuerySubscribersCmd.Flags().Int64Var(&QuerySubscribersCmdLimit, "limit", 10, TRAPI("The maximum number of item to retrieve"))
 
 	QuerySubscribersCmd.Flags().BoolVar(&QuerySubscribersCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	QuerySubscribersCmd.Flags().BoolVar(&QuerySubscribersCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	QueryCmd.AddCommand(QuerySubscribersCmd)
 }
 
@@ -125,6 +130,10 @@ var QuerySubscribersCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if QuerySubscribersCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/query_subscribers_traffic_volume_ranking.go
+++ b/soracom/generated/cmd/query_subscribers_traffic_volume_ranking.go
@@ -21,6 +21,9 @@ var QuerySubscribersTrafficVolumeRankingCmdLimit int64
 // QuerySubscribersTrafficVolumeRankingCmdTo holds value of 'to' option
 var QuerySubscribersTrafficVolumeRankingCmdTo int64
 
+// QuerySubscribersTrafficVolumeRankingCmdOutputJSONL indicates to output with jsonl format
+var QuerySubscribersTrafficVolumeRankingCmdOutputJSONL bool
+
 func init() {
 	QuerySubscribersTrafficVolumeRankingCmd.Flags().StringVar(&QuerySubscribersTrafficVolumeRankingCmdOrder, "order", "desc", TRAPI("The order of ranking"))
 
@@ -29,6 +32,8 @@ func init() {
 	QuerySubscribersTrafficVolumeRankingCmd.Flags().Int64Var(&QuerySubscribersTrafficVolumeRankingCmdLimit, "limit", 10, TRAPI("The maximum number of item to retrieve"))
 
 	QuerySubscribersTrafficVolumeRankingCmd.Flags().Int64Var(&QuerySubscribersTrafficVolumeRankingCmdTo, "to", 0, TRAPI("The end point of searching range (unixtime: in milliseconds)"))
+
+	QuerySubscribersTrafficVolumeRankingCmd.Flags().BoolVar(&QuerySubscribersTrafficVolumeRankingCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	QuerySubscribersCmd.AddCommand(QuerySubscribersTrafficVolumeRankingCmd)
 }
 
@@ -76,6 +81,10 @@ var QuerySubscribersTrafficVolumeRankingCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if QuerySubscribersTrafficVolumeRankingCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/query_traffic_ranking.go
+++ b/soracom/generated/cmd/query_traffic_ranking.go
@@ -21,6 +21,9 @@ var QueryTrafficRankingCmdLimit int64
 // QueryTrafficRankingCmdTo holds value of 'to' option
 var QueryTrafficRankingCmdTo int64
 
+// QueryTrafficRankingCmdOutputJSONL indicates to output with jsonl format
+var QueryTrafficRankingCmdOutputJSONL bool
+
 func init() {
 	QueryTrafficRankingCmd.Flags().StringVar(&QueryTrafficRankingCmdOrder, "order", "desc", TRAPI("The order of ranking"))
 
@@ -29,6 +32,8 @@ func init() {
 	QueryTrafficRankingCmd.Flags().Int64Var(&QueryTrafficRankingCmdLimit, "limit", 10, TRAPI("The maximum number of item to retrieve"))
 
 	QueryTrafficRankingCmd.Flags().Int64Var(&QueryTrafficRankingCmdTo, "to", 0, TRAPI("The end point of searching range (unixtime: in milliseconds)"))
+
+	QueryTrafficRankingCmd.Flags().BoolVar(&QueryTrafficRankingCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	QueryCmd.AddCommand(QueryTrafficRankingCmd)
 }
 
@@ -76,6 +81,10 @@ var QueryTrafficRankingCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if QueryTrafficRankingCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/roles_list.go
+++ b/soracom/generated/cmd/roles_list.go
@@ -12,8 +12,13 @@ import (
 // RolesListCmdOperatorId holds value of 'operator_id' option
 var RolesListCmdOperatorId string
 
+// RolesListCmdOutputJSONL indicates to output with jsonl format
+var RolesListCmdOutputJSONL bool
+
 func init() {
 	RolesListCmd.Flags().StringVar(&RolesListCmdOperatorId, "operator-id", "", TRAPI("operator_id"))
+
+	RolesListCmd.Flags().BoolVar(&RolesListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	RolesCmd.AddCommand(RolesListCmd)
 }
 
@@ -61,6 +66,10 @@ var RolesListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if RolesListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/roles_list_users.go
+++ b/soracom/generated/cmd/roles_list_users.go
@@ -15,10 +15,15 @@ var RolesListUsersCmdOperatorId string
 // RolesListUsersCmdRoleId holds value of 'role_id' option
 var RolesListUsersCmdRoleId string
 
+// RolesListUsersCmdOutputJSONL indicates to output with jsonl format
+var RolesListUsersCmdOutputJSONL bool
+
 func init() {
 	RolesListUsersCmd.Flags().StringVar(&RolesListUsersCmdOperatorId, "operator-id", "", TRAPI("operator_id"))
 
 	RolesListUsersCmd.Flags().StringVar(&RolesListUsersCmdRoleId, "role-id", "", TRAPI("role_id"))
+
+	RolesListUsersCmd.Flags().BoolVar(&RolesListUsersCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	RolesCmd.AddCommand(RolesListUsersCmd)
 }
 
@@ -66,6 +71,10 @@ var RolesListUsersCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if RolesListUsersCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/sigfox_devices_get_data.go
+++ b/soracom/generated/cmd/sigfox_devices_get_data.go
@@ -30,6 +30,9 @@ var SigfoxDevicesGetDataCmdTo int64
 // SigfoxDevicesGetDataCmdPaginate indicates to do pagination or not
 var SigfoxDevicesGetDataCmdPaginate bool
 
+// SigfoxDevicesGetDataCmdOutputJSONL indicates to output with jsonl format
+var SigfoxDevicesGetDataCmdOutputJSONL bool
+
 func init() {
 	SigfoxDevicesGetDataCmd.Flags().StringVar(&SigfoxDevicesGetDataCmdDeviceId, "device-id", "", TRAPI("Device ID of the target subscriber that generated data entries."))
 
@@ -44,6 +47,8 @@ func init() {
 	SigfoxDevicesGetDataCmd.Flags().Int64Var(&SigfoxDevicesGetDataCmdTo, "to", 0, TRAPI("End time for the data entries search range (unixtime in milliseconds)."))
 
 	SigfoxDevicesGetDataCmd.Flags().BoolVar(&SigfoxDevicesGetDataCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	SigfoxDevicesGetDataCmd.Flags().BoolVar(&SigfoxDevicesGetDataCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SigfoxDevicesCmd.AddCommand(SigfoxDevicesGetDataCmd)
 }
 
@@ -91,6 +96,10 @@ var SigfoxDevicesGetDataCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SigfoxDevicesGetDataCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/sigfox_devices_list.go
+++ b/soracom/generated/cmd/sigfox_devices_list.go
@@ -27,6 +27,9 @@ var SigfoxDevicesListCmdLimit int64
 // SigfoxDevicesListCmdPaginate indicates to do pagination or not
 var SigfoxDevicesListCmdPaginate bool
 
+// SigfoxDevicesListCmdOutputJSONL indicates to output with jsonl format
+var SigfoxDevicesListCmdOutputJSONL bool
+
 func init() {
 	SigfoxDevicesListCmd.Flags().StringVar(&SigfoxDevicesListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The device ID of the last device retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next device onward."))
 
@@ -39,6 +42,8 @@ func init() {
 	SigfoxDevicesListCmd.Flags().Int64Var(&SigfoxDevicesListCmdLimit, "limit", 0, TRAPI("Maximum number of Sigfox devices to retrieve."))
 
 	SigfoxDevicesListCmd.Flags().BoolVar(&SigfoxDevicesListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	SigfoxDevicesListCmd.Flags().BoolVar(&SigfoxDevicesListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SigfoxDevicesCmd.AddCommand(SigfoxDevicesListCmd)
 }
 
@@ -86,6 +91,10 @@ var SigfoxDevicesListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SigfoxDevicesListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/sims_get_data.go
+++ b/soracom/generated/cmd/sims_get_data.go
@@ -27,6 +27,9 @@ var SimsGetDataCmdLimit int64
 // SimsGetDataCmdTo holds value of 'to' option
 var SimsGetDataCmdTo int64
 
+// SimsGetDataCmdOutputJSONL indicates to output with jsonl format
+var SimsGetDataCmdOutputJSONL bool
+
 func init() {
 	SimsGetDataCmd.Flags().StringVar(&SimsGetDataCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
@@ -39,6 +42,8 @@ func init() {
 	SimsGetDataCmd.Flags().Int64Var(&SimsGetDataCmdLimit, "limit", 0, TRAPI("Maximum number of data entries to retrieve."))
 
 	SimsGetDataCmd.Flags().Int64Var(&SimsGetDataCmdTo, "to", 0, TRAPI("End time for the data entries search range (unixtime in milliseconds)."))
+
+	SimsGetDataCmd.Flags().BoolVar(&SimsGetDataCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SimsCmd.AddCommand(SimsGetDataCmd)
 }
 
@@ -86,6 +91,10 @@ var SimsGetDataCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SimsGetDataCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/sims_list.go
+++ b/soracom/generated/cmd/sims_list.go
@@ -18,12 +18,17 @@ var SimsListCmdLimit int64
 // SimsListCmdPaginate indicates to do pagination or not
 var SimsListCmdPaginate bool
 
+// SimsListCmdOutputJSONL indicates to output with jsonl format
+var SimsListCmdOutputJSONL bool
+
 func init() {
 	SimsListCmd.Flags().StringVar(&SimsListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The ID of the last SIM retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next SIM onward."))
 
 	SimsListCmd.Flags().Int64Var(&SimsListCmdLimit, "limit", 0, TRAPI("Maximum number of SIMs to retrieve. Setting a limit does not guarantee the number of sims returned in the response (i.e. the response may contain fewer sims than the specified limit)."))
 
 	SimsListCmd.Flags().BoolVar(&SimsListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	SimsListCmd.Flags().BoolVar(&SimsListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SimsCmd.AddCommand(SimsListCmd)
 }
 
@@ -71,6 +76,10 @@ var SimsListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SimsListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/sims_list_packet_capture_sessions.go
+++ b/soracom/generated/cmd/sims_list_packet_capture_sessions.go
@@ -18,12 +18,17 @@ var SimsListPacketCaptureSessionsCmdSimId string
 // SimsListPacketCaptureSessionsCmdLimit holds value of 'limit' option
 var SimsListPacketCaptureSessionsCmdLimit int64
 
+// SimsListPacketCaptureSessionsCmdOutputJSONL indicates to output with jsonl format
+var SimsListPacketCaptureSessionsCmdOutputJSONL bool
+
 func init() {
 	SimsListPacketCaptureSessionsCmd.Flags().StringVar(&SimsListPacketCaptureSessionsCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("ID of the last packet capture session in the previous page"))
 
 	SimsListPacketCaptureSessionsCmd.Flags().StringVar(&SimsListPacketCaptureSessionsCmdSimId, "sim-id", "", TRAPI("SIM ID"))
 
 	SimsListPacketCaptureSessionsCmd.Flags().Int64Var(&SimsListPacketCaptureSessionsCmdLimit, "limit", 10, TRAPI("Max number of results in a response"))
+
+	SimsListPacketCaptureSessionsCmd.Flags().BoolVar(&SimsListPacketCaptureSessionsCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SimsCmd.AddCommand(SimsListPacketCaptureSessionsCmd)
 }
 
@@ -71,6 +76,10 @@ var SimsListPacketCaptureSessionsCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SimsListPacketCaptureSessionsCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/sims_session_events.go
+++ b/soracom/generated/cmd/sims_session_events.go
@@ -24,6 +24,9 @@ var SimsSessionEventsCmdLimit int64
 // SimsSessionEventsCmdTo holds value of 'to' option
 var SimsSessionEventsCmdTo int64
 
+// SimsSessionEventsCmdOutputJSONL indicates to output with jsonl format
+var SimsSessionEventsCmdOutputJSONL bool
+
 func init() {
 	SimsSessionEventsCmd.Flags().StringVar(&SimsSessionEventsCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The time stamp of the last event retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next event onward."))
 
@@ -34,6 +37,8 @@ func init() {
 	SimsSessionEventsCmd.Flags().Int64Var(&SimsSessionEventsCmdLimit, "limit", 0, TRAPI("Maximum number of events to retrieve."))
 
 	SimsSessionEventsCmd.Flags().Int64Var(&SimsSessionEventsCmdTo, "to", 0, TRAPI("End time for the events search range (unixtime)."))
+
+	SimsSessionEventsCmd.Flags().BoolVar(&SimsSessionEventsCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SimsCmd.AddCommand(SimsSessionEventsCmd)
 }
 
@@ -81,6 +86,10 @@ var SimsSessionEventsCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SimsSessionEventsCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/soralets_get_logs.go
+++ b/soracom/generated/cmd/soralets_get_logs.go
@@ -24,6 +24,9 @@ var SoraletsGetLogsCmdLimit int64
 // SoraletsGetLogsCmdPaginate indicates to do pagination or not
 var SoraletsGetLogsCmdPaginate bool
 
+// SoraletsGetLogsCmdOutputJSONL indicates to output with jsonl format
+var SoraletsGetLogsCmdOutputJSONL bool
+
 func init() {
 	SoraletsGetLogsCmd.Flags().StringVar(&SoraletsGetLogsCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The identifier of the last log message retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next log message onward."))
 
@@ -34,6 +37,8 @@ func init() {
 	SoraletsGetLogsCmd.Flags().Int64Var(&SoraletsGetLogsCmdLimit, "limit", 0, TRAPI("The maximum number of items in a response."))
 
 	SoraletsGetLogsCmd.Flags().BoolVar(&SoraletsGetLogsCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	SoraletsGetLogsCmd.Flags().BoolVar(&SoraletsGetLogsCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SoraletsCmd.AddCommand(SoraletsGetLogsCmd)
 }
 
@@ -81,6 +86,10 @@ var SoraletsGetLogsCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SoraletsGetLogsCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/soralets_list.go
+++ b/soracom/generated/cmd/soralets_list.go
@@ -21,6 +21,9 @@ var SoraletsListCmdLimit int64
 // SoraletsListCmdPaginate indicates to do pagination or not
 var SoraletsListCmdPaginate bool
 
+// SoraletsListCmdOutputJSONL indicates to output with jsonl format
+var SoraletsListCmdOutputJSONL bool
+
 func init() {
 	SoraletsListCmd.Flags().StringVar(&SoraletsListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The identifier of the last Soralet retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next Soralet onward."))
 
@@ -29,6 +32,8 @@ func init() {
 	SoraletsListCmd.Flags().Int64Var(&SoraletsListCmdLimit, "limit", 0, TRAPI("The maximum number of items in a response"))
 
 	SoraletsListCmd.Flags().BoolVar(&SoraletsListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	SoraletsListCmd.Flags().BoolVar(&SoraletsListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SoraletsCmd.AddCommand(SoraletsListCmd)
 }
 
@@ -76,6 +81,10 @@ var SoraletsListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SoraletsListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/soralets_list_versions.go
+++ b/soracom/generated/cmd/soralets_list_versions.go
@@ -24,6 +24,9 @@ var SoraletsListVersionsCmdLimit int64
 // SoraletsListVersionsCmdPaginate indicates to do pagination or not
 var SoraletsListVersionsCmdPaginate bool
 
+// SoraletsListVersionsCmdOutputJSONL indicates to output with jsonl format
+var SoraletsListVersionsCmdOutputJSONL bool
+
 func init() {
 	SoraletsListVersionsCmd.Flags().StringVar(&SoraletsListVersionsCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The identifier of the last version retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next version onward."))
 
@@ -34,6 +37,8 @@ func init() {
 	SoraletsListVersionsCmd.Flags().Int64Var(&SoraletsListVersionsCmdLimit, "limit", 0, TRAPI("The maximum number of items in a response."))
 
 	SoraletsListVersionsCmd.Flags().BoolVar(&SoraletsListVersionsCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	SoraletsListVersionsCmd.Flags().BoolVar(&SoraletsListVersionsCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SoraletsCmd.AddCommand(SoraletsListVersionsCmd)
 }
 
@@ -81,6 +86,10 @@ var SoraletsListVersionsCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SoraletsListVersionsCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/stats_air_get.go
+++ b/soracom/generated/cmd/stats_air_get.go
@@ -21,6 +21,9 @@ var StatsAirGetCmdFrom int64
 // StatsAirGetCmdTo holds value of 'to' option
 var StatsAirGetCmdTo int64
 
+// StatsAirGetCmdOutputJSONL indicates to output with jsonl format
+var StatsAirGetCmdOutputJSONL bool
+
 func init() {
 	StatsAirGetCmd.Flags().StringVar(&StatsAirGetCmdImsi, "imsi", "", TRAPI("imsi"))
 
@@ -29,6 +32,8 @@ func init() {
 	StatsAirGetCmd.Flags().Int64Var(&StatsAirGetCmdFrom, "from", 0, TRAPI("Start time in unixtime for the aggregate data."))
 
 	StatsAirGetCmd.Flags().Int64Var(&StatsAirGetCmdTo, "to", 0, TRAPI("End time in unixtime for the aggregate data."))
+
+	StatsAirGetCmd.Flags().BoolVar(&StatsAirGetCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	StatsAirCmd.AddCommand(StatsAirGetCmd)
 }
 
@@ -76,6 +81,10 @@ var StatsAirGetCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if StatsAirGetCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/stats_air_sims_get.go
+++ b/soracom/generated/cmd/stats_air_sims_get.go
@@ -21,6 +21,9 @@ var StatsAirSimsGetCmdFrom int64
 // StatsAirSimsGetCmdTo holds value of 'to' option
 var StatsAirSimsGetCmdTo int64
 
+// StatsAirSimsGetCmdOutputJSONL indicates to output with jsonl format
+var StatsAirSimsGetCmdOutputJSONL bool
+
 func init() {
 	StatsAirSimsGetCmd.Flags().StringVar(&StatsAirSimsGetCmdPeriod, "period", "", TRAPI("Units of aggregate data. For minutes, the interval is around 5 minutes."))
 
@@ -29,6 +32,8 @@ func init() {
 	StatsAirSimsGetCmd.Flags().Int64Var(&StatsAirSimsGetCmdFrom, "from", 0, TRAPI("Start time in unixtime for the aggregate data."))
 
 	StatsAirSimsGetCmd.Flags().Int64Var(&StatsAirSimsGetCmdTo, "to", 0, TRAPI("End time in unixtime for the aggregate data."))
+
+	StatsAirSimsGetCmd.Flags().BoolVar(&StatsAirSimsGetCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	StatsAirSimsCmd.AddCommand(StatsAirSimsGetCmd)
 }
 
@@ -76,6 +81,10 @@ var StatsAirSimsGetCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if StatsAirSimsGetCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/stats_beam_get.go
+++ b/soracom/generated/cmd/stats_beam_get.go
@@ -21,6 +21,9 @@ var StatsBeamGetCmdFrom int64
 // StatsBeamGetCmdTo holds value of 'to' option
 var StatsBeamGetCmdTo int64
 
+// StatsBeamGetCmdOutputJSONL indicates to output with jsonl format
+var StatsBeamGetCmdOutputJSONL bool
+
 func init() {
 	StatsBeamGetCmd.Flags().StringVar(&StatsBeamGetCmdImsi, "imsi", "", TRAPI("imsi"))
 
@@ -29,6 +32,8 @@ func init() {
 	StatsBeamGetCmd.Flags().Int64Var(&StatsBeamGetCmdFrom, "from", 0, TRAPI("Start time in unixtime for the aggregate data."))
 
 	StatsBeamGetCmd.Flags().Int64Var(&StatsBeamGetCmdTo, "to", 0, TRAPI("End time in unixtime for the aggregate data."))
+
+	StatsBeamGetCmd.Flags().BoolVar(&StatsBeamGetCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	StatsBeamCmd.AddCommand(StatsBeamGetCmd)
 }
 
@@ -76,6 +81,10 @@ var StatsBeamGetCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if StatsBeamGetCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/stats_funk_get.go
+++ b/soracom/generated/cmd/stats_funk_get.go
@@ -21,6 +21,9 @@ var StatsFunkGetCmdFrom int64
 // StatsFunkGetCmdTo holds value of 'to' option
 var StatsFunkGetCmdTo int64
 
+// StatsFunkGetCmdOutputJSONL indicates to output with jsonl format
+var StatsFunkGetCmdOutputJSONL bool
+
 func init() {
 	StatsFunkGetCmd.Flags().StringVar(&StatsFunkGetCmdImsi, "imsi", "", TRAPI("imsi"))
 
@@ -29,6 +32,8 @@ func init() {
 	StatsFunkGetCmd.Flags().Int64Var(&StatsFunkGetCmdFrom, "from", 0, TRAPI("Start time in unixtime for the aggregate data."))
 
 	StatsFunkGetCmd.Flags().Int64Var(&StatsFunkGetCmdTo, "to", 0, TRAPI("End time in unixtime for the aggregate data."))
+
+	StatsFunkGetCmd.Flags().BoolVar(&StatsFunkGetCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	StatsFunkCmd.AddCommand(StatsFunkGetCmd)
 }
 
@@ -76,6 +81,10 @@ var StatsFunkGetCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if StatsFunkGetCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/stats_funnel_get.go
+++ b/soracom/generated/cmd/stats_funnel_get.go
@@ -21,6 +21,9 @@ var StatsFunnelGetCmdFrom int64
 // StatsFunnelGetCmdTo holds value of 'to' option
 var StatsFunnelGetCmdTo int64
 
+// StatsFunnelGetCmdOutputJSONL indicates to output with jsonl format
+var StatsFunnelGetCmdOutputJSONL bool
+
 func init() {
 	StatsFunnelGetCmd.Flags().StringVar(&StatsFunnelGetCmdImsi, "imsi", "", TRAPI("imsi"))
 
@@ -29,6 +32,8 @@ func init() {
 	StatsFunnelGetCmd.Flags().Int64Var(&StatsFunnelGetCmdFrom, "from", 0, TRAPI("Start time in unixtime for the aggregate data."))
 
 	StatsFunnelGetCmd.Flags().Int64Var(&StatsFunnelGetCmdTo, "to", 0, TRAPI("End time in unixtime for the aggregate data."))
+
+	StatsFunnelGetCmd.Flags().BoolVar(&StatsFunnelGetCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	StatsFunnelCmd.AddCommand(StatsFunnelGetCmd)
 }
 
@@ -76,6 +81,10 @@ var StatsFunnelGetCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if StatsFunnelGetCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/subscribers_get_data.go
+++ b/soracom/generated/cmd/subscribers_get_data.go
@@ -30,6 +30,9 @@ var SubscribersGetDataCmdTo int64
 // SubscribersGetDataCmdPaginate indicates to do pagination or not
 var SubscribersGetDataCmdPaginate bool
 
+// SubscribersGetDataCmdOutputJSONL indicates to output with jsonl format
+var SubscribersGetDataCmdOutputJSONL bool
+
 func init() {
 	SubscribersGetDataCmd.Flags().StringVar(&SubscribersGetDataCmdImsi, "imsi", "", TRAPI("IMSI of the target subscriber that generated data entries."))
 
@@ -44,6 +47,8 @@ func init() {
 	SubscribersGetDataCmd.Flags().Int64Var(&SubscribersGetDataCmdTo, "to", 0, TRAPI("End time for the data entries search range (unixtime in milliseconds)."))
 
 	SubscribersGetDataCmd.Flags().BoolVar(&SubscribersGetDataCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	SubscribersGetDataCmd.Flags().BoolVar(&SubscribersGetDataCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SubscribersCmd.AddCommand(SubscribersGetDataCmd)
 }
 
@@ -91,6 +96,10 @@ var SubscribersGetDataCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SubscribersGetDataCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/subscribers_list.go
+++ b/soracom/generated/cmd/subscribers_list.go
@@ -36,6 +36,9 @@ var SubscribersListCmdLimit int64
 // SubscribersListCmdPaginate indicates to do pagination or not
 var SubscribersListCmdPaginate bool
 
+// SubscribersListCmdOutputJSONL indicates to output with jsonl format
+var SubscribersListCmdOutputJSONL bool
+
 func init() {
 	SubscribersListCmd.Flags().StringVar(&SubscribersListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The IMSI of the last subscriber retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next subscriber onward."))
 
@@ -54,6 +57,8 @@ func init() {
 	SubscribersListCmd.Flags().Int64Var(&SubscribersListCmdLimit, "limit", 0, TRAPI("Maximum number of subscribers to retrieve. Setting a limit does not guarantee the number of subscribers returned in the response (i.e. the response may contain fewer subscribers than the specified limit)."))
 
 	SubscribersListCmd.Flags().BoolVar(&SubscribersListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	SubscribersListCmd.Flags().BoolVar(&SubscribersListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SubscribersCmd.AddCommand(SubscribersListCmd)
 }
 
@@ -101,6 +106,10 @@ var SubscribersListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SubscribersListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/subscribers_session_events.go
+++ b/soracom/generated/cmd/subscribers_session_events.go
@@ -27,6 +27,9 @@ var SubscribersSessionEventsCmdTo int64
 // SubscribersSessionEventsCmdPaginate indicates to do pagination or not
 var SubscribersSessionEventsCmdPaginate bool
 
+// SubscribersSessionEventsCmdOutputJSONL indicates to output with jsonl format
+var SubscribersSessionEventsCmdOutputJSONL bool
+
 func init() {
 	SubscribersSessionEventsCmd.Flags().StringVar(&SubscribersSessionEventsCmdImsi, "imsi", "", TRAPI("IMSI of the target subscriber."))
 
@@ -39,6 +42,8 @@ func init() {
 	SubscribersSessionEventsCmd.Flags().Int64Var(&SubscribersSessionEventsCmdTo, "to", 0, TRAPI("End time for the events search range (unixtime)."))
 
 	SubscribersSessionEventsCmd.Flags().BoolVar(&SubscribersSessionEventsCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	SubscribersSessionEventsCmd.Flags().BoolVar(&SubscribersSessionEventsCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SubscribersCmd.AddCommand(SubscribersSessionEventsCmd)
 }
 
@@ -86,6 +91,10 @@ var SubscribersSessionEventsCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SubscribersSessionEventsCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/system_notifications_list.go
+++ b/soracom/generated/cmd/system_notifications_list.go
@@ -12,8 +12,13 @@ import (
 // SystemNotificationsListCmdOperatorId holds value of 'operator_id' option
 var SystemNotificationsListCmdOperatorId string
 
+// SystemNotificationsListCmdOutputJSONL indicates to output with jsonl format
+var SystemNotificationsListCmdOutputJSONL bool
+
 func init() {
 	SystemNotificationsListCmd.Flags().StringVar(&SystemNotificationsListCmdOperatorId, "operator-id", "", TRAPI("operator_id"))
+
+	SystemNotificationsListCmd.Flags().BoolVar(&SystemNotificationsListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	SystemNotificationsCmd.AddCommand(SystemNotificationsListCmd)
 }
 
@@ -61,6 +66,10 @@ var SystemNotificationsListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if SystemNotificationsListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/users_auth_keys_list.go
+++ b/soracom/generated/cmd/users_auth_keys_list.go
@@ -15,10 +15,15 @@ var UsersAuthKeysListCmdOperatorId string
 // UsersAuthKeysListCmdUserName holds value of 'user_name' option
 var UsersAuthKeysListCmdUserName string
 
+// UsersAuthKeysListCmdOutputJSONL indicates to output with jsonl format
+var UsersAuthKeysListCmdOutputJSONL bool
+
 func init() {
 	UsersAuthKeysListCmd.Flags().StringVar(&UsersAuthKeysListCmdOperatorId, "operator-id", "", TRAPI("operator_id"))
 
 	UsersAuthKeysListCmd.Flags().StringVar(&UsersAuthKeysListCmdUserName, "user-name", "", TRAPI("user_name"))
+
+	UsersAuthKeysListCmd.Flags().BoolVar(&UsersAuthKeysListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	UsersAuthKeysCmd.AddCommand(UsersAuthKeysListCmd)
 }
 
@@ -66,6 +71,10 @@ var UsersAuthKeysListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if UsersAuthKeysListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/users_list.go
+++ b/soracom/generated/cmd/users_list.go
@@ -12,8 +12,13 @@ import (
 // UsersListCmdOperatorId holds value of 'operator_id' option
 var UsersListCmdOperatorId string
 
+// UsersListCmdOutputJSONL indicates to output with jsonl format
+var UsersListCmdOutputJSONL bool
+
 func init() {
 	UsersListCmd.Flags().StringVar(&UsersListCmdOperatorId, "operator-id", "", TRAPI("operator_id"))
+
+	UsersListCmd.Flags().BoolVar(&UsersListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	UsersCmd.AddCommand(UsersListCmd)
 }
 
@@ -61,6 +66,10 @@ var UsersListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if UsersListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/users_list_roles.go
+++ b/soracom/generated/cmd/users_list_roles.go
@@ -15,10 +15,15 @@ var UsersListRolesCmdOperatorId string
 // UsersListRolesCmdUserName holds value of 'user_name' option
 var UsersListRolesCmdUserName string
 
+// UsersListRolesCmdOutputJSONL indicates to output with jsonl format
+var UsersListRolesCmdOutputJSONL bool
+
 func init() {
 	UsersListRolesCmd.Flags().StringVar(&UsersListRolesCmdOperatorId, "operator-id", "", TRAPI("operator_id"))
 
 	UsersListRolesCmd.Flags().StringVar(&UsersListRolesCmdUserName, "user-name", "", TRAPI("user_name"))
+
+	UsersListRolesCmd.Flags().BoolVar(&UsersListRolesCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	UsersCmd.AddCommand(UsersListRolesCmd)
 }
 
@@ -66,6 +71,10 @@ var UsersListRolesCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if UsersListRolesCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/vpg_list.go
+++ b/soracom/generated/cmd/vpg_list.go
@@ -27,6 +27,9 @@ var VpgListCmdLimit int64
 // VpgListCmdPaginate indicates to do pagination or not
 var VpgListCmdPaginate bool
 
+// VpgListCmdOutputJSONL indicates to output with jsonl format
+var VpgListCmdOutputJSONL bool
+
 func init() {
 	VpgListCmd.Flags().StringVar(&VpgListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The last group ID retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next VPG onward."))
 
@@ -39,6 +42,8 @@ func init() {
 	VpgListCmd.Flags().Int64Var(&VpgListCmdLimit, "limit", 0, TRAPI("Maximum number of results per response page."))
 
 	VpgListCmd.Flags().BoolVar(&VpgListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
+
+	VpgListCmd.Flags().BoolVar(&VpgListCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	VpgCmd.AddCommand(VpgListCmd)
 }
 
@@ -86,6 +91,10 @@ var VpgListCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if VpgListCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/vpg_list_gate_peers.go
+++ b/soracom/generated/cmd/vpg_list_gate_peers.go
@@ -12,8 +12,13 @@ import (
 // VpgListGatePeersCmdVpgId holds value of 'vpg_id' option
 var VpgListGatePeersCmdVpgId string
 
+// VpgListGatePeersCmdOutputJSONL indicates to output with jsonl format
+var VpgListGatePeersCmdOutputJSONL bool
+
 func init() {
 	VpgListGatePeersCmd.Flags().StringVar(&VpgListGatePeersCmdVpgId, "vpg-id", "", TRAPI("Target VPG ID."))
+
+	VpgListGatePeersCmd.Flags().BoolVar(&VpgListGatePeersCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	VpgCmd.AddCommand(VpgListGatePeersCmd)
 }
 
@@ -61,6 +66,10 @@ var VpgListGatePeersCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if VpgListGatePeersCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/vpg_list_ip_address_map_entries.go
+++ b/soracom/generated/cmd/vpg_list_ip_address_map_entries.go
@@ -12,8 +12,13 @@ import (
 // VpgListIpAddressMapEntriesCmdVpgId holds value of 'vpg_id' option
 var VpgListIpAddressMapEntriesCmdVpgId string
 
+// VpgListIpAddressMapEntriesCmdOutputJSONL indicates to output with jsonl format
+var VpgListIpAddressMapEntriesCmdOutputJSONL bool
+
 func init() {
 	VpgListIpAddressMapEntriesCmd.Flags().StringVar(&VpgListIpAddressMapEntriesCmdVpgId, "vpg-id", "", TRAPI("Target VPG ID."))
+
+	VpgListIpAddressMapEntriesCmd.Flags().BoolVar(&VpgListIpAddressMapEntriesCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	VpgCmd.AddCommand(VpgListIpAddressMapEntriesCmd)
 }
 
@@ -61,6 +66,10 @@ var VpgListIpAddressMapEntriesCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if VpgListIpAddressMapEntriesCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/soracom/generated/cmd/vpg_list_packet_capture_sessions.go
+++ b/soracom/generated/cmd/vpg_list_packet_capture_sessions.go
@@ -18,12 +18,17 @@ var VpgListPacketCaptureSessionsCmdVpgId string
 // VpgListPacketCaptureSessionsCmdLimit holds value of 'limit' option
 var VpgListPacketCaptureSessionsCmdLimit int64
 
+// VpgListPacketCaptureSessionsCmdOutputJSONL indicates to output with jsonl format
+var VpgListPacketCaptureSessionsCmdOutputJSONL bool
+
 func init() {
 	VpgListPacketCaptureSessionsCmd.Flags().StringVar(&VpgListPacketCaptureSessionsCmdLastEvaluatedKey, "last-evaluated-key", "null", TRAPI("ID of the last group in the previous page"))
 
 	VpgListPacketCaptureSessionsCmd.Flags().StringVar(&VpgListPacketCaptureSessionsCmdVpgId, "vpg-id", "", TRAPI("VPG ID"))
 
 	VpgListPacketCaptureSessionsCmd.Flags().Int64Var(&VpgListPacketCaptureSessionsCmdLimit, "limit", 10, TRAPI("Max number of results in a response"))
+
+	VpgListPacketCaptureSessionsCmd.Flags().BoolVar(&VpgListPacketCaptureSessionsCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	VpgCmd.AddCommand(VpgListPacketCaptureSessionsCmd)
 }
 
@@ -71,6 +76,10 @@ var VpgListPacketCaptureSessionsCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if VpgListPacketCaptureSessionsCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err

--- a/test/test.sh
+++ b/test/test.sh
@@ -251,6 +251,15 @@ invoke_soracom_command() {
         --profile soracom-cli-test
 }
 
+: "Get subscribers list with --jsonl option" && {
+    subscribers="$( invoke_soracom_command subscribers list --jsonl )"
+    if [ "$( echo "$subscribers" | wc -l )" -ne 4 ]; then
+        echo "expected 4 lines for 4 subscribers, but got the following:" 2>&1
+        echo "$subscribers" 2>&1
+        exit 1
+    fi
+}
+
 : "Create a group" && {
     resp="$( env "${SORACOM_ENVS[@]}" "$SORACOM" \
         groups create \


### PR DESCRIPTION
配列型のレスポンスを持つ API に `--jsonl` というオプションを指定できるようにしました。

対象となる API（コマンド）はたとえば `soracom subscribers list` などです。

`soracom subscribers list` では従来は以下のような出力が得られました。

```
[
        {
                "apn": "soracom.io",
                "bundles": [
                        "bundle50",
                        "test"
                ],
                "createdAt": 1519373616156,
                "createdTime": 1519373616156,
                ...
        },
        {
                "apn": "soracom.io",
                "createdAt": 1519373616525,
                "createdTime": 1519373616525,
                "expiredAt": null,
                "expiryAction": null,
                ...
        },
        {
                "apn": "soracom.io",
                "createdAt": 1519373616895,
                "createdTime": 1519373616895,
                "expiredAt": null,
                "expiryAction": null,
                ...
        }
]
```

`soracom subscribers list --jsonl` では以下のような出力になります。

```
{"apn":"soracom.io","bundles":["bundle50","test"],"createdAt":1519373616156,"createdTime":1519373616156, ...
{"apn":"soracom.io","createdAt":1519373616525,"createdTime":1519373616525,"expiredAt":null,"expiryAction":null, ...
{"apn":"soracom.io","createdAt":1519373616895,"createdTime":1519373616895,"expiredAt":null,"expiryAction":null, ...
```