### PR TITLE
add snap plug to be able to access user's $HOME/.soracom

### DIFF
--- a/snap/build.sh
+++ b/snap/build.sh
@@ -29,6 +29,14 @@ architectures:
   - build-on: all
     run-on: ${arch}
 
+plugs:
+  dot-soracom:
+    interface: personal-files
+    read:
+      - \$HOME/.soracom
+    write:
+      - \$HOME/.soracom
+
 parts:
   soracom:
     plugin: dump
@@ -40,6 +48,10 @@ parts:
 apps:
   soracom:
     command: soracom
+    plugs:
+      - home
+      - network
+      - dot-soracom
 EOD
 }
 


### PR DESCRIPTION
snap でインストールした soracom コマンドはデフォルトでは Sandbox に閉じ込められており `$SNAP_USER_DATA`（すなわち `$HOME/snap/soracom/<revision>/`）以下のディレクトリのファイルしか読み書きすることができません。
そこでユーザーに明示的にその制約を解除してもらった場合に `$HOME/.soracom` のみ読み書きできるようにするための変更です。