### PR TITLE
update golang version

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.2'
+          go-version: '1.17.8'
         id: go
 
       - name: Check out code into the Go module directory

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/golang:1.17.2
+FROM public.ecr.aws/bitnami/golang:1.17.8
 
 RUN apt update && apt upgrade -y && apt install -y fakeroot shellcheck zip
 


### PR DESCRIPTION
Go のバージョンを現時点の安定版の最新である 1.17.8 に更新しました