### PR TITLE
hide secure headers from HTTP request

### DIFF
--- a/generators/cmd/predefined/apiclient.go
+++ b/generators/cmd/predefined/apiclient.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -29,6 +30,11 @@ type apiClient struct {
 	language   string
 	verbose    bool
 }
+
+var (
+	// reSecretHeader is the representation of a compiled regular expression for secure headers which should be hidden.
+	reSecretHeader = regexp.MustCompile(`(?m:^([^:]*(X-Soracom-Api-Key|X-Soracom-Token)[^:]*):.*$)`)
+)
 
 // APIError represents an error occurred while calling API
 type apiError struct {
@@ -355,6 +361,10 @@ func (ac *apiClient) SetVerbose(verbose bool) {
 	ac.verbose = verbose
 }
 
+func hideSecureHeaders(dump []byte) []byte {
+	return reSecretHeader.ReplaceAll(dump, []byte("$1: <hidden>"))
+}
+
 func dumpHTTPRequest(req *http.Request) {
 	dumpBody := req.Header.Get("Content-Type") != "application/octet-stream"
 	dump, err := httputil.DumpRequest(req, dumpBody)
@@ -362,6 +372,7 @@ func dumpHTTPRequest(req *http.Request) {
 		lib.PrintfStderr("error while dumping http request header and body: %s\n", err)
 		return
 	}
+	dump = hideSecureHeaders(dump)
 	lib.PrintfStderr("%s\n", string(dump))
 }
 

--- a/generators/cmd/predefined/apiclient.go
+++ b/generators/cmd/predefined/apiclient.go
@@ -33,7 +33,7 @@ type apiClient struct {
 
 var (
 	// reSecretHeader is the representation of a compiled regular expression for secure headers which should be hidden.
-	reSecretHeader = regexp.MustCompile(`(?m:^([^:]*(X-Soracom-Api-Key|X-Soracom-Token)[^:]*):.*$)`)
+	reSecretHeader = regexp.MustCompile(`(?mi:^((X-Soracom-Api-Key|X-Soracom-Token)):.*$)`)
 )
 
 // APIError represents an error occurred while calling API

--- a/generators/cmd/predefined/apiclient.go
+++ b/generators/cmd/predefined/apiclient.go
@@ -361,7 +361,7 @@ func (ac *apiClient) SetVerbose(verbose bool) {
 	ac.verbose = verbose
 }
 
-func hideSecureHeaders(dump []byte) []byte {
+func hideSecretHeaders(dump []byte) []byte {
 	return reSecretHeader.ReplaceAll(dump, []byte("$1: <hidden>"))
 }
 
@@ -372,7 +372,7 @@ func dumpHTTPRequest(req *http.Request) {
 		lib.PrintfStderr("error while dumping http request header and body: %s\n", err)
 		return
 	}
-	dump = hideSecureHeaders(dump)
+	dump = hideSecretHeaders(dump)
 	lib.PrintfStderr("%s\n", string(dump))
 }
 

--- a/generators/cmd/predefined/apiclient_test.go
+++ b/generators/cmd/predefined/apiclient_test.go
@@ -164,6 +164,16 @@ func TestHideSecretHeaders(t *testing.T) {
 			Input:    "GET / HTTP/1.1\nHeader: leave-this-as-it-is\nHello: world",
 			Expected: "GET / HTTP/1.1\nHeader: leave-this-as-it-is\nHello: world",
 		},
+		{
+			Name:     "Headers which contain secret header but are not exactly same with secret header should not be replaced",
+			Input:    "GET / HTTP/1.1\nX-Soracom-Api-Key-Version: 2022-04-22\nHello: world",
+			Expected: "GET / HTTP/1.1\nX-Soracom-Api-Key-Version: 2022-04-22\nHello: world",
+		},
+		{
+			Name:     "Headers should be treated as case-insensitive and transparently",
+			Input:    "GET / HTTP/1.1\nx-sORACOM-aPI-kEY: this-should-be-hidden\nHello: world",
+			Expected: "GET / HTTP/1.1\nx-sORACOM-aPI-kEY: <hidden>\nHello: world",
+		},
 	}
 
 	for _, data := range testData {

--- a/generators/cmd/predefined/apiclient_test.go
+++ b/generators/cmd/predefined/apiclient_test.go
@@ -143,19 +143,19 @@ func TestConcatJSONArray(t *testing.T) {
 	}
 }
 
-func TestHideSecureHeaders(t *testing.T) {
+func TestHideSecretHeaders(t *testing.T) {
 	var testData = []struct {
 		Name     string
 		Input    string
 		Expected string
 	}{
 		{
-			Name:     "Nominal case for secure headers: X-Soracom-Api-Key",
+			Name:     "Nominal case for secret headers: X-Soracom-Api-Key",
 			Input:    "GET / HTTP/1.1\nX-Soracom-Api-Key: this-should-be-hidden\nHello: world",
 			Expected: "GET / HTTP/1.1\nX-Soracom-Api-Key: <hidden>\nHello: world",
 		},
 		{
-			Name:     "Nominal case for secure headers: X-Soracom-Token",
+			Name:     "Nominal case for secret headers: X-Soracom-Token",
 			Input:    "GET / HTTP/1.1\nX-Soracom-Token: this-should-be-hidden\nHello: world",
 			Expected: "GET / HTTP/1.1\nX-Soracom-Token: <hidden>\nHello: world",
 		},
@@ -171,7 +171,7 @@ func TestHideSecureHeaders(t *testing.T) {
 		t.Run(data.Name, func(t *testing.T) {
 			t.Parallel()
 
-			actualByte := hideSecureHeaders([]byte(data.Input))
+			actualByte := hideSecretHeaders([]byte(data.Input))
 			actual := string(actualByte)
 			if actual != data.Expected {
 				t.Errorf("result of hideSecureHeaders() is unmatched with expected.\nExpected: %v\nActual: %v", data.Expected, actual)

--- a/generators/cmd/predefined/apiclient_test.go
+++ b/generators/cmd/predefined/apiclient_test.go
@@ -142,3 +142,40 @@ func TestConcatJSONArray(t *testing.T) {
 		})
 	}
 }
+
+func TestHideSecureHeaders(t *testing.T) {
+	var testData = []struct {
+		Name     string
+		Input    string
+		Expected string
+	}{
+		{
+			Name:     "Nominal case for secure headers: X-Soracom-Api-Key",
+			Input:    "GET / HTTP/1.1\nX-Soracom-Api-Key: this-should-be-hidden\nHello: world",
+			Expected: "GET / HTTP/1.1\nX-Soracom-Api-Key: <hidden>\nHello: world",
+		},
+		{
+			Name:     "Nominal case for secure headers: X-Soracom-Token",
+			Input:    "GET / HTTP/1.1\nX-Soracom-Token: this-should-be-hidden\nHello: world",
+			Expected: "GET / HTTP/1.1\nX-Soracom-Token: <hidden>\nHello: world",
+		},
+		{
+			Name:     "Nominal case for headers",
+			Input:    "GET / HTTP/1.1\nHeader: leave-this-as-it-is\nHello: world",
+			Expected: "GET / HTTP/1.1\nHeader: leave-this-as-it-is\nHello: world",
+		},
+	}
+
+	for _, data := range testData {
+		data := data // capture
+		t.Run(data.Name, func(t *testing.T) {
+			t.Parallel()
+
+			actualByte := hideSecureHeaders([]byte(data.Input))
+			actual := string(actualByte)
+			if actual != data.Expected {
+				t.Errorf("result of hideSecureHeaders() is unmatched with expected.\nExpected: %v\nActual: %v", data.Expected, actual)
+			}
+		})
+	}
+}

--- a/soracom/generated/cmd/apiclient.go
+++ b/soracom/generated/cmd/apiclient.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -29,6 +30,11 @@ type apiClient struct {
 	language   string
 	verbose    bool
 }
+
+var (
+	// reSecretHeader is the representation of a compiled regular expression for secure headers which should be hidden.
+	reSecretHeader = regexp.MustCompile(`(?m:^([^:]*(X-Soracom-Api-Key|X-Soracom-Token)[^:]*):.*$)`)
+)
 
 // APIError represents an error occurred while calling API
 type apiError struct {
@@ -355,6 +361,10 @@ func (ac *apiClient) SetVerbose(verbose bool) {
 	ac.verbose = verbose
 }
 
+func hideSecureHeaders(dump []byte) []byte {
+	return reSecretHeader.ReplaceAll(dump, []byte("$1: <hidden>"))
+}
+
 func dumpHTTPRequest(req *http.Request) {
 	dumpBody := req.Header.Get("Content-Type") != "application/octet-stream"
 	dump, err := httputil.DumpRequest(req, dumpBody)
@@ -362,6 +372,7 @@ func dumpHTTPRequest(req *http.Request) {
 		lib.PrintfStderr("error while dumping http request header and body: %s\n", err)
 		return
 	}
+	dump = hideSecureHeaders(dump)
 	lib.PrintfStderr("%s\n", string(dump))
 }
 

--- a/soracom/generated/cmd/apiclient.go
+++ b/soracom/generated/cmd/apiclient.go
@@ -33,7 +33,7 @@ type apiClient struct {
 
 var (
 	// reSecretHeader is the representation of a compiled regular expression for secure headers which should be hidden.
-	reSecretHeader = regexp.MustCompile(`(?m:^([^:]*(X-Soracom-Api-Key|X-Soracom-Token)[^:]*):.*$)`)
+	reSecretHeader = regexp.MustCompile(`(?mi:^((X-Soracom-Api-Key|X-Soracom-Token)):.*$)`)
 )
 
 // APIError represents an error occurred while calling API

--- a/soracom/generated/cmd/apiclient.go
+++ b/soracom/generated/cmd/apiclient.go
@@ -361,7 +361,7 @@ func (ac *apiClient) SetVerbose(verbose bool) {
 	ac.verbose = verbose
 }
 
-func hideSecureHeaders(dump []byte) []byte {
+func hideSecretHeaders(dump []byte) []byte {
 	return reSecretHeader.ReplaceAll(dump, []byte("$1: <hidden>"))
 }
 
@@ -372,7 +372,7 @@ func dumpHTTPRequest(req *http.Request) {
 		lib.PrintfStderr("error while dumping http request header and body: %s\n", err)
 		return
 	}
-	dump = hideSecureHeaders(dump)
+	dump = hideSecretHeaders(dump)
 	lib.PrintfStderr("%s\n", string(dump))
 }
 

--- a/soracom/generated/cmd/apiclient_test.go
+++ b/soracom/generated/cmd/apiclient_test.go
@@ -164,6 +164,16 @@ func TestHideSecretHeaders(t *testing.T) {
 			Input:    "GET / HTTP/1.1\nHeader: leave-this-as-it-is\nHello: world",
 			Expected: "GET / HTTP/1.1\nHeader: leave-this-as-it-is\nHello: world",
 		},
+		{
+			Name:     "Headers which contain secret header but are not exactly same with secret header should not be replaced",
+			Input:    "GET / HTTP/1.1\nX-Soracom-Api-Key-Version: 2022-04-22\nHello: world",
+			Expected: "GET / HTTP/1.1\nX-Soracom-Api-Key-Version: 2022-04-22\nHello: world",
+		},
+		{
+			Name:     "Headers should be treated as case-insensitive and transparently",
+			Input:    "GET / HTTP/1.1\nx-sORACOM-aPI-kEY: this-should-be-hidden\nHello: world",
+			Expected: "GET / HTTP/1.1\nx-sORACOM-aPI-kEY: <hidden>\nHello: world",
+		},
 	}
 
 	for _, data := range testData {

--- a/soracom/generated/cmd/apiclient_test.go
+++ b/soracom/generated/cmd/apiclient_test.go
@@ -143,19 +143,19 @@ func TestConcatJSONArray(t *testing.T) {
 	}
 }
 
-func TestHideSecureHeaders(t *testing.T) {
+func TestHideSecretHeaders(t *testing.T) {
 	var testData = []struct {
 		Name     string
 		Input    string
 		Expected string
 	}{
 		{
-			Name:     "Nominal case for secure headers: X-Soracom-Api-Key",
+			Name:     "Nominal case for secret headers: X-Soracom-Api-Key",
 			Input:    "GET / HTTP/1.1\nX-Soracom-Api-Key: this-should-be-hidden\nHello: world",
 			Expected: "GET / HTTP/1.1\nX-Soracom-Api-Key: <hidden>\nHello: world",
 		},
 		{
-			Name:     "Nominal case for secure headers: X-Soracom-Token",
+			Name:     "Nominal case for secret headers: X-Soracom-Token",
 			Input:    "GET / HTTP/1.1\nX-Soracom-Token: this-should-be-hidden\nHello: world",
 			Expected: "GET / HTTP/1.1\nX-Soracom-Token: <hidden>\nHello: world",
 		},
@@ -171,7 +171,7 @@ func TestHideSecureHeaders(t *testing.T) {
 		t.Run(data.Name, func(t *testing.T) {
 			t.Parallel()
 
-			actualByte := hideSecureHeaders([]byte(data.Input))
+			actualByte := hideSecretHeaders([]byte(data.Input))
 			actual := string(actualByte)
 			if actual != data.Expected {
 				t.Errorf("result of hideSecureHeaders() is unmatched with expected.\nExpected: %v\nActual: %v", data.Expected, actual)

--- a/soracom/generated/cmd/apiclient_test.go
+++ b/soracom/generated/cmd/apiclient_test.go
@@ -142,3 +142,40 @@ func TestConcatJSONArray(t *testing.T) {
 		})
 	}
 }
+
+func TestHideSecureHeaders(t *testing.T) {
+	var testData = []struct {
+		Name     string
+		Input    string
+		Expected string
+	}{
+		{
+			Name:     "Nominal case for secure headers: X-Soracom-Api-Key",
+			Input:    "GET / HTTP/1.1\nX-Soracom-Api-Key: this-should-be-hidden\nHello: world",
+			Expected: "GET / HTTP/1.1\nX-Soracom-Api-Key: <hidden>\nHello: world",
+		},
+		{
+			Name:     "Nominal case for secure headers: X-Soracom-Token",
+			Input:    "GET / HTTP/1.1\nX-Soracom-Token: this-should-be-hidden\nHello: world",
+			Expected: "GET / HTTP/1.1\nX-Soracom-Token: <hidden>\nHello: world",
+		},
+		{
+			Name:     "Nominal case for headers",
+			Input:    "GET / HTTP/1.1\nHeader: leave-this-as-it-is\nHello: world",
+			Expected: "GET / HTTP/1.1\nHeader: leave-this-as-it-is\nHello: world",
+		},
+	}
+
+	for _, data := range testData {
+		data := data // capture
+		t.Run(data.Name, func(t *testing.T) {
+			t.Parallel()
+
+			actualByte := hideSecureHeaders([]byte(data.Input))
+			actual := string(actualByte)
+			if actual != data.Expected {
+				t.Errorf("result of hideSecureHeaders() is unmatched with expected.\nExpected: %v\nActual: %v", data.Expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Do not dump X-Soracom-Api-Key and X-Soracom-Token even when SORACOM_VERBOSE is set.
This PR will replace header values of both `X-Soracom-Api-Key` and `X-Soracom-Token` to `<hidden>` from HTTP request

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #64 

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

No

#### Additional documentation