### PR TITLE
avoid '&', '<' and '>' from escaping while marshaling to json

### DIFF
--- a/generators/cmd/predefined/apiclient.go
+++ b/generators/cmd/predefined/apiclient.go
@@ -213,8 +213,19 @@ func concatJSONArray(arr1, arr2 string) (string, error) {
 
 	a := append(a1, a2...)
 
-	b, err := json.Marshal(a)
+	b, err := marshalJSONUnescaped(a)
 	return string(b), err
+}
+
+func marshalJSONUnescaped(x interface{}) ([]byte, error) {
+	var bb bytes.Buffer
+	e := json.NewEncoder(&bb)
+	e.SetEscapeHTML(false)
+	err := e.Encode(x)
+	if err != nil {
+		return nil, err
+	}
+	return bb.Bytes()[:len(bb.Bytes())-1], nil // removing trailing `\n`
 }
 
 func (ac *apiClient) constructURL(params *apiParams) (*url.URL, error) {

--- a/generators/cmd/predefined/apiclient_test.go
+++ b/generators/cmd/predefined/apiclient_test.go
@@ -133,12 +133,8 @@ func TestConcatJSONArray(t *testing.T) {
 			t.Parallel()
 
 			v, err := concatJSONArray(data.Arr1, data.Arr2)
-			if err != nil {
-				t.Fatalf("%+v\n", err)
-			}
-			if v != data.Expected {
-				t.Errorf("result of concatJSONArray() is unmatched with expected.\nArr1: %v\nArr2: %v\nExpected: %#08x\nActual:   %#08x", data.Arr1, data.Arr2, data.Expected, v)
-			}
+			assert.NoError(t, err)
+			assert.Equal(t, data.Expected, v)
 		})
 	}
 }

--- a/generators/cmd/predefined/pretty_print_json.go
+++ b/generators/cmd/predefined/pretty_print_json.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"os"
@@ -24,17 +25,20 @@ func prettyPrintStringAsJSONToWriter(rawJSON string, w io.Writer) error {
 }
 
 func prettyPrintObjectAsJSON(obj interface{}, w io.Writer) error {
-	b, err := json.MarshalIndent(obj, "", "\t")
+	var bb bytes.Buffer
+	e := json.NewEncoder(&bb)
+	e.SetEscapeHTML(false)
+	e.SetIndent("", "\t")
+	err := e.Encode(obj)
 	if err != nil {
 		return err
 	}
 
-	_, err = w.Write(b)
+	_, err = bb.WriteTo(w)
 	if err != nil {
 		return err
 	}
 
-	w.Write([]byte{'\n'})
 	return nil
 }
 
@@ -63,16 +67,18 @@ func printStringAsJSONLToWriter(rawJSON string, w io.Writer) error {
 }
 
 func printObjectOneLine(obj interface{}, w io.Writer) error {
-	b, err := json.Marshal(obj)
+	var bb bytes.Buffer
+	e := json.NewEncoder(&bb)
+	e.SetEscapeHTML(false)
+	err := e.Encode(obj)
 	if err != nil {
 		return err
 	}
 
-	_, err = w.Write(b)
+	_, err = bb.WriteTo(w)
 	if err != nil {
 		return err
 	}
 
-	w.Write([]byte{'\n'})
 	return nil
 }

--- a/soracom/generated/cmd/apiclient.go
+++ b/soracom/generated/cmd/apiclient.go
@@ -213,8 +213,19 @@ func concatJSONArray(arr1, arr2 string) (string, error) {
 
 	a := append(a1, a2...)
 
-	b, err := json.Marshal(a)
+	b, err := marshalJSONUnescaped(a)
 	return string(b), err
+}
+
+func marshalJSONUnescaped(x interface{}) ([]byte, error) {
+	var bb bytes.Buffer
+	e := json.NewEncoder(&bb)
+	e.SetEscapeHTML(false)
+	err := e.Encode(x)
+	if err != nil {
+		return nil, err
+	}
+	return bb.Bytes()[:len(bb.Bytes())-1], nil // removing trailing `\n`
 }
 
 func (ac *apiClient) constructURL(params *apiParams) (*url.URL, error) {

--- a/soracom/generated/cmd/apiclient_test.go
+++ b/soracom/generated/cmd/apiclient_test.go
@@ -133,12 +133,8 @@ func TestConcatJSONArray(t *testing.T) {
 			t.Parallel()
 
 			v, err := concatJSONArray(data.Arr1, data.Arr2)
-			if err != nil {
-				t.Fatalf("%+v\n", err)
-			}
-			if v != data.Expected {
-				t.Errorf("result of concatJSONArray() is unmatched with expected.\nArr1: %v\nArr2: %v\nExpected: %#08x\nActual:   %#08x", data.Arr1, data.Arr2, data.Expected, v)
-			}
+			assert.NoError(t, err)
+			assert.Equal(t, data.Expected, v)
 		})
 	}
 }

--- a/soracom/generated/cmd/pretty_print_json.go
+++ b/soracom/generated/cmd/pretty_print_json.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"os"
@@ -24,17 +25,20 @@ func prettyPrintStringAsJSONToWriter(rawJSON string, w io.Writer) error {
 }
 
 func prettyPrintObjectAsJSON(obj interface{}, w io.Writer) error {
-	b, err := json.MarshalIndent(obj, "", "\t")
+	var bb bytes.Buffer
+	e := json.NewEncoder(&bb)
+	e.SetEscapeHTML(false)
+	e.SetIndent("", "\t")
+	err := e.Encode(obj)
 	if err != nil {
 		return err
 	}
 
-	_, err = w.Write(b)
+	_, err = bb.WriteTo(w)
 	if err != nil {
 		return err
 	}
 
-	w.Write([]byte{'\n'})
 	return nil
 }
 
@@ -63,16 +67,18 @@ func printStringAsJSONLToWriter(rawJSON string, w io.Writer) error {
 }
 
 func printObjectOneLine(obj interface{}, w io.Writer) error {
-	b, err := json.Marshal(obj)
+	var bb bytes.Buffer
+	e := json.NewEncoder(&bb)
+	e.SetEscapeHTML(false)
+	err := e.Encode(obj)
 	if err != nil {
 		return err
 	}
 
-	_, err = w.Write(b)
+	_, err = bb.WriteTo(w)
 	if err != nil {
 		return err
 	}
 
-	w.Write([]byte{'\n'})
 	return nil
 }


### PR DESCRIPTION
soracom-cli の出力する JSON は、文字列中に `&` `<` および `>` が含まれるとそれらをエスケープして `\u0026` `\u003c` および `\u003e` に変換しています。これは Go の `json` パッケージの `Marshal()` 関数の [仕様](https://pkg.go.dev/encoding/json#Marshal) によるものです。

この仕様は元々、Marshal して生成した JSON を HTML の中に埋め込む際に安全なように、ということでデフォルトでエスケープするようになっているようです。

soracom-cli の出力をそのまま HTML に埋め込むことは考えづらいのでセキュリティ問題には直接的には繋がりにくいであろうことと、SORACOM API の各種 Export 系の API が返してくる AWS S3 の Pre-signed URL に含まれる `&` が `\u0026` に変換されてしまうとその URL は無効でありアクセスできないという問題がありますがそれが回避できるという利便性があることから、自動的にエスケープしないようにしました。

何か懸念がございましたらお知らせください。