### PR TITLE
Add link to API reference

### DIFF
--- a/generators/assets/cli/en.yaml
+++ b/generators/assets/cli/en.yaml
@@ -154,7 +154,7 @@ cli:
   query:
     summary: Search resources such as subscribers or sigfox devices.
     description: Search resources such as subscribers or sigfox devices.
-  refer-api-reference: For more information on the arguments of this command, see https://developers.soracom.io/en/api/#!/%s/%s
+  refer-api-reference: For more information on the arguments and response of this command, see https://developers.soracom.io/en/api/#!/%s/%s
   roles:
     summary: List, create, update or delete roles.
     description: List, create, update or delete roles.

--- a/generators/assets/cli/en.yaml
+++ b/generators/assets/cli/en.yaml
@@ -154,6 +154,7 @@ cli:
   query:
     summary: Search resources such as subscribers or sigfox devices.
     description: Search resources such as subscribers or sigfox devices.
+  refer-api-reference: For more information on the arguments of this command, see https://developers.soracom.io/en/api/#!/%s/%s
   roles:
     summary: List, create, update or delete roles.
     description: List, create, update or delete roles.

--- a/generators/assets/cli/ja.yaml
+++ b/generators/assets/cli/ja.yaml
@@ -154,6 +154,7 @@ cli:
   query:
     summary: リソース（サブスクライバー、Sigfox デバイス）をいろいろな条件で検索します。
     description: いろいろな条件を指定して、その条件に適合するリソース（サブスクライバー、Sigfox デバイス）を抽出します。
+  refer-api-reference: このコマンドの引数についての詳細は、https://users.soracom.io/ja-jp/tools/api/reference/#/%s/%s を参照してください。
   roles:
     summary: ロールに関する操作を行います。
     description: ロールに関する操作を行います。

--- a/generators/assets/cli/ja.yaml
+++ b/generators/assets/cli/ja.yaml
@@ -154,7 +154,7 @@ cli:
   query:
     summary: リソース（サブスクライバー、Sigfox デバイス）をいろいろな条件で検索します。
     description: いろいろな条件を指定して、その条件に適合するリソース（サブスクライバー、Sigfox デバイス）を抽出します。
-  refer-api-reference: このコマンドの引数についての詳細は、https://users.soracom.io/ja-jp/tools/api/reference/#/%s/%s を参照してください。
+  refer-api-reference: このコマンドの引数およびレスポンスについての詳細は、https://users.soracom.io/ja-jp/tools/api/reference/#/%s/%s を参照してください。
   roles:
     summary: ロールに関する操作を行います。
     description: ロールに関する操作を行います。

--- a/generators/cmd/predefined/lang_utils.go
+++ b/generators/cmd/predefined/lang_utils.go
@@ -280,3 +280,7 @@ func visit(data map[interface{}]interface{}, path string) string {
 		}
 	}
 }
+
+func createLinkToAPIReference(tag, operationID string) string {
+	return fmt.Sprintf(TRCLI("cli.refer-api-reference"), tag, operationID)
+}

--- a/generators/cmd/src/gen_leaf_cmd.go
+++ b/generators/cmd/src/gen_leaf_cmd.go
@@ -48,6 +48,10 @@ func generateCommandFiles(apiDef *openapi3.T, path, method string, op *openapi3.
 		}()
 
 		pagination := getXSoracomCliPagination(op)
+		tag := ""
+		if len(op.Tags) > 0 {
+			tag = op.Tags[0]
+		}
 
 		a := commandArgs{
 			Use:                               getLast(commandName),
@@ -77,6 +81,8 @@ func generateCommandFiles(apiDef *openapi3.T, path, method string, op *openapi3.
 			Deprecated:                        op.Deprecated,
 			AlternativeCommand:                getXSoracomAlternativeCli(op),
 			HasArrayResponse:                  hasArrayResponse(op.Responses),
+			Tag:                               tag,
+			OperationID:                       op.OperationID,
 		}
 		if a.Method == "POST" || a.Method == "PUT" {
 			if doesContentTypeParamExist(op.Parameters) {

--- a/generators/cmd/src/types.go
+++ b/generators/cmd/src/types.go
@@ -153,4 +153,6 @@ type commandArgs struct {
 	Deprecated                        bool
 	AlternativeCommand                string
 	HasArrayResponse                  bool
+	Tag                               string
+	OperationID                       string
 }

--- a/generators/cmd/templates/leaf.gotmpl
+++ b/generators/cmd/templates/leaf.gotmpl
@@ -100,7 +100,7 @@ func init() {
 var {{ $cmdvar }} = &cobra.Command{
   Use: "{{.Use}}",
   Short: TRAPI("{{.Short}}"),
-  Long: TRAPI(`{{.Long}}`),
+  Long: TRAPI(`{{.Long}}`) + "\n\n" + createLinkToAPIReference("{{.Tag}}", "{{.OperationID}}"),
   RunE: func(cmd *cobra.Command, args []string) error {
     {{- if .Deprecated}}
     lib.WarnfStderr(TRCLI("cli.deprecated-api")+"\n")

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tj/assert v0.0.3
-	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b
+	golang.org/x/sys v0.0.0-20220721230656-c6bc011c0c49
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -432,6 +432,8 @@ golang.org/x/sys v0.0.0-20220624220833-87e55d714810 h1:rHZQSjJdAI4Xf5Qzeh2bBc5YJ
 golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b h1:2n253B2r0pYSmEV+UNCQoPfU/FiaizQEK5Gu4Bq4JE8=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220721230656-c6bc011c0c49 h1:TMjZDarEwf621XDryfitp/8awEhiZNiwgphKlTMGRIg=
+golang.org/x/sys v0.0.0-20220721230656-c6bc011c0c49/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/soracom/generated/cmd/assets/cli/en.yaml
+++ b/soracom/generated/cmd/assets/cli/en.yaml
@@ -154,6 +154,7 @@ cli:
   query:
     summary: Search resources such as subscribers or sigfox devices.
     description: Search resources such as subscribers or sigfox devices.
+  refer-api-reference: For more information on the arguments and response of this command, see https://developers.soracom.io/en/api/#!/%s/%s
   roles:
     summary: List, create, update or delete roles.
     description: List, create, update or delete roles.

--- a/soracom/generated/cmd/assets/cli/ja.yaml
+++ b/soracom/generated/cmd/assets/cli/ja.yaml
@@ -154,6 +154,7 @@ cli:
   query:
     summary: リソース（サブスクライバー、Sigfox デバイス）をいろいろな条件で検索します。
     description: いろいろな条件を指定して、その条件に適合するリソース（サブスクライバー、Sigfox デバイス）を抽出します。
+  refer-api-reference: このコマンドの引数およびレスポンスについての詳細は、https://users.soracom.io/ja-jp/tools/api/reference/#/%s/%s を参照してください。
   roles:
     summary: ロールに関する操作を行います。
     description: ロールに関する操作を行います。

--- a/soracom/generated/cmd/audit_logs_api_get.go
+++ b/soracom/generated/cmd/audit_logs_api_get.go
@@ -51,7 +51,7 @@ func init() {
 var AuditLogsApiGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/audit_logs/api:get:summary"),
-	Long:  TRAPI(`/audit_logs/api:get:description`),
+	Long:  TRAPI(`/audit_logs/api:get:description`) + "\n\n" + createLinkToAPIReference("AuditLog", "getApiAuditLogs"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/audit_logs_napter_get.go
+++ b/soracom/generated/cmd/audit_logs_napter_get.go
@@ -56,7 +56,7 @@ func init() {
 var AuditLogsNapterGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/audit_logs/napter:get:summary"),
-	Long:  TRAPI(`/audit_logs/napter:get:description`),
+	Long:  TRAPI(`/audit_logs/napter:get:description`) + "\n\n" + createLinkToAPIReference("AuditLog", "getNapterAuditLogs"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/auth.go
+++ b/soracom/generated/cmd/auth.go
@@ -65,7 +65,7 @@ func init() {
 var AuthCmd = &cobra.Command{
 	Use:   "auth",
 	Short: TRAPI("/auth:post:summary"),
-	Long:  TRAPI(`/auth:post:description`),
+	Long:  TRAPI(`/auth:post:description`) + "\n\n" + createLinkToAPIReference("Auth", "auth"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/auth_issue_password_reset_token.go
+++ b/soracom/generated/cmd/auth_issue_password_reset_token.go
@@ -30,7 +30,7 @@ func init() {
 var AuthIssuePasswordResetTokenCmd = &cobra.Command{
 	Use:   "issue-password-reset-token",
 	Short: TRAPI("/auth/password_reset_token/issue:post:summary"),
-	Long:  TRAPI(`/auth/password_reset_token/issue:post:description`),
+	Long:  TRAPI(`/auth/password_reset_token/issue:post:description`) + "\n\n" + createLinkToAPIReference("Auth", "issuePasswordResetToken"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/auth_verify_password_reset_token.go
+++ b/soracom/generated/cmd/auth_verify_password_reset_token.go
@@ -35,7 +35,7 @@ func init() {
 var AuthVerifyPasswordResetTokenCmd = &cobra.Command{
 	Use:   "verify-password-reset-token",
 	Short: TRAPI("/auth/password_reset_token/verify:post:summary"),
-	Long:  TRAPI(`/auth/password_reset_token/verify:post:description`),
+	Long:  TRAPI(`/auth/password_reset_token/verify:post:description`) + "\n\n" + createLinkToAPIReference("Auth", "verifyPasswordResetToken"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/bills_export.go
+++ b/soracom/generated/cmd/bills_export.go
@@ -26,7 +26,7 @@ func init() {
 var BillsExportCmd = &cobra.Command{
 	Use:   "export",
 	Short: TRAPI("/bills/{yyyyMM}/export:post:summary"),
-	Long:  TRAPI(`/bills/{yyyyMM}/export:post:description`),
+	Long:  TRAPI(`/bills/{yyyyMM}/export:post:description`) + "\n\n" + createLinkToAPIReference("Billing", "exportBilling"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/bills_export_latest.go
+++ b/soracom/generated/cmd/bills_export_latest.go
@@ -21,7 +21,7 @@ func init() {
 var BillsExportLatestCmd = &cobra.Command{
 	Use:   "export-latest",
 	Short: TRAPI("/bills/latest/export:post:summary"),
-	Long:  TRAPI(`/bills/latest/export:post:description`),
+	Long:  TRAPI(`/bills/latest/export:post:description`) + "\n\n" + createLinkToAPIReference("Billing", "exportLatestBilling"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/bills_get.go
+++ b/soracom/generated/cmd/bills_get.go
@@ -21,7 +21,7 @@ func init() {
 var BillsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/bills/{yyyyMM}:get:summary"),
-	Long:  TRAPI(`/bills/{yyyyMM}:get:description`),
+	Long:  TRAPI(`/bills/{yyyyMM}:get:description`) + "\n\n" + createLinkToAPIReference("Billing", "getBilling"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/bills_get_daily.go
+++ b/soracom/generated/cmd/bills_get_daily.go
@@ -21,7 +21,7 @@ func init() {
 var BillsGetDailyCmd = &cobra.Command{
 	Use:   "get-daily",
 	Short: TRAPI("/bills/{yyyyMM}/daily:get:summary"),
-	Long:  TRAPI(`/bills/{yyyyMM}/daily:get:description`),
+	Long:  TRAPI(`/bills/{yyyyMM}/daily:get:description`) + "\n\n" + createLinkToAPIReference("Billing", "getBillingPerDay"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/bills_get_latest.go
+++ b/soracom/generated/cmd/bills_get_latest.go
@@ -17,7 +17,7 @@ func init() {
 var BillsGetLatestCmd = &cobra.Command{
 	Use:   "get-latest",
 	Short: TRAPI("/bills/latest:get:summary"),
-	Long:  TRAPI(`/bills/latest:get:description`),
+	Long:  TRAPI(`/bills/latest:get:description`) + "\n\n" + createLinkToAPIReference("Billing", "getLatestBilling"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/bills_list.go
+++ b/soracom/generated/cmd/bills_list.go
@@ -17,7 +17,7 @@ func init() {
 var BillsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/bills:get:summary"),
-	Long:  TRAPI(`/bills:get:description`),
+	Long:  TRAPI(`/bills:get:description`) + "\n\n" + createLinkToAPIReference("Billing", "getBillingHistory"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/cell_locations_batch_get.go
+++ b/soracom/generated/cmd/cell_locations_batch_get.go
@@ -30,7 +30,7 @@ func init() {
 var CellLocationsBatchGetCmd = &cobra.Command{
 	Use:   "batch-get",
 	Short: TRAPI("/cell_locations:post:summary"),
-	Long:  TRAPI(`/cell_locations:post:description`),
+	Long:  TRAPI(`/cell_locations:post:description`) + "\n\n" + createLinkToAPIReference("CellLocation", "batchGetCellLocations"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/cell_locations_get.go
+++ b/soracom/generated/cmd/cell_locations_get.go
@@ -51,7 +51,7 @@ func init() {
 var CellLocationsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/cell_locations:get:summary"),
-	Long:  TRAPI(`/cell_locations:get:description`),
+	Long:  TRAPI(`/cell_locations:get:description`) + "\n\n" + createLinkToAPIReference("CellLocation", "getCellLocation"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/coupons_confirm.go
+++ b/soracom/generated/cmd/coupons_confirm.go
@@ -21,7 +21,7 @@ func init() {
 var CouponsConfirmCmd = &cobra.Command{
 	Use:   "confirm",
 	Short: TRAPI("/coupons/{order_id}/confirm:put:summary"),
-	Long:  TRAPI(`/coupons/{order_id}/confirm:put:description`),
+	Long:  TRAPI(`/coupons/{order_id}/confirm:put:description`) + "\n\n" + createLinkToAPIReference("Order", "confirmCouponOrder"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/coupons_create.go
+++ b/soracom/generated/cmd/coupons_create.go
@@ -30,7 +30,7 @@ func init() {
 var CouponsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/coupons:post:summary"),
-	Long:  TRAPI(`/coupons:post:description`),
+	Long:  TRAPI(`/coupons:post:description`) + "\n\n" + createLinkToAPIReference("Order", "createCouponQuotation"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/coupons_list.go
+++ b/soracom/generated/cmd/coupons_list.go
@@ -17,7 +17,7 @@ func init() {
 var CouponsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/coupons:get:summary"),
-	Long:  TRAPI(`/coupons:get:description`),
+	Long:  TRAPI(`/coupons:get:description`) + "\n\n" + createLinkToAPIReference("Payment", "listCoupons"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/coupons_register.go
+++ b/soracom/generated/cmd/coupons_register.go
@@ -21,7 +21,7 @@ func init() {
 var CouponsRegisterCmd = &cobra.Command{
 	Use:   "register",
 	Short: TRAPI("/coupons/{coupon_code}/register:post:summary"),
-	Long:  TRAPI(`/coupons/{coupon_code}/register:post:description`),
+	Long:  TRAPI(`/coupons/{coupon_code}/register:post:description`) + "\n\n" + createLinkToAPIReference("Payment", "registerCoupon"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/credentials_create.go
+++ b/soracom/generated/cmd/credentials_create.go
@@ -40,7 +40,7 @@ func init() {
 var CredentialsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/credentials/{credentials_id}:post:summary"),
-	Long:  TRAPI(`/credentials/{credentials_id}:post:description`),
+	Long:  TRAPI(`/credentials/{credentials_id}:post:description`) + "\n\n" + createLinkToAPIReference("Credential", "createCredential"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/credentials_delete.go
+++ b/soracom/generated/cmd/credentials_delete.go
@@ -21,7 +21,7 @@ func init() {
 var CredentialsDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/credentials/{credentials_id}:delete:summary"),
-	Long:  TRAPI(`/credentials/{credentials_id}:delete:description`),
+	Long:  TRAPI(`/credentials/{credentials_id}:delete:description`) + "\n\n" + createLinkToAPIReference("Credential", "deleteCredential"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/credentials_list.go
+++ b/soracom/generated/cmd/credentials_list.go
@@ -21,7 +21,7 @@ func init() {
 var CredentialsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/credentials:get:summary"),
-	Long:  TRAPI(`/credentials:get:description`),
+	Long:  TRAPI(`/credentials:get:description`) + "\n\n" + createLinkToAPIReference("Credential", "listCredentials"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/credentials_update.go
+++ b/soracom/generated/cmd/credentials_update.go
@@ -40,7 +40,7 @@ func init() {
 var CredentialsUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: TRAPI("/credentials/{credentials_id}:put:summary"),
-	Long:  TRAPI(`/credentials/{credentials_id}:put:description`),
+	Long:  TRAPI(`/credentials/{credentials_id}:put:description`) + "\n\n" + createLinkToAPIReference("Credential", "updateCredential"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/data_delete_entry.go
+++ b/soracom/generated/cmd/data_delete_entry.go
@@ -31,7 +31,7 @@ func init() {
 var DataDeleteEntryCmd = &cobra.Command{
 	Use:   "delete-entry",
 	Short: TRAPI("/data/{resource_type}/{resource_id}/{time}:delete:summary"),
-	Long:  TRAPI(`/data/{resource_type}/{resource_id}/{time}:delete:description`),
+	Long:  TRAPI(`/data/{resource_type}/{resource_id}/{time}:delete:description`) + "\n\n" + createLinkToAPIReference("DataEntry", "deleteDataEntry"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/data_get.go
+++ b/soracom/generated/cmd/data_get.go
@@ -56,7 +56,7 @@ func init() {
 var DataGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/subscribers/{imsi}/data:get:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/data:get:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/data:get:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "getDataFromSubscriber"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/data_get_entries.go
+++ b/soracom/generated/cmd/data_get_entries.go
@@ -61,7 +61,7 @@ func init() {
 var DataGetEntriesCmd = &cobra.Command{
 	Use:   "get-entries",
 	Short: TRAPI("/data/{resource_type}/{resource_id}:get:summary"),
-	Long:  TRAPI(`/data/{resource_type}/{resource_id}:get:description`),
+	Long:  TRAPI(`/data/{resource_type}/{resource_id}:get:description`) + "\n\n" + createLinkToAPIReference("DataEntry", "getDataEntries"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/data_get_entry.go
+++ b/soracom/generated/cmd/data_get_entry.go
@@ -31,7 +31,7 @@ func init() {
 var DataGetEntryCmd = &cobra.Command{
 	Use:   "get-entry",
 	Short: TRAPI("/data/{resource_type}/{resource_id}/{time}:get:summary"),
-	Long:  TRAPI(`/data/{resource_type}/{resource_id}/{time}:get:description`),
+	Long:  TRAPI(`/data/{resource_type}/{resource_id}/{time}:get:description`) + "\n\n" + createLinkToAPIReference("DataEntry", "getDataEntry"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/data_list_source_resources.go
+++ b/soracom/generated/cmd/data_list_source_resources.go
@@ -41,7 +41,7 @@ func init() {
 var DataListSourceResourcesCmd = &cobra.Command{
 	Use:   "list-source-resources",
 	Short: TRAPI("/data/resources:get:summary"),
-	Long:  TRAPI(`/data/resources:get:description`),
+	Long:  TRAPI(`/data/resources:get:description`) + "\n\n" + createLinkToAPIReference("DataEntry", "listDataSourceResources"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_create.go
+++ b/soracom/generated/cmd/devices_create.go
@@ -95,7 +95,7 @@ func init() {
 var DevicesCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/devices:post:summary"),
-	Long:  TRAPI(`/devices:post:description`),
+	Long:  TRAPI(`/devices:post:description`) + "\n\n" + createLinkToAPIReference("Device", "createDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_create_object_model.go
+++ b/soracom/generated/cmd/devices_create_object_model.go
@@ -60,7 +60,7 @@ func init() {
 var DevicesCreateObjectModelCmd = &cobra.Command{
 	Use:   "create-object-model",
 	Short: TRAPI("/device_object_models:post:summary"),
-	Long:  TRAPI(`/device_object_models:post:description`),
+	Long:  TRAPI(`/device_object_models:post:description`) + "\n\n" + createLinkToAPIReference("DeviceObjectModel", "createDeviceObjectModel"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_delete.go
+++ b/soracom/generated/cmd/devices_delete.go
@@ -21,7 +21,7 @@ func init() {
 var DevicesDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/devices/{device_id}:delete:summary"),
-	Long:  TRAPI(`/devices/{device_id}:delete:description`),
+	Long:  TRAPI(`/devices/{device_id}:delete:description`) + "\n\n" + createLinkToAPIReference("Device", "deleteDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_delete_device_tag.go
+++ b/soracom/generated/cmd/devices_delete_device_tag.go
@@ -26,7 +26,7 @@ func init() {
 var DevicesDeleteDeviceTagCmd = &cobra.Command{
 	Use:   "delete-device-tag",
 	Short: TRAPI("/devices/{device_id}/tags/{tag_name}:delete:summary"),
-	Long:  TRAPI(`/devices/{device_id}/tags/{tag_name}:delete:description`),
+	Long:  TRAPI(`/devices/{device_id}/tags/{tag_name}:delete:description`) + "\n\n" + createLinkToAPIReference("Device", "deleteDeviceTag"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_delete_object_model.go
+++ b/soracom/generated/cmd/devices_delete_object_model.go
@@ -21,7 +21,7 @@ func init() {
 var DevicesDeleteObjectModelCmd = &cobra.Command{
 	Use:   "delete-object-model",
 	Short: TRAPI("/device_object_models/{model_id}:delete:summary"),
-	Long:  TRAPI(`/device_object_models/{model_id}:delete:description`),
+	Long:  TRAPI(`/device_object_models/{model_id}:delete:description`) + "\n\n" + createLinkToAPIReference("DeviceObjectModel", "deleteDeviceObjectModel"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_execute_resource.go
+++ b/soracom/generated/cmd/devices_execute_resource.go
@@ -45,7 +45,7 @@ func init() {
 var DevicesExecuteResourceCmd = &cobra.Command{
 	Use:   "execute-resource",
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/{resource}/execute:post:summary"),
-	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}/execute:post:description`),
+	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}/execute:post:description`) + "\n\n" + createLinkToAPIReference("Device", "executeDeviceResource"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_get.go
+++ b/soracom/generated/cmd/devices_get.go
@@ -26,7 +26,7 @@ func init() {
 var DevicesGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/devices/{device_id}:get:summary"),
-	Long:  TRAPI(`/devices/{device_id}:get:description`),
+	Long:  TRAPI(`/devices/{device_id}:get:description`) + "\n\n" + createLinkToAPIReference("Device", "getDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_get_data.go
+++ b/soracom/generated/cmd/devices_get_data.go
@@ -56,7 +56,7 @@ func init() {
 var DevicesGetDataCmd = &cobra.Command{
 	Use:   "get-data",
 	Short: TRAPI("/devices/{device_id}/data:get:summary"),
-	Long:  TRAPI(`/devices/{device_id}/data:get:description`),
+	Long:  TRAPI(`/devices/{device_id}/data:get:description`) + "\n\n" + createLinkToAPIReference("Device", "getDataFromDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_get_instance.go
+++ b/soracom/generated/cmd/devices_get_instance.go
@@ -36,7 +36,7 @@ func init() {
 var DevicesGetInstanceCmd = &cobra.Command{
 	Use:   "get-instance",
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}:get:summary"),
-	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}:get:description`),
+	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}:get:description`) + "\n\n" + createLinkToAPIReference("Device", "readDeviceResources"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_get_object_model.go
+++ b/soracom/generated/cmd/devices_get_object_model.go
@@ -21,7 +21,7 @@ func init() {
 var DevicesGetObjectModelCmd = &cobra.Command{
 	Use:   "get-object-model",
 	Short: TRAPI("/device_object_models/{model_id}:get:summary"),
-	Long:  TRAPI(`/device_object_models/{model_id}:get:description`),
+	Long:  TRAPI(`/device_object_models/{model_id}:get:description`) + "\n\n" + createLinkToAPIReference("DeviceObjectModel", "getDeviceObjectModel"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_get_resource.go
+++ b/soracom/generated/cmd/devices_get_resource.go
@@ -41,7 +41,7 @@ func init() {
 var DevicesGetResourceCmd = &cobra.Command{
 	Use:   "get-resource",
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/{resource}:get:summary"),
-	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}:get:description`),
+	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}:get:description`) + "\n\n" + createLinkToAPIReference("Device", "readDeviceResource"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_list.go
+++ b/soracom/generated/cmd/devices_list.go
@@ -51,7 +51,7 @@ func init() {
 var DevicesListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/devices:get:summary"),
-	Long:  TRAPI(`/devices:get:description`),
+	Long:  TRAPI(`/devices:get:description`) + "\n\n" + createLinkToAPIReference("Device", "listDevices"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_list_object_models.go
+++ b/soracom/generated/cmd/devices_list_object_models.go
@@ -36,7 +36,7 @@ func init() {
 var DevicesListObjectModelsCmd = &cobra.Command{
 	Use:   "list-object-models",
 	Short: TRAPI("/device_object_models:get:summary"),
-	Long:  TRAPI(`/device_object_models:get:description`),
+	Long:  TRAPI(`/device_object_models:get:description`) + "\n\n" + createLinkToAPIReference("DeviceObjectModel", "listDeviceObjectModels"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_observe_resource.go
+++ b/soracom/generated/cmd/devices_observe_resource.go
@@ -41,7 +41,7 @@ func init() {
 var DevicesObserveResourceCmd = &cobra.Command{
 	Use:   "observe-resource",
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/{resource}/observe:post:summary"),
-	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}/observe:post:description`),
+	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}/observe:post:description`) + "\n\n" + createLinkToAPIReference("Device", "observeDeviceResource"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_observe_resources.go
+++ b/soracom/generated/cmd/devices_observe_resources.go
@@ -36,7 +36,7 @@ func init() {
 var DevicesObserveResourcesCmd = &cobra.Command{
 	Use:   "observe-resources",
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/observe:post:summary"),
-	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/observe:post:description`),
+	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/observe:post:description`) + "\n\n" + createLinkToAPIReference("Device", "observeDeviceResources"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_put_device_tags.go
+++ b/soracom/generated/cmd/devices_put_device_tags.go
@@ -30,7 +30,7 @@ func init() {
 var DevicesPutDeviceTagsCmd = &cobra.Command{
 	Use:   "put-device-tags",
 	Short: TRAPI("/devices/{device_id}/tags:put:summary"),
-	Long:  TRAPI(`/devices/{device_id}/tags:put:description`),
+	Long:  TRAPI(`/devices/{device_id}/tags:put:description`) + "\n\n" + createLinkToAPIReference("Device", "putDeviceTags"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_put_resource.go
+++ b/soracom/generated/cmd/devices_put_resource.go
@@ -45,7 +45,7 @@ func init() {
 var DevicesPutResourceCmd = &cobra.Command{
 	Use:   "put-resource",
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/{resource}:put:summary"),
-	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}:put:description`),
+	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}:put:description`) + "\n\n" + createLinkToAPIReference("Device", "writeDeviceResource"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_set_group.go
+++ b/soracom/generated/cmd/devices_set_group.go
@@ -30,7 +30,7 @@ func init() {
 var DevicesSetGroupCmd = &cobra.Command{
 	Use:   "set-group",
 	Short: TRAPI("/devices/{device_id}/set_group:post:summary"),
-	Long:  TRAPI(`/devices/{device_id}/set_group:post:description`),
+	Long:  TRAPI(`/devices/{device_id}/set_group:post:description`) + "\n\n" + createLinkToAPIReference("Device", "setDeviceGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_set_object_model_scope.go
+++ b/soracom/generated/cmd/devices_set_object_model_scope.go
@@ -35,7 +35,7 @@ func init() {
 var DevicesSetObjectModelScopeCmd = &cobra.Command{
 	Use:   "set-object-model-scope",
 	Short: TRAPI("/device_object_models/{model_id}/set_scope:post:summary"),
-	Long:  TRAPI(`/device_object_models/{model_id}/set_scope:post:description`),
+	Long:  TRAPI(`/device_object_models/{model_id}/set_scope:post:description`) + "\n\n" + createLinkToAPIReference("DeviceObjectModel", "setDeviceObjectModelScope"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_unobserve_resource.go
+++ b/soracom/generated/cmd/devices_unobserve_resource.go
@@ -36,7 +36,7 @@ func init() {
 var DevicesUnobserveResourceCmd = &cobra.Command{
 	Use:   "unobserve-resource",
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/{resource}/unobserve:post:summary"),
-	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}/unobserve:post:description`),
+	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/{resource}/unobserve:post:description`) + "\n\n" + createLinkToAPIReference("Device", "unobserveDeviceResource"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_unobserve_resources.go
+++ b/soracom/generated/cmd/devices_unobserve_resources.go
@@ -31,7 +31,7 @@ func init() {
 var DevicesUnobserveResourcesCmd = &cobra.Command{
 	Use:   "unobserve-resources",
 	Short: TRAPI("/devices/{device_id}/{object}/{instance}/unobserve:post:summary"),
-	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/unobserve:post:description`),
+	Long:  TRAPI(`/devices/{device_id}/{object}/{instance}/unobserve:post:description`) + "\n\n" + createLinkToAPIReference("Device", "unobserveDeviceResources"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_unset_group.go
+++ b/soracom/generated/cmd/devices_unset_group.go
@@ -21,7 +21,7 @@ func init() {
 var DevicesUnsetGroupCmd = &cobra.Command{
 	Use:   "unset-group",
 	Short: TRAPI("/devices/{device_id}/unset_group:post:summary"),
-	Long:  TRAPI(`/devices/{device_id}/unset_group:post:description`),
+	Long:  TRAPI(`/devices/{device_id}/unset_group:post:description`) + "\n\n" + createLinkToAPIReference("Device", "unsetDeviceGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/devices_update_object_model.go
+++ b/soracom/generated/cmd/devices_update_object_model.go
@@ -65,7 +65,7 @@ func init() {
 var DevicesUpdateObjectModelCmd = &cobra.Command{
 	Use:   "update-object-model",
 	Short: TRAPI("/device_object_models/{model_id}:post:summary"),
-	Long:  TRAPI(`/device_object_models/{model_id}:post:description`),
+	Long:  TRAPI(`/device_object_models/{model_id}:post:description`) + "\n\n" + createLinkToAPIReference("DeviceObjectModel", "updateDeviceObjectModel"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/diagnostics_get.go
+++ b/soracom/generated/cmd/diagnostics_get.go
@@ -21,7 +21,7 @@ func init() {
 var DiagnosticsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/diagnostics/{diagnostic_id}:get:summary"),
-	Long:  TRAPI(`/diagnostics/{diagnostic_id}:get:description`),
+	Long:  TRAPI(`/diagnostics/{diagnostic_id}:get:description`) + "\n\n" + createLinkToAPIReference("Diagnostic", "getDiagnostic"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/diagnostics_send_request.go
+++ b/soracom/generated/cmd/diagnostics_send_request.go
@@ -55,7 +55,7 @@ func init() {
 var DiagnosticsSendRequestCmd = &cobra.Command{
 	Use:   "send-request",
 	Short: TRAPI("/diagnostics:post:summary"),
-	Long:  TRAPI(`/diagnostics:post:description`),
+	Long:  TRAPI(`/diagnostics:post:description`) + "\n\n" + createLinkToAPIReference("Diagnostic", "sendDiagnosticRequest"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/emails_delete.go
+++ b/soracom/generated/cmd/emails_delete.go
@@ -26,7 +26,7 @@ func init() {
 var EmailsDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/operators/{operator_id}/emails/{email_id}:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/emails/{email_id}:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/emails/{email_id}:delete:description`) + "\n\n" + createLinkToAPIReference("Email", "deleteEmail"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/emails_get.go
+++ b/soracom/generated/cmd/emails_get.go
@@ -26,7 +26,7 @@ func init() {
 var EmailsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/operators/{operator_id}/emails/{email_id}:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/emails/{email_id}:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/emails/{email_id}:get:description`) + "\n\n" + createLinkToAPIReference("Email", "getEmail"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/emails_issue_add_email_token.go
+++ b/soracom/generated/cmd/emails_issue_add_email_token.go
@@ -35,7 +35,7 @@ func init() {
 var EmailsIssueAddEmailTokenCmd = &cobra.Command{
 	Use:   "issue-add-email-token",
 	Short: TRAPI("/operators/add_email_token/issue:post:summary"),
-	Long:  TRAPI(`/operators/add_email_token/issue:post:description`),
+	Long:  TRAPI(`/operators/add_email_token/issue:post:description`) + "\n\n" + createLinkToAPIReference("Email", "issueAddEmailToken"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/emails_list.go
+++ b/soracom/generated/cmd/emails_list.go
@@ -26,7 +26,7 @@ func init() {
 var EmailsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/operators/{operator_id}/emails:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/emails:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/emails:get:description`) + "\n\n" + createLinkToAPIReference("Email", "listEmails"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/emails_verify_add_email_token.go
+++ b/soracom/generated/cmd/emails_verify_add_email_token.go
@@ -30,7 +30,7 @@ func init() {
 var EmailsVerifyAddEmailTokenCmd = &cobra.Command{
 	Use:   "verify-add-email-token",
 	Short: TRAPI("/operators/add_email_token/verify:post:summary"),
-	Long:  TRAPI(`/operators/add_email_token/verify:post:description`),
+	Long:  TRAPI(`/operators/add_email_token/verify:post:description`) + "\n\n" + createLinkToAPIReference("Email", "verifyAddEmailToken"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/event_handlers_create.go
+++ b/soracom/generated/cmd/event_handlers_create.go
@@ -60,7 +60,7 @@ func init() {
 var EventHandlersCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/event_handlers:post:summary"),
-	Long:  TRAPI(`/event_handlers:post:description`),
+	Long:  TRAPI(`/event_handlers:post:description`) + "\n\n" + createLinkToAPIReference("EventHandler", "createEventHandler"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/event_handlers_delete.go
+++ b/soracom/generated/cmd/event_handlers_delete.go
@@ -21,7 +21,7 @@ func init() {
 var EventHandlersDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/event_handlers/{handler_id}:delete:summary"),
-	Long:  TRAPI(`/event_handlers/{handler_id}:delete:description`),
+	Long:  TRAPI(`/event_handlers/{handler_id}:delete:description`) + "\n\n" + createLinkToAPIReference("EventHandler", "deleteEventHandler"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/event_handlers_get.go
+++ b/soracom/generated/cmd/event_handlers_get.go
@@ -21,7 +21,7 @@ func init() {
 var EventHandlersGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/event_handlers/{handler_id}:get:summary"),
-	Long:  TRAPI(`/event_handlers/{handler_id}:get:description`),
+	Long:  TRAPI(`/event_handlers/{handler_id}:get:description`) + "\n\n" + createLinkToAPIReference("EventHandler", "getEventHandler"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/event_handlers_ignore.go
+++ b/soracom/generated/cmd/event_handlers_ignore.go
@@ -26,7 +26,7 @@ func init() {
 var EventHandlersIgnoreCmd = &cobra.Command{
 	Use:   "ignore",
 	Short: TRAPI("/event_handlers/{handler_id}/subscribers/{imsi}/ignore:post:summary"),
-	Long:  TRAPI(`/event_handlers/{handler_id}/subscribers/{imsi}/ignore:post:description`),
+	Long:  TRAPI(`/event_handlers/{handler_id}/subscribers/{imsi}/ignore:post:description`) + "\n\n" + createLinkToAPIReference("EventHandler", "setIgnoreEventHandler"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/event_handlers_list.go
+++ b/soracom/generated/cmd/event_handlers_list.go
@@ -26,7 +26,7 @@ func init() {
 var EventHandlersListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/event_handlers:get:summary"),
-	Long:  TRAPI(`/event_handlers:get:description`),
+	Long:  TRAPI(`/event_handlers:get:description`) + "\n\n" + createLinkToAPIReference("EventHandler", "listEventHandlers"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/event_handlers_list_for_subscriber.go
+++ b/soracom/generated/cmd/event_handlers_list_for_subscriber.go
@@ -26,7 +26,7 @@ func init() {
 var EventHandlersListForSubscriberCmd = &cobra.Command{
 	Use:   "list-for-subscriber",
 	Short: TRAPI("/event_handlers/subscribers/{imsi}:get:summary"),
-	Long:  TRAPI(`/event_handlers/subscribers/{imsi}:get:description`),
+	Long:  TRAPI(`/event_handlers/subscribers/{imsi}:get:description`) + "\n\n" + createLinkToAPIReference("EventHandler", "listEventHandlersBySubscriber"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/event_handlers_unignore.go
+++ b/soracom/generated/cmd/event_handlers_unignore.go
@@ -26,7 +26,7 @@ func init() {
 var EventHandlersUnignoreCmd = &cobra.Command{
 	Use:   "unignore",
 	Short: TRAPI("/event_handlers/{handler_id}/subscribers/{imsi}/ignore:delete:summary"),
-	Long:  TRAPI(`/event_handlers/{handler_id}/subscribers/{imsi}/ignore:delete:description`),
+	Long:  TRAPI(`/event_handlers/{handler_id}/subscribers/{imsi}/ignore:delete:description`) + "\n\n" + createLinkToAPIReference("EventHandler", "deleteIgnoreEventHandler"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/event_handlers_update.go
+++ b/soracom/generated/cmd/event_handlers_update.go
@@ -65,7 +65,7 @@ func init() {
 var EventHandlersUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: TRAPI("/event_handlers/{handler_id}:put:summary"),
-	Long:  TRAPI(`/event_handlers/{handler_id}:put:description`),
+	Long:  TRAPI(`/event_handlers/{handler_id}:put:description`) + "\n\n" + createLinkToAPIReference("EventHandler", "updateEventHandler"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/files_delete.go
+++ b/soracom/generated/cmd/files_delete.go
@@ -26,7 +26,7 @@ func init() {
 var FilesDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/files/{scope}/{path}:delete:summary"),
-	Long:  TRAPI(`/files/{scope}/{path}:delete:description`),
+	Long:  TRAPI(`/files/{scope}/{path}:delete:description`) + "\n\n" + createLinkToAPIReference("FileEntry", "deleteFile"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/files_delete_directory.go
+++ b/soracom/generated/cmd/files_delete_directory.go
@@ -26,7 +26,7 @@ func init() {
 var FilesDeleteDirectoryCmd = &cobra.Command{
 	Use:   "delete-directory",
 	Short: TRAPI("/files/{scope}/{path}/:delete:summary"),
-	Long:  TRAPI(`/files/{scope}/{path}/:delete:description`),
+	Long:  TRAPI(`/files/{scope}/{path}/:delete:description`) + "\n\n" + createLinkToAPIReference("FileEntry", "deleteDirectory"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/files_find.go
+++ b/soracom/generated/cmd/files_find.go
@@ -46,7 +46,7 @@ func init() {
 var FilesFindCmd = &cobra.Command{
 	Use:   "find",
 	Short: TRAPI("/files:get:summary"),
-	Long:  TRAPI(`/files:get:description`),
+	Long:  TRAPI(`/files:get:description`) + "\n\n" + createLinkToAPIReference("FileEntry", "findFiles"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/files_get.go
+++ b/soracom/generated/cmd/files_get.go
@@ -26,7 +26,7 @@ func init() {
 var FilesGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/files/{scope}/{path}:get:summary"),
-	Long:  TRAPI(`/files/{scope}/{path}:get:description`),
+	Long:  TRAPI(`/files/{scope}/{path}:get:description`) + "\n\n" + createLinkToAPIReference("FileEntry", "getFile"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/files_get_exported.go
+++ b/soracom/generated/cmd/files_get_exported.go
@@ -21,7 +21,7 @@ func init() {
 var FilesGetExportedCmd = &cobra.Command{
 	Use:   "get-exported",
 	Short: TRAPI("/files/exported/{exported_file_id}:get:summary"),
-	Long:  TRAPI(`/files/exported/{exported_file_id}:get:description`),
+	Long:  TRAPI(`/files/exported/{exported_file_id}:get:description`) + "\n\n" + createLinkToAPIReference("Files", "getExportedFile"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/files_get_metadata.go
+++ b/soracom/generated/cmd/files_get_metadata.go
@@ -26,7 +26,7 @@ func init() {
 var FilesGetMetadataCmd = &cobra.Command{
 	Use:   "get-metadata",
 	Short: TRAPI("/files/{scope}/{path}:head:summary"),
-	Long:  TRAPI(`/files/{scope}/{path}:head:description`),
+	Long:  TRAPI(`/files/{scope}/{path}:head:description`) + "\n\n" + createLinkToAPIReference("FileEntry", "getFileMetadata"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/files_list.go
+++ b/soracom/generated/cmd/files_list.go
@@ -46,7 +46,7 @@ func init() {
 var FilesListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/files/{scope}/{path}/:get:summary"),
-	Long:  TRAPI(`/files/{scope}/{path}/:get:description`),
+	Long:  TRAPI(`/files/{scope}/{path}/:get:description`) + "\n\n" + createLinkToAPIReference("FileEntry", "listFiles"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/files_put.go
+++ b/soracom/generated/cmd/files_put.go
@@ -40,7 +40,7 @@ func init() {
 var FilesPutCmd = &cobra.Command{
 	Use:   "put",
 	Short: TRAPI("/files/{scope}/{path}:put:summary"),
-	Long:  TRAPI(`/files/{scope}/{path}:put:description`),
+	Long:  TRAPI(`/files/{scope}/{path}:put:description`) + "\n\n" + createLinkToAPIReference("FileEntry", "putFile"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/gadgets_delete_tag.go
+++ b/soracom/generated/cmd/gadgets_delete_tag.go
@@ -31,7 +31,7 @@ func init() {
 var GadgetsDeleteTagCmd = &cobra.Command{
 	Use:   "delete-tag",
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/tags/{tag_name}:delete:summary"),
-	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/tags/{tag_name}:delete:description`),
+	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/tags/{tag_name}:delete:description`) + "\n\n" + createLinkToAPIReference("Gadget", "deleteGadgetTag"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/gadgets_disable_termination.go
+++ b/soracom/generated/cmd/gadgets_disable_termination.go
@@ -26,7 +26,7 @@ func init() {
 var GadgetsDisableTerminationCmd = &cobra.Command{
 	Use:   "disable-termination",
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/disable_termination:post:summary"),
-	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/disable_termination:post:description`),
+	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/disable_termination:post:description`) + "\n\n" + createLinkToAPIReference("Gadget", "disableTerminationOnGadget"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/gadgets_enable_termination.go
+++ b/soracom/generated/cmd/gadgets_enable_termination.go
@@ -26,7 +26,7 @@ func init() {
 var GadgetsEnableTerminationCmd = &cobra.Command{
 	Use:   "enable-termination",
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/enable_termination:post:summary"),
-	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/enable_termination:post:description`),
+	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/enable_termination:post:description`) + "\n\n" + createLinkToAPIReference("Gadget", "enableTerminationOnGadget"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/gadgets_get.go
+++ b/soracom/generated/cmd/gadgets_get.go
@@ -26,7 +26,7 @@ func init() {
 var GadgetsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}:get:summary"),
-	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}:get:description`),
+	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}:get:description`) + "\n\n" + createLinkToAPIReference("Gadget", "getGadget"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/gadgets_list.go
+++ b/soracom/generated/cmd/gadgets_list.go
@@ -56,7 +56,7 @@ func init() {
 var GadgetsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/gadgets:get:summary"),
-	Long:  TRAPI(`/gadgets:get:description`),
+	Long:  TRAPI(`/gadgets:get:description`) + "\n\n" + createLinkToAPIReference("Gadget", "listGadgets"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/gadgets_put_tags.go
+++ b/soracom/generated/cmd/gadgets_put_tags.go
@@ -35,7 +35,7 @@ func init() {
 var GadgetsPutTagsCmd = &cobra.Command{
 	Use:   "put-tags",
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/tags:put:summary"),
-	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/tags:put:description`),
+	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/tags:put:description`) + "\n\n" + createLinkToAPIReference("Gadget", "putGadgetTags"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/gadgets_register.go
+++ b/soracom/generated/cmd/gadgets_register.go
@@ -35,7 +35,7 @@ func init() {
 var GadgetsRegisterCmd = &cobra.Command{
 	Use:   "register",
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/register:post:summary"),
-	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/register:post:description`),
+	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/register:post:description`) + "\n\n" + createLinkToAPIReference("Gadget", "registerGadget"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/gadgets_set_group.go
+++ b/soracom/generated/cmd/gadgets_set_group.go
@@ -55,7 +55,7 @@ func init() {
 var GadgetsSetGroupCmd = &cobra.Command{
 	Use:   "set-group",
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/set_group:post:summary"),
-	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/set_group:post:description`),
+	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/set_group:post:description`) + "\n\n" + createLinkToAPIReference("Gadget", "setGadgetGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/gadgets_terminate.go
+++ b/soracom/generated/cmd/gadgets_terminate.go
@@ -26,7 +26,7 @@ func init() {
 var GadgetsTerminateCmd = &cobra.Command{
 	Use:   "terminate",
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/terminate:post:summary"),
-	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/terminate:post:description`),
+	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/terminate:post:description`) + "\n\n" + createLinkToAPIReference("Gadget", "terminateGadget"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/gadgets_unset_group.go
+++ b/soracom/generated/cmd/gadgets_unset_group.go
@@ -26,7 +26,7 @@ func init() {
 var GadgetsUnsetGroupCmd = &cobra.Command{
 	Use:   "unset-group",
 	Short: TRAPI("/gadgets/{product_id}/{serial_number}/unset_group:post:summary"),
-	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/unset_group:post:description`),
+	Long:  TRAPI(`/gadgets/{product_id}/{serial_number}/unset_group:post:description`) + "\n\n" + createLinkToAPIReference("Gadget", "unsetGadgetGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/groups_create.go
+++ b/soracom/generated/cmd/groups_create.go
@@ -25,7 +25,7 @@ func init() {
 var GroupsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/groups:post:summary"),
-	Long:  TRAPI(`/groups:post:description`),
+	Long:  TRAPI(`/groups:post:description`) + "\n\n" + createLinkToAPIReference("Group", "createGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/groups_delete.go
+++ b/soracom/generated/cmd/groups_delete.go
@@ -21,7 +21,7 @@ func init() {
 var GroupsDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/groups/{group_id}:delete:summary"),
-	Long:  TRAPI(`/groups/{group_id}:delete:description`),
+	Long:  TRAPI(`/groups/{group_id}:delete:description`) + "\n\n" + createLinkToAPIReference("Group", "deleteGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/groups_delete_config.go
+++ b/soracom/generated/cmd/groups_delete_config.go
@@ -31,7 +31,7 @@ func init() {
 var GroupsDeleteConfigCmd = &cobra.Command{
 	Use:   "delete-config",
 	Short: TRAPI("/groups/{group_id}/configuration/{namespace}/{name}:delete:summary"),
-	Long:  TRAPI(`/groups/{group_id}/configuration/{namespace}/{name}:delete:description`),
+	Long:  TRAPI(`/groups/{group_id}/configuration/{namespace}/{name}:delete:description`) + "\n\n" + createLinkToAPIReference("Group", "deleteConfigurationParameter"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/groups_delete_config_namespace.go
+++ b/soracom/generated/cmd/groups_delete_config_namespace.go
@@ -26,7 +26,7 @@ func init() {
 var GroupsDeleteConfigNamespaceCmd = &cobra.Command{
 	Use:   "delete-config-namespace",
 	Short: TRAPI("/groups/{group_id}/configuration/{namespace}:delete:summary"),
-	Long:  TRAPI(`/groups/{group_id}/configuration/{namespace}:delete:description`),
+	Long:  TRAPI(`/groups/{group_id}/configuration/{namespace}:delete:description`) + "\n\n" + createLinkToAPIReference("Group", "deleteConfigurationNamespace"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/groups_delete_tag.go
+++ b/soracom/generated/cmd/groups_delete_tag.go
@@ -26,7 +26,7 @@ func init() {
 var GroupsDeleteTagCmd = &cobra.Command{
 	Use:   "delete-tag",
 	Short: TRAPI("/groups/{group_id}/tags/{tag_name}:delete:summary"),
-	Long:  TRAPI(`/groups/{group_id}/tags/{tag_name}:delete:description`),
+	Long:  TRAPI(`/groups/{group_id}/tags/{tag_name}:delete:description`) + "\n\n" + createLinkToAPIReference("Group", "deleteGroupTag"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/groups_get.go
+++ b/soracom/generated/cmd/groups_get.go
@@ -21,7 +21,7 @@ func init() {
 var GroupsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/groups/{group_id}:get:summary"),
-	Long:  TRAPI(`/groups/{group_id}:get:description`),
+	Long:  TRAPI(`/groups/{group_id}:get:description`) + "\n\n" + createLinkToAPIReference("Group", "getGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/groups_list.go
+++ b/soracom/generated/cmd/groups_list.go
@@ -51,7 +51,7 @@ func init() {
 var GroupsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/groups:get:summary"),
-	Long:  TRAPI(`/groups:get:description`),
+	Long:  TRAPI(`/groups:get:description`) + "\n\n" + createLinkToAPIReference("Group", "listGroups"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/groups_list_subscribers.go
+++ b/soracom/generated/cmd/groups_list_subscribers.go
@@ -36,7 +36,7 @@ func init() {
 var GroupsListSubscribersCmd = &cobra.Command{
 	Use:   "list-subscribers",
 	Short: TRAPI("/groups/{group_id}/subscribers:get:summary"),
-	Long:  TRAPI(`/groups/{group_id}/subscribers:get:description`),
+	Long:  TRAPI(`/groups/{group_id}/subscribers:get:description`) + "\n\n" + createLinkToAPIReference("Group", "listSubscribersInGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/groups_put_config.go
+++ b/soracom/generated/cmd/groups_put_config.go
@@ -35,7 +35,7 @@ func init() {
 var GroupsPutConfigCmd = &cobra.Command{
 	Use:   "put-config",
 	Short: TRAPI("/groups/{group_id}/configuration/{namespace}:put:summary"),
-	Long:  TRAPI(`/groups/{group_id}/configuration/{namespace}:put:description`),
+	Long:  TRAPI(`/groups/{group_id}/configuration/{namespace}:put:description`) + "\n\n" + createLinkToAPIReference("Group", "putConfigurationParameters"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/groups_put_tags.go
+++ b/soracom/generated/cmd/groups_put_tags.go
@@ -30,7 +30,7 @@ func init() {
 var GroupsPutTagsCmd = &cobra.Command{
 	Use:   "put-tags",
 	Short: TRAPI("/groups/{group_id}/tags:put:summary"),
-	Long:  TRAPI(`/groups/{group_id}/tags:put:description`),
+	Long:  TRAPI(`/groups/{group_id}/tags:put:description`) + "\n\n" + createLinkToAPIReference("Group", "putGroupTags"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_create_user.go
+++ b/soracom/generated/cmd/lagoon_create_user.go
@@ -40,7 +40,7 @@ func init() {
 var LagoonCreateUserCmd = &cobra.Command{
 	Use:   "create-user",
 	Short: TRAPI("/lagoon/users:post:summary"),
-	Long:  TRAPI(`/lagoon/users:post:description`),
+	Long:  TRAPI(`/lagoon/users:post:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "createLagoonUser"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_dashboards_init_permissions.go
+++ b/soracom/generated/cmd/lagoon_dashboards_init_permissions.go
@@ -26,7 +26,7 @@ func init() {
 var LagoonDashboardsInitPermissionsCmd = &cobra.Command{
 	Use:   "init-permissions",
 	Short: TRAPI("/lagoon/dashboards/{dashboard_id}/permissions/init:post:summary"),
-	Long:  TRAPI(`/lagoon/dashboards/{dashboard_id}/permissions/init:post:description`),
+	Long:  TRAPI(`/lagoon/dashboards/{dashboard_id}/permissions/init:post:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "initializeLagoonDashboardPermissions"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_dashboards_list_permissions.go
+++ b/soracom/generated/cmd/lagoon_dashboards_list_permissions.go
@@ -26,7 +26,7 @@ func init() {
 var LagoonDashboardsListPermissionsCmd = &cobra.Command{
 	Use:   "list-permissions",
 	Short: TRAPI("/lagoon/dashboards/permissions:get:summary"),
-	Long:  TRAPI(`/lagoon/dashboards/permissions:get:description`),
+	Long:  TRAPI(`/lagoon/dashboards/permissions:get:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "listLagoonDashboardsPermissions"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_dashboards_update_permissions.go
+++ b/soracom/generated/cmd/lagoon_dashboards_update_permissions.go
@@ -35,7 +35,7 @@ func init() {
 var LagoonDashboardsUpdatePermissionsCmd = &cobra.Command{
 	Use:   "update-permissions",
 	Short: TRAPI("/lagoon/dashboards/{dashboard_id}/permissions:put:summary"),
-	Long:  TRAPI(`/lagoon/dashboards/{dashboard_id}/permissions:put:description`),
+	Long:  TRAPI(`/lagoon/dashboards/{dashboard_id}/permissions:put:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "updateLagoonDashboardPermissions"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_delete_user.go
+++ b/soracom/generated/cmd/lagoon_delete_user.go
@@ -21,7 +21,7 @@ func init() {
 var LagoonDeleteUserCmd = &cobra.Command{
 	Use:   "delete-user",
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}:delete:summary"),
-	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}:delete:description`),
+	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}:delete:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "deleteLagoonUser"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_get_image_link.go
+++ b/soracom/generated/cmd/lagoon_get_image_link.go
@@ -21,7 +21,7 @@ func init() {
 var LagoonGetImageLinkCmd = &cobra.Command{
 	Use:   "get-image-link",
 	Short: TRAPI("/lagoon/image/link:get:summary"),
-	Long:  TRAPI(`/lagoon/image/link:get:description`),
+	Long:  TRAPI(`/lagoon/image/link:get:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "getImageLink"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_license_packs_list_status.go
+++ b/soracom/generated/cmd/lagoon_license_packs_list_status.go
@@ -21,7 +21,7 @@ func init() {
 var LagoonLicensePacksListStatusCmd = &cobra.Command{
 	Use:   "list-status",
 	Short: TRAPI("/lagoon/license_packs:get:summary"),
-	Long:  TRAPI(`/lagoon/license_packs:get:description`),
+	Long:  TRAPI(`/lagoon/license_packs:get:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "listLagoonLicensePackStatus"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_license_packs_update.go
+++ b/soracom/generated/cmd/lagoon_license_packs_update.go
@@ -25,7 +25,7 @@ func init() {
 var LagoonLicensePacksUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: TRAPI("/lagoon/license_packs:put:summary"),
-	Long:  TRAPI(`/lagoon/license_packs:put:description`),
+	Long:  TRAPI(`/lagoon/license_packs:put:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "updateLagoonLicensePack"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_list_users.go
+++ b/soracom/generated/cmd/lagoon_list_users.go
@@ -26,7 +26,7 @@ func init() {
 var LagoonListUsersCmd = &cobra.Command{
 	Use:   "list-users",
 	Short: TRAPI("/lagoon/users:get:summary"),
-	Long:  TRAPI(`/lagoon/users:get:description`),
+	Long:  TRAPI(`/lagoon/users:get:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "listLagoonUsers"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_migration_get_info.go
+++ b/soracom/generated/cmd/lagoon_migration_get_info.go
@@ -32,7 +32,7 @@ func init() {
 var LagoonMigrationGetInfoCmd = &cobra.Command{
 	Use:   "get-info",
 	Short: TRAPI("/lagoon/migration:get:summary"),
-	Long:  TRAPI(`/lagoon/migration:get:description`),
+	Long:  TRAPI(`/lagoon/migration:get:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "getLagoonMigrationInfo"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lib.WarnfStderr(TRCLI("cli.deprecated-api") + "\n")
 

--- a/soracom/generated/cmd/lagoon_migration_migrate.go
+++ b/soracom/generated/cmd/lagoon_migration_migrate.go
@@ -27,7 +27,7 @@ func init() {
 var LagoonMigrationMigrateCmd = &cobra.Command{
 	Use:   "migrate",
 	Short: TRAPI("/lagoon/migration:post:summary"),
-	Long:  TRAPI(`/lagoon/migration:post:description`),
+	Long:  TRAPI(`/lagoon/migration:post:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "migrateLagoon"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lib.WarnfStderr(TRCLI("cli.deprecated-api") + "\n")
 

--- a/soracom/generated/cmd/lagoon_register.go
+++ b/soracom/generated/cmd/lagoon_register.go
@@ -35,7 +35,7 @@ func init() {
 var LagoonRegisterCmd = &cobra.Command{
 	Use:   "register",
 	Short: TRAPI("/lagoon/register:post:summary"),
-	Long:  TRAPI(`/lagoon/register:post:description`),
+	Long:  TRAPI(`/lagoon/register:post:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "registerLagoon"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_terminate.go
+++ b/soracom/generated/cmd/lagoon_terminate.go
@@ -17,7 +17,7 @@ func init() {
 var LagoonTerminateCmd = &cobra.Command{
 	Use:   "terminate",
 	Short: TRAPI("/lagoon/terminate:post:summary"),
-	Long:  TRAPI(`/lagoon/terminate:post:description`),
+	Long:  TRAPI(`/lagoon/terminate:post:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "terminateLagoon"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_update_user_email.go
+++ b/soracom/generated/cmd/lagoon_update_user_email.go
@@ -35,7 +35,7 @@ func init() {
 var LagoonUpdateUserEmailCmd = &cobra.Command{
 	Use:   "update-user-email",
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}/email:put:summary"),
-	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/email:put:description`),
+	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/email:put:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "updateLagoonUserEmail"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_update_user_password.go
+++ b/soracom/generated/cmd/lagoon_update_user_password.go
@@ -40,7 +40,7 @@ func init() {
 var LagoonUpdateUserPasswordCmd = &cobra.Command{
 	Use:   "update-user-password",
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}/password:put:summary"),
-	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/password:put:description`),
+	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/password:put:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "updateLagoonUserPassword"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_update_user_permission.go
+++ b/soracom/generated/cmd/lagoon_update_user_permission.go
@@ -35,7 +35,7 @@ func init() {
 var LagoonUpdateUserPermissionCmd = &cobra.Command{
 	Use:   "update-user-permission",
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}/permission:put:summary"),
-	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/permission:put:description`),
+	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/permission:put:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "updateLagoonUserPermission"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_updated_plan.go
+++ b/soracom/generated/cmd/lagoon_updated_plan.go
@@ -30,7 +30,7 @@ func init() {
 var LagoonUpdatedPlanCmd = &cobra.Command{
 	Use:   "updated-plan",
 	Short: TRAPI("/lagoon/plan:put:summary"),
-	Long:  TRAPI(`/lagoon/plan:put:description`),
+	Long:  TRAPI(`/lagoon/plan:put:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "updateLagoonPlan"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_users_create.go
+++ b/soracom/generated/cmd/lagoon_users_create.go
@@ -40,7 +40,7 @@ func init() {
 var LagoonUsersCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/lagoon/users:post:summary"),
-	Long:  TRAPI(`/lagoon/users:post:description`),
+	Long:  TRAPI(`/lagoon/users:post:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "createLagoonUser"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_users_delete.go
+++ b/soracom/generated/cmd/lagoon_users_delete.go
@@ -21,7 +21,7 @@ func init() {
 var LagoonUsersDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}:delete:summary"),
-	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}:delete:description`),
+	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}:delete:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "deleteLagoonUser"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_users_list.go
+++ b/soracom/generated/cmd/lagoon_users_list.go
@@ -26,7 +26,7 @@ func init() {
 var LagoonUsersListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/lagoon/users:get:summary"),
-	Long:  TRAPI(`/lagoon/users:get:description`),
+	Long:  TRAPI(`/lagoon/users:get:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "listLagoonUsers"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_users_update_email.go
+++ b/soracom/generated/cmd/lagoon_users_update_email.go
@@ -35,7 +35,7 @@ func init() {
 var LagoonUsersUpdateEmailCmd = &cobra.Command{
 	Use:   "update-email",
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}/email:put:summary"),
-	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/email:put:description`),
+	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/email:put:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "updateLagoonUserEmail"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_users_update_password.go
+++ b/soracom/generated/cmd/lagoon_users_update_password.go
@@ -40,7 +40,7 @@ func init() {
 var LagoonUsersUpdatePasswordCmd = &cobra.Command{
 	Use:   "update-password",
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}/password:put:summary"),
-	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/password:put:description`),
+	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/password:put:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "updateLagoonUserPassword"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lagoon_users_update_permission.go
+++ b/soracom/generated/cmd/lagoon_users_update_permission.go
@@ -35,7 +35,7 @@ func init() {
 var LagoonUsersUpdatePermissionCmd = &cobra.Command{
 	Use:   "update-permission",
 	Short: TRAPI("/lagoon/users/{lagoon_user_id}/permission:put:summary"),
-	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/permission:put:description`),
+	Long:  TRAPI(`/lagoon/users/{lagoon_user_id}/permission:put:description`) + "\n\n" + createLinkToAPIReference("Lagoon", "updateLagoonUserPermission"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lang_utils.go
+++ b/soracom/generated/cmd/lang_utils.go
@@ -280,3 +280,7 @@ func visit(data map[interface{}]interface{}, path string) string {
 		}
 	}
 }
+
+func createLinkToAPIReference(tag, operationID string) string {
+	return fmt.Sprintf(TRCLI("cli.refer-api-reference"), tag, operationID)
+}

--- a/soracom/generated/cmd/logout.go
+++ b/soracom/generated/cmd/logout.go
@@ -17,7 +17,7 @@ func init() {
 var LogoutCmd = &cobra.Command{
 	Use:   "logout",
 	Short: TRAPI("/auth/logout:post:summary"),
-	Long:  TRAPI(`/auth/logout:post:description`),
+	Long:  TRAPI(`/auth/logout:post:description`) + "\n\n" + createLinkToAPIReference("Auth", "logout"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/logs_get.go
+++ b/soracom/generated/cmd/logs_get.go
@@ -61,7 +61,7 @@ func init() {
 var LogsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/logs:get:summary"),
-	Long:  TRAPI(`/logs:get:description`),
+	Long:  TRAPI(`/logs:get:description`) + "\n\n" + createLinkToAPIReference("Log", "getLogs"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_devices_delete_tag.go
+++ b/soracom/generated/cmd/lora_devices_delete_tag.go
@@ -26,7 +26,7 @@ func init() {
 var LoraDevicesDeleteTagCmd = &cobra.Command{
 	Use:   "delete-tag",
 	Short: TRAPI("/lora_devices/{device_id}/tags/{tag_name}:delete:summary"),
-	Long:  TRAPI(`/lora_devices/{device_id}/tags/{tag_name}:delete:description`),
+	Long:  TRAPI(`/lora_devices/{device_id}/tags/{tag_name}:delete:description`) + "\n\n" + createLinkToAPIReference("LoraDevice", "deleteLoraDeviceTag"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_devices_disable_termination.go
+++ b/soracom/generated/cmd/lora_devices_disable_termination.go
@@ -21,7 +21,7 @@ func init() {
 var LoraDevicesDisableTerminationCmd = &cobra.Command{
 	Use:   "disable-termination",
 	Short: TRAPI("/lora_devices/{device_id}/disable_termination:post:summary"),
-	Long:  TRAPI(`/lora_devices/{device_id}/disable_termination:post:description`),
+	Long:  TRAPI(`/lora_devices/{device_id}/disable_termination:post:description`) + "\n\n" + createLinkToAPIReference("LoraDevice", "disableTerminationOnLoraDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_devices_enable_termination.go
+++ b/soracom/generated/cmd/lora_devices_enable_termination.go
@@ -21,7 +21,7 @@ func init() {
 var LoraDevicesEnableTerminationCmd = &cobra.Command{
 	Use:   "enable-termination",
 	Short: TRAPI("/lora_devices/{device_id}/enable_termination:post:summary"),
-	Long:  TRAPI(`/lora_devices/{device_id}/enable_termination:post:description`),
+	Long:  TRAPI(`/lora_devices/{device_id}/enable_termination:post:description`) + "\n\n" + createLinkToAPIReference("LoraDevice", "enableTerminationOnLoraDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_devices_get.go
+++ b/soracom/generated/cmd/lora_devices_get.go
@@ -21,7 +21,7 @@ func init() {
 var LoraDevicesGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/lora_devices/{device_id}:get:summary"),
-	Long:  TRAPI(`/lora_devices/{device_id}:get:description`),
+	Long:  TRAPI(`/lora_devices/{device_id}:get:description`) + "\n\n" + createLinkToAPIReference("LoraDevice", "getLoraDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_devices_get_data.go
+++ b/soracom/generated/cmd/lora_devices_get_data.go
@@ -56,7 +56,7 @@ func init() {
 var LoraDevicesGetDataCmd = &cobra.Command{
 	Use:   "get-data",
 	Short: TRAPI("/lora_devices/{device_id}/data:get:summary"),
-	Long:  TRAPI(`/lora_devices/{device_id}/data:get:description`),
+	Long:  TRAPI(`/lora_devices/{device_id}/data:get:description`) + "\n\n" + createLinkToAPIReference("LoraDevice", "getDataFromLoraDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_devices_list.go
+++ b/soracom/generated/cmd/lora_devices_list.go
@@ -51,7 +51,7 @@ func init() {
 var LoraDevicesListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/lora_devices:get:summary"),
-	Long:  TRAPI(`/lora_devices:get:description`),
+	Long:  TRAPI(`/lora_devices:get:description`) + "\n\n" + createLinkToAPIReference("LoraDevice", "listLoraDevices"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_devices_put_tags.go
+++ b/soracom/generated/cmd/lora_devices_put_tags.go
@@ -30,7 +30,7 @@ func init() {
 var LoraDevicesPutTagsCmd = &cobra.Command{
 	Use:   "put-tags",
 	Short: TRAPI("/lora_devices/{device_id}/tags:put:summary"),
-	Long:  TRAPI(`/lora_devices/{device_id}/tags:put:description`),
+	Long:  TRAPI(`/lora_devices/{device_id}/tags:put:description`) + "\n\n" + createLinkToAPIReference("LoraDevice", "putLoraDeviceTags"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_devices_register.go
+++ b/soracom/generated/cmd/lora_devices_register.go
@@ -40,7 +40,7 @@ func init() {
 var LoraDevicesRegisterCmd = &cobra.Command{
 	Use:   "register",
 	Short: TRAPI("/lora_devices/{device_id}/register:post:summary"),
-	Long:  TRAPI(`/lora_devices/{device_id}/register:post:description`),
+	Long:  TRAPI(`/lora_devices/{device_id}/register:post:description`) + "\n\n" + createLinkToAPIReference("LoraDevice", "registerLoraDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_devices_send_data.go
+++ b/soracom/generated/cmd/lora_devices_send_data.go
@@ -40,7 +40,7 @@ func init() {
 var LoraDevicesSendDataCmd = &cobra.Command{
 	Use:   "send-data",
 	Short: TRAPI("/lora_devices/{device_id}/data:post:summary"),
-	Long:  TRAPI(`/lora_devices/{device_id}/data:post:description`),
+	Long:  TRAPI(`/lora_devices/{device_id}/data:post:description`) + "\n\n" + createLinkToAPIReference("LoraDevice", "sendDataToLoraDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_devices_set_group.go
+++ b/soracom/generated/cmd/lora_devices_set_group.go
@@ -50,7 +50,7 @@ func init() {
 var LoraDevicesSetGroupCmd = &cobra.Command{
 	Use:   "set-group",
 	Short: TRAPI("/lora_devices/{device_id}/set_group:post:summary"),
-	Long:  TRAPI(`/lora_devices/{device_id}/set_group:post:description`),
+	Long:  TRAPI(`/lora_devices/{device_id}/set_group:post:description`) + "\n\n" + createLinkToAPIReference("LoraDevice", "setLoraDeviceGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_devices_terminate.go
+++ b/soracom/generated/cmd/lora_devices_terminate.go
@@ -21,7 +21,7 @@ func init() {
 var LoraDevicesTerminateCmd = &cobra.Command{
 	Use:   "terminate",
 	Short: TRAPI("/lora_devices/{device_id}/terminate:post:summary"),
-	Long:  TRAPI(`/lora_devices/{device_id}/terminate:post:description`),
+	Long:  TRAPI(`/lora_devices/{device_id}/terminate:post:description`) + "\n\n" + createLinkToAPIReference("LoraDevice", "terminateLoraDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_devices_unset_group.go
+++ b/soracom/generated/cmd/lora_devices_unset_group.go
@@ -21,7 +21,7 @@ func init() {
 var LoraDevicesUnsetGroupCmd = &cobra.Command{
 	Use:   "unset-group",
 	Short: TRAPI("/lora_devices/{device_id}/unset_group:post:summary"),
-	Long:  TRAPI(`/lora_devices/{device_id}/unset_group:post:description`),
+	Long:  TRAPI(`/lora_devices/{device_id}/unset_group:post:description`) + "\n\n" + createLinkToAPIReference("LoraDevice", "unsetLoraDeviceGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_gateways_delete_tag.go
+++ b/soracom/generated/cmd/lora_gateways_delete_tag.go
@@ -26,7 +26,7 @@ func init() {
 var LoraGatewaysDeleteTagCmd = &cobra.Command{
 	Use:   "delete-tag",
 	Short: TRAPI("/lora_gateways/{gateway_id}/tags/{tag_name}:delete:summary"),
-	Long:  TRAPI(`/lora_gateways/{gateway_id}/tags/{tag_name}:delete:description`),
+	Long:  TRAPI(`/lora_gateways/{gateway_id}/tags/{tag_name}:delete:description`) + "\n\n" + createLinkToAPIReference("LoraGateway", "deleteLoraGatewayTag"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_gateways_disable_termination.go
+++ b/soracom/generated/cmd/lora_gateways_disable_termination.go
@@ -21,7 +21,7 @@ func init() {
 var LoraGatewaysDisableTerminationCmd = &cobra.Command{
 	Use:   "disable-termination",
 	Short: TRAPI("/lora_gateways/{gateway_id}/disable_termination:post:summary"),
-	Long:  TRAPI(`/lora_gateways/{gateway_id}/disable_termination:post:description`),
+	Long:  TRAPI(`/lora_gateways/{gateway_id}/disable_termination:post:description`) + "\n\n" + createLinkToAPIReference("LoraGateway", "disableTerminationOnLoraGateway"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_gateways_enable_termination.go
+++ b/soracom/generated/cmd/lora_gateways_enable_termination.go
@@ -21,7 +21,7 @@ func init() {
 var LoraGatewaysEnableTerminationCmd = &cobra.Command{
 	Use:   "enable-termination",
 	Short: TRAPI("/lora_gateways/{gateway_id}/enable_termination:post:summary"),
-	Long:  TRAPI(`/lora_gateways/{gateway_id}/enable_termination:post:description`),
+	Long:  TRAPI(`/lora_gateways/{gateway_id}/enable_termination:post:description`) + "\n\n" + createLinkToAPIReference("LoraGateway", "enableTerminationOnLoraGateway"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_gateways_get.go
+++ b/soracom/generated/cmd/lora_gateways_get.go
@@ -21,7 +21,7 @@ func init() {
 var LoraGatewaysGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/lora_gateways/{gateway_id}:get:summary"),
-	Long:  TRAPI(`/lora_gateways/{gateway_id}:get:description`),
+	Long:  TRAPI(`/lora_gateways/{gateway_id}:get:description`) + "\n\n" + createLinkToAPIReference("LoraGateway", "getLoraGateway"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_gateways_list.go
+++ b/soracom/generated/cmd/lora_gateways_list.go
@@ -51,7 +51,7 @@ func init() {
 var LoraGatewaysListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/lora_gateways:get:summary"),
-	Long:  TRAPI(`/lora_gateways:get:description`),
+	Long:  TRAPI(`/lora_gateways:get:description`) + "\n\n" + createLinkToAPIReference("LoraGateway", "listLoraGateways"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_gateways_put_tags.go
+++ b/soracom/generated/cmd/lora_gateways_put_tags.go
@@ -30,7 +30,7 @@ func init() {
 var LoraGatewaysPutTagsCmd = &cobra.Command{
 	Use:   "put-tags",
 	Short: TRAPI("/lora_gateways/{gateway_id}/tags:put:summary"),
-	Long:  TRAPI(`/lora_gateways/{gateway_id}/tags:put:description`),
+	Long:  TRAPI(`/lora_gateways/{gateway_id}/tags:put:description`) + "\n\n" + createLinkToAPIReference("LoraGateway", "putLoraGatewayTags"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_gateways_set_network_set.go
+++ b/soracom/generated/cmd/lora_gateways_set_network_set.go
@@ -35,7 +35,7 @@ func init() {
 var LoraGatewaysSetNetworkSetCmd = &cobra.Command{
 	Use:   "set-network-set",
 	Short: TRAPI("/lora_gateways/{gateway_id}/set_network_set:post:summary"),
-	Long:  TRAPI(`/lora_gateways/{gateway_id}/set_network_set:post:description`),
+	Long:  TRAPI(`/lora_gateways/{gateway_id}/set_network_set:post:description`) + "\n\n" + createLinkToAPIReference("LoraGateway", "setLoraNetworkSet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_gateways_terminate.go
+++ b/soracom/generated/cmd/lora_gateways_terminate.go
@@ -21,7 +21,7 @@ func init() {
 var LoraGatewaysTerminateCmd = &cobra.Command{
 	Use:   "terminate",
 	Short: TRAPI("/lora_gateways/{gateway_id}/terminate:post:summary"),
-	Long:  TRAPI(`/lora_gateways/{gateway_id}/terminate:post:description`),
+	Long:  TRAPI(`/lora_gateways/{gateway_id}/terminate:post:description`) + "\n\n" + createLinkToAPIReference("LoraGateway", "terminateLoraGateway"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_gateways_unset_network_set.go
+++ b/soracom/generated/cmd/lora_gateways_unset_network_set.go
@@ -21,7 +21,7 @@ func init() {
 var LoraGatewaysUnsetNetworkSetCmd = &cobra.Command{
 	Use:   "unset-network-set",
 	Short: TRAPI("/lora_gateways/{gateway_id}/unset_network_set:post:summary"),
-	Long:  TRAPI(`/lora_gateways/{gateway_id}/unset_network_set:post:description`),
+	Long:  TRAPI(`/lora_gateways/{gateway_id}/unset_network_set:post:description`) + "\n\n" + createLinkToAPIReference("LoraGateway", "unsetLoraNetworkSet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_network_sets_add_permission.go
+++ b/soracom/generated/cmd/lora_network_sets_add_permission.go
@@ -35,7 +35,7 @@ func init() {
 var LoraNetworkSetsAddPermissionCmd = &cobra.Command{
 	Use:   "add-permission",
 	Short: TRAPI("/lora_network_sets/{ns_id}/add_permission:post:summary"),
-	Long:  TRAPI(`/lora_network_sets/{ns_id}/add_permission:post:description`),
+	Long:  TRAPI(`/lora_network_sets/{ns_id}/add_permission:post:description`) + "\n\n" + createLinkToAPIReference("LoraNetworkSet", "addPermissionToLoraNetworkSet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_network_sets_create.go
+++ b/soracom/generated/cmd/lora_network_sets_create.go
@@ -45,7 +45,7 @@ func init() {
 var LoraNetworkSetsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/lora_network_sets:post:summary"),
-	Long:  TRAPI(`/lora_network_sets:post:description`),
+	Long:  TRAPI(`/lora_network_sets:post:description`) + "\n\n" + createLinkToAPIReference("LoraNetworkSet", "createLoraNetworkSet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_network_sets_delete.go
+++ b/soracom/generated/cmd/lora_network_sets_delete.go
@@ -21,7 +21,7 @@ func init() {
 var LoraNetworkSetsDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/lora_network_sets/{ns_id}:delete:summary"),
-	Long:  TRAPI(`/lora_network_sets/{ns_id}:delete:description`),
+	Long:  TRAPI(`/lora_network_sets/{ns_id}:delete:description`) + "\n\n" + createLinkToAPIReference("LoraNetworkSet", "deleteLoraNetworkSet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_network_sets_delete_tag.go
+++ b/soracom/generated/cmd/lora_network_sets_delete_tag.go
@@ -26,7 +26,7 @@ func init() {
 var LoraNetworkSetsDeleteTagCmd = &cobra.Command{
 	Use:   "delete-tag",
 	Short: TRAPI("/lora_network_sets/{ns_id}/tags/{tag_name}:delete:summary"),
-	Long:  TRAPI(`/lora_network_sets/{ns_id}/tags/{tag_name}:delete:description`),
+	Long:  TRAPI(`/lora_network_sets/{ns_id}/tags/{tag_name}:delete:description`) + "\n\n" + createLinkToAPIReference("LoraNetworkSet", "deleteLoraNetworkSetTag"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_network_sets_get.go
+++ b/soracom/generated/cmd/lora_network_sets_get.go
@@ -21,7 +21,7 @@ func init() {
 var LoraNetworkSetsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/lora_network_sets/{ns_id}:get:summary"),
-	Long:  TRAPI(`/lora_network_sets/{ns_id}:get:description`),
+	Long:  TRAPI(`/lora_network_sets/{ns_id}:get:description`) + "\n\n" + createLinkToAPIReference("LoraNetworkSet", "getLoraNetworkSet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_network_sets_list.go
+++ b/soracom/generated/cmd/lora_network_sets_list.go
@@ -51,7 +51,7 @@ func init() {
 var LoraNetworkSetsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/lora_network_sets:get:summary"),
-	Long:  TRAPI(`/lora_network_sets:get:description`),
+	Long:  TRAPI(`/lora_network_sets:get:description`) + "\n\n" + createLinkToAPIReference("LoraNetworkSet", "listLoraNetworkSets"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_network_sets_list_gateways.go
+++ b/soracom/generated/cmd/lora_network_sets_list_gateways.go
@@ -41,7 +41,7 @@ func init() {
 var LoraNetworkSetsListGatewaysCmd = &cobra.Command{
 	Use:   "list-gateways",
 	Short: TRAPI("/lora_network_sets/{ns_id}/gateways:get:summary"),
-	Long:  TRAPI(`/lora_network_sets/{ns_id}/gateways:get:description`),
+	Long:  TRAPI(`/lora_network_sets/{ns_id}/gateways:get:description`) + "\n\n" + createLinkToAPIReference("LoraNetworkSet", "listGatewaysInLoraNetworkSet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/lora_network_sets_revoke_permission.go
+++ b/soracom/generated/cmd/lora_network_sets_revoke_permission.go
@@ -35,7 +35,7 @@ func init() {
 var LoraNetworkSetsRevokePermissionCmd = &cobra.Command{
 	Use:   "revoke-permission",
 	Short: TRAPI("/lora_network_sets/{ns_id}/revoke_permission:post:summary"),
-	Long:  TRAPI(`/lora_network_sets/{ns_id}/revoke_permission:post:description`),
+	Long:  TRAPI(`/lora_network_sets/{ns_id}/revoke_permission:post:description`) + "\n\n" + createLinkToAPIReference("LoraNetworkSet", "revokePermissionFromLoraNetworkSet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_add_contract.go
+++ b/soracom/generated/cmd/operator_add_contract.go
@@ -35,7 +35,7 @@ func init() {
 var OperatorAddContractCmd = &cobra.Command{
 	Use:   "add-contract",
 	Short: TRAPI("/operators/{operator_id}/contracts:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/contracts:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/contracts:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "addOperatorContract"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_add_coverage_type.go
+++ b/soracom/generated/cmd/operator_add_coverage_type.go
@@ -26,7 +26,7 @@ func init() {
 var OperatorAddCoverageTypeCmd = &cobra.Command{
 	Use:   "add-coverage-type",
 	Short: TRAPI("/operators/{operator_id}/coverage_type/{coverage_type}:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/coverage_type/{coverage_type}:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/coverage_type/{coverage_type}:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "addCoverageType"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_auth_keys_delete.go
+++ b/soracom/generated/cmd/operator_auth_keys_delete.go
@@ -26,7 +26,7 @@ func init() {
 var OperatorAuthKeysDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/operators/{operator_id}/auth_keys/{auth_key_id}:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/auth_keys/{auth_key_id}:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/auth_keys/{auth_key_id}:delete:description`) + "\n\n" + createLinkToAPIReference("Operator", "deleteOperatorAuthKey"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_auth_keys_generate.go
+++ b/soracom/generated/cmd/operator_auth_keys_generate.go
@@ -21,7 +21,7 @@ func init() {
 var OperatorAuthKeysGenerateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: TRAPI("/operators/{operator_id}/auth_keys:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/auth_keys:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/auth_keys:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "generateOperatorAuthKey"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_auth_keys_list.go
+++ b/soracom/generated/cmd/operator_auth_keys_list.go
@@ -26,7 +26,7 @@ func init() {
 var OperatorAuthKeysListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/operators/{operator_id}/auth_keys:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/auth_keys:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/auth_keys:get:description`) + "\n\n" + createLinkToAPIReference("Operator", "listOperatorAuthKeys"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_create.go
+++ b/soracom/generated/cmd/operator_create.go
@@ -35,7 +35,7 @@ func init() {
 var OperatorCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/operators:post:summary"),
-	Long:  TRAPI(`/operators:post:description`),
+	Long:  TRAPI(`/operators:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "createOperator"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_create_company_information.go
+++ b/soracom/generated/cmd/operator_create_company_information.go
@@ -90,7 +90,7 @@ func init() {
 var OperatorCreateCompanyInformationCmd = &cobra.Command{
 	Use:   "create-company-information",
 	Short: TRAPI("/operators/{operator_id}/company_information:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/company_information:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/company_information:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "createCompanyInformation"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_create_individual_information.go
+++ b/soracom/generated/cmd/operator_create_individual_information.go
@@ -75,7 +75,7 @@ func init() {
 var OperatorCreateIndividualInformationCmd = &cobra.Command{
 	Use:   "create-individual-information",
 	Short: TRAPI("/operators/{operator_id}/individual_information:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/individual_information:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/individual_information:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "createIndividualInformation"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_delete_contract.go
+++ b/soracom/generated/cmd/operator_delete_contract.go
@@ -26,7 +26,7 @@ func init() {
 var OperatorDeleteContractCmd = &cobra.Command{
 	Use:   "delete-contract",
 	Short: TRAPI("/operators/{operator_id}/contracts/{contract_name}:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/contracts/{contract_name}:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/contracts/{contract_name}:delete:description`) + "\n\n" + createLinkToAPIReference("Operator", "deleteOperatorContract"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_enable_mfa.go
+++ b/soracom/generated/cmd/operator_enable_mfa.go
@@ -21,7 +21,7 @@ func init() {
 var OperatorEnableMfaCmd = &cobra.Command{
 	Use:   "enable-mfa",
 	Short: TRAPI("/operators/{operator_id}/mfa:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/mfa:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/mfa:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "enableMFA"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_generate_api_token.go
+++ b/soracom/generated/cmd/operator_generate_api_token.go
@@ -35,7 +35,7 @@ func init() {
 var OperatorGenerateApiTokenCmd = &cobra.Command{
 	Use:   "generate-api-token",
 	Short: TRAPI("/operators/{operator_id}/token:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/token:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/token:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "generateAuthToken"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_get.go
+++ b/soracom/generated/cmd/operator_get.go
@@ -21,7 +21,7 @@ func init() {
 var OperatorGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/operators/{operator_id}:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}:get:description`) + "\n\n" + createLinkToAPIReference("Operator", "getOperator"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_get_company_information.go
+++ b/soracom/generated/cmd/operator_get_company_information.go
@@ -21,7 +21,7 @@ func init() {
 var OperatorGetCompanyInformationCmd = &cobra.Command{
 	Use:   "get-company-information",
 	Short: TRAPI("/operators/{operator_id}/company_information:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/company_information:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/company_information:get:description`) + "\n\n" + createLinkToAPIReference("Operator", "getCompanyInformation"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_get_individual_information.go
+++ b/soracom/generated/cmd/operator_get_individual_information.go
@@ -21,7 +21,7 @@ func init() {
 var OperatorGetIndividualInformationCmd = &cobra.Command{
 	Use:   "get-individual-information",
 	Short: TRAPI("/operators/{operator_id}/individual_information:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/individual_information:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/individual_information:get:description`) + "\n\n" + createLinkToAPIReference("Operator", "getIndividualInformation"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_get_mfa_status.go
+++ b/soracom/generated/cmd/operator_get_mfa_status.go
@@ -21,7 +21,7 @@ func init() {
 var OperatorGetMfaStatusCmd = &cobra.Command{
 	Use:   "get-mfa-status",
 	Short: TRAPI("/operators/{operator_id}/mfa:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/mfa:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/mfa:get:description`) + "\n\n" + createLinkToAPIReference("Operator", "getMFAStatus"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_get_support_token.go
+++ b/soracom/generated/cmd/operator_get_support_token.go
@@ -21,7 +21,7 @@ func init() {
 var OperatorGetSupportTokenCmd = &cobra.Command{
 	Use:   "get-support-token",
 	Short: TRAPI("/operators/{operator_id}/support/token:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/support/token:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/support/token:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "generateSupportToken"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_issue_mfa_revoke_token.go
+++ b/soracom/generated/cmd/operator_issue_mfa_revoke_token.go
@@ -35,7 +35,7 @@ func init() {
 var OperatorIssueMfaRevokeTokenCmd = &cobra.Command{
 	Use:   "issue-mfa-revoke-token",
 	Short: TRAPI("/operators/mfa_revoke_token/issue:post:summary"),
-	Long:  TRAPI(`/operators/mfa_revoke_token/issue:post:description`),
+	Long:  TRAPI(`/operators/mfa_revoke_token/issue:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "issueMFARevokingToken"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_revoke_mfa.go
+++ b/soracom/generated/cmd/operator_revoke_mfa.go
@@ -21,7 +21,7 @@ func init() {
 var OperatorRevokeMfaCmd = &cobra.Command{
 	Use:   "revoke-mfa",
 	Short: TRAPI("/operators/{operator_id}/mfa:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/mfa:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/mfa:delete:description`) + "\n\n" + createLinkToAPIReference("Operator", "revokeMFA"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_revoke_operator_auth_tokens.go
+++ b/soracom/generated/cmd/operator_revoke_operator_auth_tokens.go
@@ -21,7 +21,7 @@ func init() {
 var OperatorRevokeOperatorAuthTokensCmd = &cobra.Command{
 	Use:   "revoke-operator-auth-tokens",
 	Short: TRAPI("/operators/{operator_id}/tokens:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/tokens:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/tokens:delete:description`) + "\n\n" + createLinkToAPIReference("Operator", "revokeOperatorAuthTokens"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_update_company_information.go
+++ b/soracom/generated/cmd/operator_update_company_information.go
@@ -90,7 +90,7 @@ func init() {
 var OperatorUpdateCompanyInformationCmd = &cobra.Command{
 	Use:   "update-company-information",
 	Short: TRAPI("/operators/{operator_id}/company_information:put:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/company_information:put:description`),
+	Long:  TRAPI(`/operators/{operator_id}/company_information:put:description`) + "\n\n" + createLinkToAPIReference("Operator", "updateCompanyInformation"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_update_individual_information.go
+++ b/soracom/generated/cmd/operator_update_individual_information.go
@@ -75,7 +75,7 @@ func init() {
 var OperatorUpdateIndividualInformationCmd = &cobra.Command{
 	Use:   "update-individual-information",
 	Short: TRAPI("/operators/{operator_id}/individual_information:put:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/individual_information:put:description`),
+	Long:  TRAPI(`/operators/{operator_id}/individual_information:put:description`) + "\n\n" + createLinkToAPIReference("Operator", "updateIndividualInformation"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_update_password.go
+++ b/soracom/generated/cmd/operator_update_password.go
@@ -40,7 +40,7 @@ func init() {
 var OperatorUpdatePasswordCmd = &cobra.Command{
 	Use:   "update-password",
 	Short: TRAPI("/operators/{operator_id}/password:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/password:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/password:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "updateOperatorPassword"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_verify.go
+++ b/soracom/generated/cmd/operator_verify.go
@@ -30,7 +30,7 @@ func init() {
 var OperatorVerifyCmd = &cobra.Command{
 	Use:   "verify",
 	Short: TRAPI("/operators/verify:post:summary"),
-	Long:  TRAPI(`/operators/verify:post:description`),
+	Long:  TRAPI(`/operators/verify:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "verifyOperator"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_verify_mfa_otp.go
+++ b/soracom/generated/cmd/operator_verify_mfa_otp.go
@@ -35,7 +35,7 @@ func init() {
 var OperatorVerifyMfaOtpCmd = &cobra.Command{
 	Use:   "verify-mfa-otp",
 	Short: TRAPI("/operators/{operator_id}/mfa/verify:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/mfa/verify:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/mfa/verify:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "verifyMFA"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/operator_verify_mfa_revoke_token.go
+++ b/soracom/generated/cmd/operator_verify_mfa_revoke_token.go
@@ -45,7 +45,7 @@ func init() {
 var OperatorVerifyMfaRevokeTokenCmd = &cobra.Command{
 	Use:   "verify-mfa-revoke-token",
 	Short: TRAPI("/operators/mfa_revoke_token/verify:post:summary"),
-	Long:  TRAPI(`/operators/mfa_revoke_token/verify:post:description`),
+	Long:  TRAPI(`/operators/mfa_revoke_token/verify:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "verifyMFARevokingToken"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/orders_cancel.go
+++ b/soracom/generated/cmd/orders_cancel.go
@@ -21,7 +21,7 @@ func init() {
 var OrdersCancelCmd = &cobra.Command{
 	Use:   "cancel",
 	Short: TRAPI("/orders/{order_id}/cancel:put:summary"),
-	Long:  TRAPI(`/orders/{order_id}/cancel:put:description`),
+	Long:  TRAPI(`/orders/{order_id}/cancel:put:description`) + "\n\n" + createLinkToAPIReference("Order", "cancelOrder"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/orders_confirm.go
+++ b/soracom/generated/cmd/orders_confirm.go
@@ -21,7 +21,7 @@ func init() {
 var OrdersConfirmCmd = &cobra.Command{
 	Use:   "confirm",
 	Short: TRAPI("/orders/{order_id}/confirm:put:summary"),
-	Long:  TRAPI(`/orders/{order_id}/confirm:put:description`),
+	Long:  TRAPI(`/orders/{order_id}/confirm:put:description`) + "\n\n" + createLinkToAPIReference("Order", "confirmOrder"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/orders_create.go
+++ b/soracom/generated/cmd/orders_create.go
@@ -30,7 +30,7 @@ func init() {
 var OrdersCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/orders:post:summary"),
-	Long:  TRAPI(`/orders:post:description`),
+	Long:  TRAPI(`/orders:post:description`) + "\n\n" + createLinkToAPIReference("Order", "createQuotation"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/orders_get.go
+++ b/soracom/generated/cmd/orders_get.go
@@ -21,7 +21,7 @@ func init() {
 var OrdersGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/orders/{order_id}:get:summary"),
-	Long:  TRAPI(`/orders/{order_id}:get:description`),
+	Long:  TRAPI(`/orders/{order_id}:get:description`) + "\n\n" + createLinkToAPIReference("Order", "getOrder"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/orders_list.go
+++ b/soracom/generated/cmd/orders_list.go
@@ -17,7 +17,7 @@ func init() {
 var OrdersListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/orders:get:summary"),
-	Long:  TRAPI(`/orders:get:description`),
+	Long:  TRAPI(`/orders:get:description`) + "\n\n" + createLinkToAPIReference("Order", "listOrders"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/orders_list_subscribers.go
+++ b/soracom/generated/cmd/orders_list_subscribers.go
@@ -36,7 +36,7 @@ func init() {
 var OrdersListSubscribersCmd = &cobra.Command{
 	Use:   "list-subscribers",
 	Short: TRAPI("/orders/{order_id}/subscribers:get:summary"),
-	Long:  TRAPI(`/orders/{order_id}/subscribers:get:description`),
+	Long:  TRAPI(`/orders/{order_id}/subscribers:get:description`) + "\n\n" + createLinkToAPIReference("Order", "listOrderedSubscribers"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/orders_register_subscribers.go
+++ b/soracom/generated/cmd/orders_register_subscribers.go
@@ -21,7 +21,7 @@ func init() {
 var OrdersRegisterSubscribersCmd = &cobra.Command{
 	Use:   "register-subscribers",
 	Short: TRAPI("/orders/{order_id}/subscribers/register:post:summary"),
-	Long:  TRAPI(`/orders/{order_id}/subscribers/register:post:description`),
+	Long:  TRAPI(`/orders/{order_id}/subscribers/register:post:description`) + "\n\n" + createLinkToAPIReference("Order", "registerOrderedSim"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/payer_information_get.go
+++ b/soracom/generated/cmd/payer_information_get.go
@@ -17,7 +17,7 @@ func init() {
 var PayerInformationGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/payment_statements/payer_information:get:summary"),
-	Long:  TRAPI(`/payment_statements/payer_information:get:description`),
+	Long:  TRAPI(`/payment_statements/payer_information:get:description`) + "\n\n" + createLinkToAPIReference("Payment", "getPayerInformation"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/payer_information_register.go
+++ b/soracom/generated/cmd/payer_information_register.go
@@ -40,7 +40,7 @@ func init() {
 var PayerInformationRegisterCmd = &cobra.Command{
 	Use:   "register",
 	Short: TRAPI("/payment_statements/payer_information:post:summary"),
-	Long:  TRAPI(`/payment_statements/payer_information:post:description`),
+	Long:  TRAPI(`/payment_statements/payer_information:post:description`) + "\n\n" + createLinkToAPIReference("Payment", "registerPayerInformation"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/payment_history_get.go
+++ b/soracom/generated/cmd/payment_history_get.go
@@ -21,7 +21,7 @@ func init() {
 var PaymentHistoryGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/payment_history/transactions/{payment_transaction_id}:get:summary"),
-	Long:  TRAPI(`/payment_history/transactions/{payment_transaction_id}:get:description`),
+	Long:  TRAPI(`/payment_history/transactions/{payment_transaction_id}:get:description`) + "\n\n" + createLinkToAPIReference("Payment", "getPaymentTransaction"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/payment_methods_get_current.go
+++ b/soracom/generated/cmd/payment_methods_get_current.go
@@ -17,7 +17,7 @@ func init() {
 var PaymentMethodsGetCurrentCmd = &cobra.Command{
 	Use:   "get-current",
 	Short: TRAPI("/payment_methods/current:get:summary"),
-	Long:  TRAPI(`/payment_methods/current:get:description`),
+	Long:  TRAPI(`/payment_methods/current:get:description`) + "\n\n" + createLinkToAPIReference("Payment", "getPaymentMethod"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/payment_methods_reactivate_current.go
+++ b/soracom/generated/cmd/payment_methods_reactivate_current.go
@@ -17,7 +17,7 @@ func init() {
 var PaymentMethodsReactivateCurrentCmd = &cobra.Command{
 	Use:   "reactivate-current",
 	Short: TRAPI("/payment_methods/current/activate:post:summary"),
-	Long:  TRAPI(`/payment_methods/current/activate:post:description`),
+	Long:  TRAPI(`/payment_methods/current/activate:post:description`) + "\n\n" + createLinkToAPIReference("Payment", "activatePaymentMethod"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/payment_statements_export.go
+++ b/soracom/generated/cmd/payment_statements_export.go
@@ -26,7 +26,7 @@ func init() {
 var PaymentStatementsExportCmd = &cobra.Command{
 	Use:   "export",
 	Short: TRAPI("/payment_statements/{payment_statement_id}/export:post:summary"),
-	Long:  TRAPI(`/payment_statements/{payment_statement_id}/export:post:description`),
+	Long:  TRAPI(`/payment_statements/{payment_statement_id}/export:post:description`) + "\n\n" + createLinkToAPIReference("Payment", "exportPaymentStatement"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/payment_statements_list.go
+++ b/soracom/generated/cmd/payment_statements_list.go
@@ -17,7 +17,7 @@ func init() {
 var PaymentStatementsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/payment_statements:get:summary"),
-	Long:  TRAPI(`/payment_statements:get:description`),
+	Long:  TRAPI(`/payment_statements:get:description`) + "\n\n" + createLinkToAPIReference("Payment", "listPaymentStatements"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/port_mappings_create.go
+++ b/soracom/generated/cmd/port_mappings_create.go
@@ -35,7 +35,7 @@ func init() {
 var PortMappingsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/port_mappings:post:summary"),
-	Long:  TRAPI(`/port_mappings:post:description`),
+	Long:  TRAPI(`/port_mappings:post:description`) + "\n\n" + createLinkToAPIReference("PortMapping", "createPortMapping"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/port_mappings_delete.go
+++ b/soracom/generated/cmd/port_mappings_delete.go
@@ -26,7 +26,7 @@ func init() {
 var PortMappingsDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/port_mappings/{ip_address}/{port}:delete:summary"),
-	Long:  TRAPI(`/port_mappings/{ip_address}/{port}:delete:description`),
+	Long:  TRAPI(`/port_mappings/{ip_address}/{port}:delete:description`) + "\n\n" + createLinkToAPIReference("PortMapping", "deletePortMapping"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/port_mappings_get.go
+++ b/soracom/generated/cmd/port_mappings_get.go
@@ -21,7 +21,7 @@ func init() {
 var PortMappingsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/port_mappings/subscribers/{imsi}:get:summary"),
-	Long:  TRAPI(`/port_mappings/subscribers/{imsi}:get:description`),
+	Long:  TRAPI(`/port_mappings/subscribers/{imsi}:get:description`) + "\n\n" + createLinkToAPIReference("PortMapping", "listPortMappingsForSubscriber"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/port_mappings_list.go
+++ b/soracom/generated/cmd/port_mappings_list.go
@@ -36,7 +36,7 @@ func init() {
 var PortMappingsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/port_mappings:get:summary"),
-	Long:  TRAPI(`/port_mappings:get:description`),
+	Long:  TRAPI(`/port_mappings:get:description`) + "\n\n" + createLinkToAPIReference("PortMapping", "listPortMappings"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/products_list.go
+++ b/soracom/generated/cmd/products_list.go
@@ -17,7 +17,7 @@ func init() {
 var ProductsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/products:get:summary"),
-	Long:  TRAPI(`/products:get:description`),
+	Long:  TRAPI(`/products:get:description`) + "\n\n" + createLinkToAPIReference("Order", "listProducts"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/query_devices.go
+++ b/soracom/generated/cmd/query_devices.go
@@ -71,7 +71,7 @@ func init() {
 var QueryDevicesCmd = &cobra.Command{
 	Use:   "devices",
 	Short: TRAPI("/query/devices:get:summary"),
-	Long:  TRAPI(`/query/devices:get:description`),
+	Long:  TRAPI(`/query/devices:get:description`) + "\n\n" + createLinkToAPIReference("Query", "searchDevices"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/query_sigfox_devices.go
+++ b/soracom/generated/cmd/query_sigfox_devices.go
@@ -71,7 +71,7 @@ func init() {
 var QuerySigfoxDevicesCmd = &cobra.Command{
 	Use:   "sigfox-devices",
 	Short: TRAPI("/query/sigfox_devices:get:summary"),
-	Long:  TRAPI(`/query/sigfox_devices:get:description`),
+	Long:  TRAPI(`/query/sigfox_devices:get:description`) + "\n\n" + createLinkToAPIReference("Query", "searchSigfoxDevices"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/query_sims.go
+++ b/soracom/generated/cmd/query_sims.go
@@ -91,7 +91,7 @@ func init() {
 var QuerySimsCmd = &cobra.Command{
 	Use:   "sims",
 	Short: TRAPI("/query/sims:get:summary"),
-	Long:  TRAPI(`/query/sims:get:description`),
+	Long:  TRAPI(`/query/sims:get:description`) + "\n\n" + createLinkToAPIReference("Query", "searchSims"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/query_subscribers.go
+++ b/soracom/generated/cmd/query_subscribers.go
@@ -88,7 +88,7 @@ func init() {
 var QuerySubscribersCmd = &cobra.Command{
 	Use:   "subscribers",
 	Short: TRAPI("/query/subscribers:get:summary"),
-	Long:  TRAPI(`/query/subscribers:get:description`),
+	Long:  TRAPI(`/query/subscribers:get:description`) + "\n\n" + createLinkToAPIReference("Query", "searchSubscribers"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lib.WarnfStderr(TRCLI("cli.deprecated-api") + "\n")
 		lib.WarnfStderr(TRCLI("cli.alternative-api-suggestion")+"\n", "query sims")

--- a/soracom/generated/cmd/query_subscribers_traffic_volume_ranking.go
+++ b/soracom/generated/cmd/query_subscribers_traffic_volume_ranking.go
@@ -41,7 +41,7 @@ func init() {
 var QuerySubscribersTrafficVolumeRankingCmd = &cobra.Command{
 	Use:   "traffic-volume-ranking",
 	Short: TRAPI("/query/subscribers/traffic_volume/ranking:get:summary"),
-	Long:  TRAPI(`/query/subscribers/traffic_volume/ranking:get:description`),
+	Long:  TRAPI(`/query/subscribers/traffic_volume/ranking:get:description`) + "\n\n" + createLinkToAPIReference("Query", "searchSubscriberTrafficVolumeRanking"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/query_traffic_ranking.go
+++ b/soracom/generated/cmd/query_traffic_ranking.go
@@ -41,7 +41,7 @@ func init() {
 var QueryTrafficRankingCmd = &cobra.Command{
 	Use:   "traffic-ranking",
 	Short: TRAPI("/query/subscribers/traffic_volume/ranking:get:summary"),
-	Long:  TRAPI(`/query/subscribers/traffic_volume/ranking:get:description`),
+	Long:  TRAPI(`/query/subscribers/traffic_volume/ranking:get:description`) + "\n\n" + createLinkToAPIReference("Query", "searchSubscriberTrafficVolumeRanking"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/roles_create.go
+++ b/soracom/generated/cmd/roles_create.go
@@ -45,7 +45,7 @@ func init() {
 var RolesCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/operators/{operator_id}/roles/{role_id}:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}:post:description`) + "\n\n" + createLinkToAPIReference("Role", "createRole"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/roles_delete.go
+++ b/soracom/generated/cmd/roles_delete.go
@@ -26,7 +26,7 @@ func init() {
 var RolesDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/operators/{operator_id}/roles/{role_id}:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}:delete:description`) + "\n\n" + createLinkToAPIReference("Role", "deleteRole"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/roles_get.go
+++ b/soracom/generated/cmd/roles_get.go
@@ -26,7 +26,7 @@ func init() {
 var RolesGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/operators/{operator_id}/roles/{role_id}:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}:get:description`) + "\n\n" + createLinkToAPIReference("Role", "getRole"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/roles_list.go
+++ b/soracom/generated/cmd/roles_list.go
@@ -26,7 +26,7 @@ func init() {
 var RolesListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/operators/{operator_id}/roles:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/roles:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/roles:get:description`) + "\n\n" + createLinkToAPIReference("Role", "listRoles"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/roles_list_users.go
+++ b/soracom/generated/cmd/roles_list_users.go
@@ -31,7 +31,7 @@ func init() {
 var RolesListUsersCmd = &cobra.Command{
 	Use:   "list-users",
 	Short: TRAPI("/operators/{operator_id}/roles/{role_id}/users:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}/users:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}/users:get:description`) + "\n\n" + createLinkToAPIReference("Role", "listRoleAttachedUsers"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/roles_update.go
+++ b/soracom/generated/cmd/roles_update.go
@@ -45,7 +45,7 @@ func init() {
 var RolesUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: TRAPI("/operators/{operator_id}/roles/{role_id}:put:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}:put:description`),
+	Long:  TRAPI(`/operators/{operator_id}/roles/{role_id}:put:description`) + "\n\n" + createLinkToAPIReference("Role", "updateRole"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sandbox_coupons_create.go
+++ b/soracom/generated/cmd/sandbox_coupons_create.go
@@ -40,7 +40,7 @@ func init() {
 var SandboxCouponsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/sandbox/coupons/create:post:summary"),
-	Long:  TRAPI(`/sandbox/coupons/create:post:description`),
+	Long:  TRAPI(`/sandbox/coupons/create:post:description`) + "\n\n" + createLinkToAPIReference("Coupon", "sandboxCreateCoupon"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sandbox_init.go
+++ b/soracom/generated/cmd/sandbox_init.go
@@ -50,7 +50,7 @@ func init() {
 var SandboxInitCmd = &cobra.Command{
 	Use:   "init",
 	Short: TRAPI("/sandbox/init:post:summary"),
-	Long:  TRAPI(`/sandbox/init:post:description`),
+	Long:  TRAPI(`/sandbox/init:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "sandboxInitializeOperator"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sandbox_operators_delete.go
+++ b/soracom/generated/cmd/sandbox_operators_delete.go
@@ -21,7 +21,7 @@ func init() {
 var SandboxOperatorsDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/sandbox/operators/{operator_id}:delete:summary"),
-	Long:  TRAPI(`/sandbox/operators/{operator_id}:delete:description`),
+	Long:  TRAPI(`/sandbox/operators/{operator_id}:delete:description`) + "\n\n" + createLinkToAPIReference("Operator", "sandboxDeleteOperator"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sandbox_operators_get_signup_token.go
+++ b/soracom/generated/cmd/sandbox_operators_get_signup_token.go
@@ -40,7 +40,7 @@ func init() {
 var SandboxOperatorsGetSignupTokenCmd = &cobra.Command{
 	Use:   "get-signup-token",
 	Short: TRAPI("/sandbox/operators/token/{email}:post:summary"),
-	Long:  TRAPI(`/sandbox/operators/token/{email}:post:description`),
+	Long:  TRAPI(`/sandbox/operators/token/{email}:post:description`) + "\n\n" + createLinkToAPIReference("Operator", "sandboxGetSignupToken"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sandbox_orders_ship.go
+++ b/soracom/generated/cmd/sandbox_orders_ship.go
@@ -35,7 +35,7 @@ func init() {
 var SandboxOrdersShipCmd = &cobra.Command{
 	Use:   "ship",
 	Short: TRAPI("/sandbox/orders/ship:post:summary"),
-	Long:  TRAPI(`/sandbox/orders/ship:post:description`),
+	Long:  TRAPI(`/sandbox/orders/ship:post:description`) + "\n\n" + createLinkToAPIReference("Order", "sandboxShipOrder"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sandbox_stats_air_insert.go
+++ b/soracom/generated/cmd/sandbox_stats_air_insert.go
@@ -35,7 +35,7 @@ func init() {
 var SandboxStatsAirInsertCmd = &cobra.Command{
 	Use:   "insert",
 	Short: TRAPI("/sandbox/stats/air/subscribers/{imsi}:post:summary"),
-	Long:  TRAPI(`/sandbox/stats/air/subscribers/{imsi}:post:description`),
+	Long:  TRAPI(`/sandbox/stats/air/subscribers/{imsi}:post:description`) + "\n\n" + createLinkToAPIReference("Stats", "sandboxInsertAirStats"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sandbox_stats_beam_insert.go
+++ b/soracom/generated/cmd/sandbox_stats_beam_insert.go
@@ -35,7 +35,7 @@ func init() {
 var SandboxStatsBeamInsertCmd = &cobra.Command{
 	Use:   "insert",
 	Short: TRAPI("/sandbox/stats/beam/subscribers/{imsi}:post:summary"),
-	Long:  TRAPI(`/sandbox/stats/beam/subscribers/{imsi}:post:description`),
+	Long:  TRAPI(`/sandbox/stats/beam/subscribers/{imsi}:post:description`) + "\n\n" + createLinkToAPIReference("Stats", "sandboxInsertBeamStats"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sandbox_subscribers_create.go
+++ b/soracom/generated/cmd/sandbox_subscribers_create.go
@@ -30,7 +30,7 @@ func init() {
 var SandboxSubscribersCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/sandbox/subscribers/create:post:summary"),
-	Long:  TRAPI(`/sandbox/subscribers/create:post:description`),
+	Long:  TRAPI(`/sandbox/subscribers/create:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "sandboxCreateSubscriber"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/shipping_addresses_create.go
+++ b/soracom/generated/cmd/shipping_addresses_create.go
@@ -90,7 +90,7 @@ func init() {
 var ShippingAddressesCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/operators/{operator_id}/shipping_addresses:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses:post:description`) + "\n\n" + createLinkToAPIReference("ShippingAddress", "createShippingAddress"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/shipping_addresses_delete.go
+++ b/soracom/generated/cmd/shipping_addresses_delete.go
@@ -26,7 +26,7 @@ func init() {
 var ShippingAddressesDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/operators/{operator_id}/shipping_addresses/{shipping_address_id}:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses/{shipping_address_id}:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses/{shipping_address_id}:delete:description`) + "\n\n" + createLinkToAPIReference("ShippingAddress", "deleteShippingAddress"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/shipping_addresses_get.go
+++ b/soracom/generated/cmd/shipping_addresses_get.go
@@ -26,7 +26,7 @@ func init() {
 var ShippingAddressesGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/operators/{operator_id}/shipping_addresses/{shipping_address_id}:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses/{shipping_address_id}:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses/{shipping_address_id}:get:description`) + "\n\n" + createLinkToAPIReference("ShippingAddress", "getShippingAddress"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/shipping_addresses_list.go
+++ b/soracom/generated/cmd/shipping_addresses_list.go
@@ -21,7 +21,7 @@ func init() {
 var ShippingAddressesListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/operators/{operator_id}/shipping_addresses:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses:get:description`) + "\n\n" + createLinkToAPIReference("ShippingAddress", "listShippingAddresses"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/shipping_addresses_update.go
+++ b/soracom/generated/cmd/shipping_addresses_update.go
@@ -95,7 +95,7 @@ func init() {
 var ShippingAddressesUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: TRAPI("/operators/{operator_id}/shipping_addresses/{shipping_address_id}:put:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses/{shipping_address_id}:put:description`),
+	Long:  TRAPI(`/operators/{operator_id}/shipping_addresses/{shipping_address_id}:put:description`) + "\n\n" + createLinkToAPIReference("ShippingAddress", "updateShippingAddress"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sigfox_devices_delete_tag.go
+++ b/soracom/generated/cmd/sigfox_devices_delete_tag.go
@@ -26,7 +26,7 @@ func init() {
 var SigfoxDevicesDeleteTagCmd = &cobra.Command{
 	Use:   "delete-tag",
 	Short: TRAPI("/sigfox_devices/{device_id}/tags/{tag_name}:delete:summary"),
-	Long:  TRAPI(`/sigfox_devices/{device_id}/tags/{tag_name}:delete:description`),
+	Long:  TRAPI(`/sigfox_devices/{device_id}/tags/{tag_name}:delete:description`) + "\n\n" + createLinkToAPIReference("SigfoxDevice", "deleteSigfoxDeviceTag"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sigfox_devices_disable_termination.go
+++ b/soracom/generated/cmd/sigfox_devices_disable_termination.go
@@ -21,7 +21,7 @@ func init() {
 var SigfoxDevicesDisableTerminationCmd = &cobra.Command{
 	Use:   "disable-termination",
 	Short: TRAPI("/sigfox_devices/{device_id}/disable_termination:post:summary"),
-	Long:  TRAPI(`/sigfox_devices/{device_id}/disable_termination:post:description`),
+	Long:  TRAPI(`/sigfox_devices/{device_id}/disable_termination:post:description`) + "\n\n" + createLinkToAPIReference("SigfoxDevice", "disableTerminationOnSigfoxDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sigfox_devices_enable_termination.go
+++ b/soracom/generated/cmd/sigfox_devices_enable_termination.go
@@ -21,7 +21,7 @@ func init() {
 var SigfoxDevicesEnableTerminationCmd = &cobra.Command{
 	Use:   "enable-termination",
 	Short: TRAPI("/sigfox_devices/{device_id}/enable_termination:post:summary"),
-	Long:  TRAPI(`/sigfox_devices/{device_id}/enable_termination:post:description`),
+	Long:  TRAPI(`/sigfox_devices/{device_id}/enable_termination:post:description`) + "\n\n" + createLinkToAPIReference("SigfoxDevice", "enableTerminationOnSigfoxDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sigfox_devices_get.go
+++ b/soracom/generated/cmd/sigfox_devices_get.go
@@ -21,7 +21,7 @@ func init() {
 var SigfoxDevicesGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/sigfox_devices/{device_id}:get:summary"),
-	Long:  TRAPI(`/sigfox_devices/{device_id}:get:description`),
+	Long:  TRAPI(`/sigfox_devices/{device_id}:get:description`) + "\n\n" + createLinkToAPIReference("SigfoxDevice", "getSigfoxDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sigfox_devices_get_data.go
+++ b/soracom/generated/cmd/sigfox_devices_get_data.go
@@ -56,7 +56,7 @@ func init() {
 var SigfoxDevicesGetDataCmd = &cobra.Command{
 	Use:   "get-data",
 	Short: TRAPI("/sigfox_devices/{device_id}/data:get:summary"),
-	Long:  TRAPI(`/sigfox_devices/{device_id}/data:get:description`),
+	Long:  TRAPI(`/sigfox_devices/{device_id}/data:get:description`) + "\n\n" + createLinkToAPIReference("SigfoxDevice", "getDataFromSigfoxDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sigfox_devices_list.go
+++ b/soracom/generated/cmd/sigfox_devices_list.go
@@ -51,7 +51,7 @@ func init() {
 var SigfoxDevicesListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/sigfox_devices:get:summary"),
-	Long:  TRAPI(`/sigfox_devices:get:description`),
+	Long:  TRAPI(`/sigfox_devices:get:description`) + "\n\n" + createLinkToAPIReference("SigfoxDevice", "listSigfoxDevices"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sigfox_devices_put_tags.go
+++ b/soracom/generated/cmd/sigfox_devices_put_tags.go
@@ -30,7 +30,7 @@ func init() {
 var SigfoxDevicesPutTagsCmd = &cobra.Command{
 	Use:   "put-tags",
 	Short: TRAPI("/sigfox_devices/{device_id}/tags:put:summary"),
-	Long:  TRAPI(`/sigfox_devices/{device_id}/tags:put:description`),
+	Long:  TRAPI(`/sigfox_devices/{device_id}/tags:put:description`) + "\n\n" + createLinkToAPIReference("SigfoxDevice", "putSigfoxDeviceTags"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sigfox_devices_register.go
+++ b/soracom/generated/cmd/sigfox_devices_register.go
@@ -35,7 +35,7 @@ func init() {
 var SigfoxDevicesRegisterCmd = &cobra.Command{
 	Use:   "register",
 	Short: TRAPI("/sigfox_devices/{device_id}/register:post:summary"),
-	Long:  TRAPI(`/sigfox_devices/{device_id}/register:post:description`),
+	Long:  TRAPI(`/sigfox_devices/{device_id}/register:post:description`) + "\n\n" + createLinkToAPIReference("SigfoxDevice", "registerSigfoxDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sigfox_devices_send_data.go
+++ b/soracom/generated/cmd/sigfox_devices_send_data.go
@@ -35,7 +35,7 @@ func init() {
 var SigfoxDevicesSendDataCmd = &cobra.Command{
 	Use:   "send-data",
 	Short: TRAPI("/sigfox_devices/{device_id}/data:post:summary"),
-	Long:  TRAPI(`/sigfox_devices/{device_id}/data:post:description`),
+	Long:  TRAPI(`/sigfox_devices/{device_id}/data:post:description`) + "\n\n" + createLinkToAPIReference("SigfoxDevice", "sendDataToSigfoxDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sigfox_devices_set_group.go
+++ b/soracom/generated/cmd/sigfox_devices_set_group.go
@@ -50,7 +50,7 @@ func init() {
 var SigfoxDevicesSetGroupCmd = &cobra.Command{
 	Use:   "set-group",
 	Short: TRAPI("/sigfox_devices/{device_id}/set_group:post:summary"),
-	Long:  TRAPI(`/sigfox_devices/{device_id}/set_group:post:description`),
+	Long:  TRAPI(`/sigfox_devices/{device_id}/set_group:post:description`) + "\n\n" + createLinkToAPIReference("SigfoxDevice", "setSigfoxDeviceGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sigfox_devices_terminate.go
+++ b/soracom/generated/cmd/sigfox_devices_terminate.go
@@ -26,7 +26,7 @@ func init() {
 var SigfoxDevicesTerminateCmd = &cobra.Command{
 	Use:   "terminate",
 	Short: TRAPI("/sigfox_devices/{device_id}/terminate:post:summary"),
-	Long:  TRAPI(`/sigfox_devices/{device_id}/terminate:post:description`),
+	Long:  TRAPI(`/sigfox_devices/{device_id}/terminate:post:description`) + "\n\n" + createLinkToAPIReference("SigfoxDevice", "terminateSigfoxDevice"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sigfox_devices_unset_group.go
+++ b/soracom/generated/cmd/sigfox_devices_unset_group.go
@@ -21,7 +21,7 @@ func init() {
 var SigfoxDevicesUnsetGroupCmd = &cobra.Command{
 	Use:   "unset-group",
 	Short: TRAPI("/sigfox_devices/{device_id}/unset_group:post:summary"),
-	Long:  TRAPI(`/sigfox_devices/{device_id}/unset_group:post:description`),
+	Long:  TRAPI(`/sigfox_devices/{device_id}/unset_group:post:description`) + "\n\n" + createLinkToAPIReference("SigfoxDevice", "unsetSigfoxDeviceGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_activate.go
+++ b/soracom/generated/cmd/sims_activate.go
@@ -21,7 +21,7 @@ func init() {
 var SimsActivateCmd = &cobra.Command{
 	Use:   "activate",
 	Short: TRAPI("/sims/{sim_id}/activate:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/activate:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/activate:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "activateSim"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_add_subscription.go
+++ b/soracom/generated/cmd/sims_add_subscription.go
@@ -35,7 +35,7 @@ func init() {
 var SimsAddSubscriptionCmd = &cobra.Command{
 	Use:   "add-subscription",
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/add_subscription:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/add_subscription:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/add_subscription:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "addSubscription"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_attach_arc_credentials.go
+++ b/soracom/generated/cmd/sims_attach_arc_credentials.go
@@ -37,7 +37,7 @@ func init() {
 var SimsAttachArcCredentialsCmd = &cobra.Command{
 	Use:   "attach-arc-credentials",
 	Short: TRAPI("/sims/{sim_id}/credentials/arc:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/credentials/arc:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/credentials/arc:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "attachArcSimCredentials"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lib.WarnfStderr(TRCLI("cli.deprecated-api") + "\n")
 

--- a/soracom/generated/cmd/sims_cancel_subscription_container_download.go
+++ b/soracom/generated/cmd/sims_cancel_subscription_container_download.go
@@ -31,7 +31,7 @@ func init() {
 var SimsCancelSubscriptionContainerDownloadCmd = &cobra.Command{
 	Use:   "cancel-subscription-container-download",
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/subscribers/{imsi}/cancel_download:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscribers/{imsi}/cancel_download:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscribers/{imsi}/cancel_download:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "cancelSubscriptionContainerDownload"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_create.go
+++ b/soracom/generated/cmd/sims_create.go
@@ -35,7 +35,7 @@ func init() {
 var SimsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/sims:post:summary"),
-	Long:  TRAPI(`/sims:post:description`),
+	Long:  TRAPI(`/sims:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "createSim"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_create_arc_session.go
+++ b/soracom/generated/cmd/sims_create_arc_session.go
@@ -21,7 +21,7 @@ func init() {
 var SimsCreateArcSessionCmd = &cobra.Command{
 	Use:   "create-arc-session",
 	Short: TRAPI("/sims/{sim_id}/sessions/arc:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/sessions/arc:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/sessions/arc:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "createArcSession"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_create_packet_capture_session.go
+++ b/soracom/generated/cmd/sims_create_packet_capture_session.go
@@ -40,7 +40,7 @@ func init() {
 var SimsCreatePacketCaptureSessionCmd = &cobra.Command{
 	Use:   "create-packet-capture-session",
 	Short: TRAPI("/sims/{sim_id}/packet_capture_sessions:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "createSimPacketCaptureSession"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_deactivate.go
+++ b/soracom/generated/cmd/sims_deactivate.go
@@ -21,7 +21,7 @@ func init() {
 var SimsDeactivateCmd = &cobra.Command{
 	Use:   "deactivate",
 	Short: TRAPI("/sims/{sim_id}/deactivate:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/deactivate:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/deactivate:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "deactivateSim"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_delete_country_mapping_entry.go
+++ b/soracom/generated/cmd/sims_delete_country_mapping_entry.go
@@ -31,7 +31,7 @@ func init() {
 var SimsDeleteCountryMappingEntryCmd = &cobra.Command{
 	Use:   "delete-country-mapping-entry",
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/subscription_containers/country_mapping/{mcc}:delete:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscription_containers/country_mapping/{mcc}:delete:description`),
+	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscription_containers/country_mapping/{mcc}:delete:description`) + "\n\n" + createLinkToAPIReference("Sim", "deleteSubscriptionContainerCountryMappingEntry"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_delete_packet_capture_session.go
+++ b/soracom/generated/cmd/sims_delete_packet_capture_session.go
@@ -26,7 +26,7 @@ func init() {
 var SimsDeletePacketCaptureSessionCmd = &cobra.Command{
 	Use:   "delete-packet-capture-session",
 	Short: TRAPI("/sims/{sim_id}/packet_capture_sessions/{session_id}:delete:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions/{session_id}:delete:description`),
+	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions/{session_id}:delete:description`) + "\n\n" + createLinkToAPIReference("Sim", "deleteSimPacketCaptureSession"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_delete_session.go
+++ b/soracom/generated/cmd/sims_delete_session.go
@@ -21,7 +21,7 @@ func init() {
 var SimsDeleteSessionCmd = &cobra.Command{
 	Use:   "delete-session",
 	Short: TRAPI("/sims/{sim_id}/delete_session:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/delete_session:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/delete_session:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "deleteSimSession"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_delete_tag.go
+++ b/soracom/generated/cmd/sims_delete_tag.go
@@ -26,7 +26,7 @@ func init() {
 var SimsDeleteTagCmd = &cobra.Command{
 	Use:   "delete-tag",
 	Short: TRAPI("/sims/{sim_id}/tags/{tag_name}:delete:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/tags/{tag_name}:delete:description`),
+	Long:  TRAPI(`/sims/{sim_id}/tags/{tag_name}:delete:description`) + "\n\n" + createLinkToAPIReference("Sim", "deleteSimTag"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_disable_termination.go
+++ b/soracom/generated/cmd/sims_disable_termination.go
@@ -21,7 +21,7 @@ func init() {
 var SimsDisableTerminationCmd = &cobra.Command{
 	Use:   "disable-termination",
 	Short: TRAPI("/sims/{sim_id}/disable_termination:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/disable_termination:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/disable_termination:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "disableSimTermination"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_downlink_ping.go
+++ b/soracom/generated/cmd/sims_downlink_ping.go
@@ -40,7 +40,7 @@ func init() {
 var SimsDownlinkPingCmd = &cobra.Command{
 	Use:   "downlink-ping",
 	Short: TRAPI("/sims/{sim_id}/downlink/ping:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/downlink/ping:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/downlink/ping:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "simDownlinkPingToUserEquipment"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_enable_subscription_container.go
+++ b/soracom/generated/cmd/sims_enable_subscription_container.go
@@ -31,7 +31,7 @@ func init() {
 var SimsEnableSubscriptionContainerCmd = &cobra.Command{
 	Use:   "enable-subscription-container",
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/subscription_containers/{container_id}/enable:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscription_containers/{container_id}/enable:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscription_containers/{container_id}/enable:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "enableSubscriptionContainer"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_enable_termination.go
+++ b/soracom/generated/cmd/sims_enable_termination.go
@@ -21,7 +21,7 @@ func init() {
 var SimsEnableTerminationCmd = &cobra.Command{
 	Use:   "enable-termination",
 	Short: TRAPI("/sims/{sim_id}/enable_termination:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/enable_termination:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/enable_termination:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "enableSimTermination"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_get.go
+++ b/soracom/generated/cmd/sims_get.go
@@ -21,7 +21,7 @@ func init() {
 var SimsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/sims/{sim_id}:get:summary"),
-	Long:  TRAPI(`/sims/{sim_id}:get:description`),
+	Long:  TRAPI(`/sims/{sim_id}:get:description`) + "\n\n" + createLinkToAPIReference("Sim", "getSim"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_get_data.go
+++ b/soracom/generated/cmd/sims_get_data.go
@@ -56,7 +56,7 @@ func init() {
 var SimsGetDataCmd = &cobra.Command{
 	Use:   "get-data",
 	Short: TRAPI("/sims/{sim_id}/data:get:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/data:get:description`),
+	Long:  TRAPI(`/sims/{sim_id}/data:get:description`) + "\n\n" + createLinkToAPIReference("Sim", "getDataFromSim"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_get_packet_capture_session.go
+++ b/soracom/generated/cmd/sims_get_packet_capture_session.go
@@ -26,7 +26,7 @@ func init() {
 var SimsGetPacketCaptureSessionCmd = &cobra.Command{
 	Use:   "get-packet-capture-session",
 	Short: TRAPI("/sims/{sim_id}/packet_capture_sessions/{session_id}:get:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions/{session_id}:get:description`),
+	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions/{session_id}:get:description`) + "\n\n" + createLinkToAPIReference("Sim", "getSimPacketCaptureSession"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_list.go
+++ b/soracom/generated/cmd/sims_list.go
@@ -36,7 +36,7 @@ func init() {
 var SimsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/sims:get:summary"),
-	Long:  TRAPI(`/sims:get:description`),
+	Long:  TRAPI(`/sims:get:description`) + "\n\n" + createLinkToAPIReference("Sim", "listSims"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_list_packet_capture_sessions.go
+++ b/soracom/generated/cmd/sims_list_packet_capture_sessions.go
@@ -41,7 +41,7 @@ func init() {
 var SimsListPacketCaptureSessionsCmd = &cobra.Command{
 	Use:   "list-packet-capture-sessions",
 	Short: TRAPI("/sims/{sim_id}/packet_capture_sessions:get:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions:get:description`),
+	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions:get:description`) + "\n\n" + createLinkToAPIReference("Sim", "listSimPacketCaptureSessions"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_list_subscription_containers.go
+++ b/soracom/generated/cmd/sims_list_subscription_containers.go
@@ -26,7 +26,7 @@ func init() {
 var SimsListSubscriptionContainersCmd = &cobra.Command{
 	Use:   "list-subscription-containers",
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/subscription_containers:get:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscription_containers:get:description`),
+	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscription_containers:get:description`) + "\n\n" + createLinkToAPIReference("Sim", "listSubscriptionContainers"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_put_country_mapping_entries.go
+++ b/soracom/generated/cmd/sims_put_country_mapping_entries.go
@@ -35,7 +35,7 @@ func init() {
 var SimsPutCountryMappingEntriesCmd = &cobra.Command{
 	Use:   "put-country-mapping-entries",
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/subscription_containers/country_mapping:put:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscription_containers/country_mapping:put:description`),
+	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscription_containers/country_mapping:put:description`) + "\n\n" + createLinkToAPIReference("Sim", "putSubscriptionContainerCountryMappingEntries"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_put_tags.go
+++ b/soracom/generated/cmd/sims_put_tags.go
@@ -30,7 +30,7 @@ func init() {
 var SimsPutTagsCmd = &cobra.Command{
 	Use:   "put-tags",
 	Short: TRAPI("/sims/{sim_id}/tags:put:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/tags:put:description`),
+	Long:  TRAPI(`/sims/{sim_id}/tags:put:description`) + "\n\n" + createLinkToAPIReference("Sim", "putSimTags"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_register.go
+++ b/soracom/generated/cmd/sims_register.go
@@ -40,7 +40,7 @@ func init() {
 var SimsRegisterCmd = &cobra.Command{
 	Use:   "register",
 	Short: TRAPI("/sims/{sim_id}/register:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/register:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/register:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "registerSim"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_remove_arc_credentials.go
+++ b/soracom/generated/cmd/sims_remove_arc_credentials.go
@@ -23,7 +23,7 @@ func init() {
 var SimsRemoveArcCredentialsCmd = &cobra.Command{
 	Use:   "remove-arc-credentials",
 	Short: TRAPI("/sims/{sim_id}/credentials/arc:delete:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/credentials/arc:delete:description`),
+	Long:  TRAPI(`/sims/{sim_id}/credentials/arc:delete:description`) + "\n\n" + createLinkToAPIReference("Sim", "removeArcSimCredentials"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lib.WarnfStderr(TRCLI("cli.deprecated-api") + "\n")
 

--- a/soracom/generated/cmd/sims_renew_arc_credentials.go
+++ b/soracom/generated/cmd/sims_renew_arc_credentials.go
@@ -35,7 +35,7 @@ func init() {
 var SimsRenewArcCredentialsCmd = &cobra.Command{
 	Use:   "renew-arc-credentials",
 	Short: TRAPI("/sims/{sim_id}/credentials/arc:put:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/credentials/arc:put:description`),
+	Long:  TRAPI(`/sims/{sim_id}/credentials/arc:put:description`) + "\n\n" + createLinkToAPIReference("Sim", "renewArcSimCredentials"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_report_local_info.go
+++ b/soracom/generated/cmd/sims_report_local_info.go
@@ -21,7 +21,7 @@ func init() {
 var SimsReportLocalInfoCmd = &cobra.Command{
 	Use:   "report-local-info",
 	Short: TRAPI("/sims/{sim_id}/report_local_info:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/report_local_info:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/report_local_info:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "reportSimLocalInfo"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_send_sms.go
+++ b/soracom/generated/cmd/sims_send_sms.go
@@ -40,7 +40,7 @@ func init() {
 var SimsSendSmsCmd = &cobra.Command{
 	Use:   "send-sms",
 	Short: TRAPI("/sims/{sim_id}/send_sms:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/send_sms:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/send_sms:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "sendSmsToSim"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_session_events.go
+++ b/soracom/generated/cmd/sims_session_events.go
@@ -51,7 +51,7 @@ func init() {
 var SimsSessionEventsCmd = &cobra.Command{
 	Use:   "session-events",
 	Short: TRAPI("/sims/{sim_id}/events/sessions:get:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/events/sessions:get:description`),
+	Long:  TRAPI(`/sims/{sim_id}/events/sessions:get:description`) + "\n\n" + createLinkToAPIReference("Sim", "listSimSessionEvents"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_set_expiry_time.go
+++ b/soracom/generated/cmd/sims_set_expiry_time.go
@@ -40,7 +40,7 @@ func init() {
 var SimsSetExpiryTimeCmd = &cobra.Command{
 	Use:   "set-expiry-time",
 	Short: TRAPI("/sims/{sim_id}/set_expiry_time:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/set_expiry_time:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/set_expiry_time:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "setSimExpiryTime"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_set_group.go
+++ b/soracom/generated/cmd/sims_set_group.go
@@ -35,7 +35,7 @@ func init() {
 var SimsSetGroupCmd = &cobra.Command{
 	Use:   "set-group",
 	Short: TRAPI("/sims/{sim_id}/set_group:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/set_group:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/set_group:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "setSimGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_set_imei_lock.go
+++ b/soracom/generated/cmd/sims_set_imei_lock.go
@@ -35,7 +35,7 @@ func init() {
 var SimsSetImeiLockCmd = &cobra.Command{
 	Use:   "set-imei-lock",
 	Short: TRAPI("/sims/{sim_id}/set_imei_lock:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/set_imei_lock:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/set_imei_lock:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "setSimImeiLock"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_set_to_standby.go
+++ b/soracom/generated/cmd/sims_set_to_standby.go
@@ -21,7 +21,7 @@ func init() {
 var SimsSetToStandbyCmd = &cobra.Command{
 	Use:   "set-to-standby",
 	Short: TRAPI("/sims/{sim_id}/set_to_standby:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/set_to_standby:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/set_to_standby:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "setSimToStandby"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_stop_packet_capture_session.go
+++ b/soracom/generated/cmd/sims_stop_packet_capture_session.go
@@ -26,7 +26,7 @@ func init() {
 var SimsStopPacketCaptureSessionCmd = &cobra.Command{
 	Use:   "stop-packet-capture-session",
 	Short: TRAPI("/sims/{sim_id}/packet_capture_sessions/{session_id}/stop:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions/{session_id}/stop:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/packet_capture_sessions/{session_id}/stop:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "stopSimPacketCaptureSession"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_suspend.go
+++ b/soracom/generated/cmd/sims_suspend.go
@@ -21,7 +21,7 @@ func init() {
 var SimsSuspendCmd = &cobra.Command{
 	Use:   "suspend",
 	Short: TRAPI("/sims/{sim_id}/suspend:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/suspend:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/suspend:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "suspendSim"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_terminate.go
+++ b/soracom/generated/cmd/sims_terminate.go
@@ -21,7 +21,7 @@ func init() {
 var SimsTerminateCmd = &cobra.Command{
 	Use:   "terminate",
 	Short: TRAPI("/sims/{sim_id}/terminate:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/terminate:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/terminate:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "terminateSim"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_terminate_subscription_container.go
+++ b/soracom/generated/cmd/sims_terminate_subscription_container.go
@@ -31,7 +31,7 @@ func init() {
 var SimsTerminateSubscriptionContainerCmd = &cobra.Command{
 	Use:   "terminate-subscription-container",
 	Short: TRAPI("/sims/{sim_id}/profiles/{iccid}/subscribers/{imsi}/terminate:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscribers/{imsi}/terminate:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/profiles/{iccid}/subscribers/{imsi}/terminate:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "terminateSubscriptionContainer"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_unset_expiry_time.go
+++ b/soracom/generated/cmd/sims_unset_expiry_time.go
@@ -21,7 +21,7 @@ func init() {
 var SimsUnsetExpiryTimeCmd = &cobra.Command{
 	Use:   "unset-expiry-time",
 	Short: TRAPI("/sims/{sim_id}/unset_expiry_time:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/unset_expiry_time:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/unset_expiry_time:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "unsetSimExpiryTime"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_unset_group.go
+++ b/soracom/generated/cmd/sims_unset_group.go
@@ -21,7 +21,7 @@ func init() {
 var SimsUnsetGroupCmd = &cobra.Command{
 	Use:   "unset-group",
 	Short: TRAPI("/sims/{sim_id}/unset_group:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/unset_group:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/unset_group:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "unsetSimGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_unset_imei_lock.go
+++ b/soracom/generated/cmd/sims_unset_imei_lock.go
@@ -21,7 +21,7 @@ func init() {
 var SimsUnsetImeiLockCmd = &cobra.Command{
 	Use:   "unset-imei-lock",
 	Short: TRAPI("/sims/{sim_id}/unset_imei_lock:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/unset_imei_lock:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/unset_imei_lock:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "unsetSimImeiLock"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/sims_update_speed_class.go
+++ b/soracom/generated/cmd/sims_update_speed_class.go
@@ -35,7 +35,7 @@ func init() {
 var SimsUpdateSpeedClassCmd = &cobra.Command{
 	Use:   "update-speed-class",
 	Short: TRAPI("/sims/{sim_id}/update_speed_class:post:summary"),
-	Long:  TRAPI(`/sims/{sim_id}/update_speed_class:post:description`),
+	Long:  TRAPI(`/sims/{sim_id}/update_speed_class:post:description`) + "\n\n" + createLinkToAPIReference("Sim", "updateSimSpeedClass"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/soralets_create.go
+++ b/soracom/generated/cmd/soralets_create.go
@@ -35,7 +35,7 @@ func init() {
 var SoraletsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/soralets:post:summary"),
-	Long:  TRAPI(`/soralets:post:description`),
+	Long:  TRAPI(`/soralets:post:description`) + "\n\n" + createLinkToAPIReference("Soralet", "createSoralet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/soralets_delete.go
+++ b/soracom/generated/cmd/soralets_delete.go
@@ -21,7 +21,7 @@ func init() {
 var SoraletsDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/soralets/{soralet_id}:delete:summary"),
-	Long:  TRAPI(`/soralets/{soralet_id}:delete:description`),
+	Long:  TRAPI(`/soralets/{soralet_id}:delete:description`) + "\n\n" + createLinkToAPIReference("Soralet", "deleteSoralet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/soralets_delete_version.go
+++ b/soracom/generated/cmd/soralets_delete_version.go
@@ -26,7 +26,7 @@ func init() {
 var SoraletsDeleteVersionCmd = &cobra.Command{
 	Use:   "delete-version",
 	Short: TRAPI("/soralets/{soralet_id}/versions/{version}:delete:summary"),
-	Long:  TRAPI(`/soralets/{soralet_id}/versions/{version}:delete:description`),
+	Long:  TRAPI(`/soralets/{soralet_id}/versions/{version}:delete:description`) + "\n\n" + createLinkToAPIReference("Soralet", "deleteSoraletVersion"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/soralets_exec.go
+++ b/soracom/generated/cmd/soralets_exec.go
@@ -60,7 +60,7 @@ func init() {
 var SoraletsExecCmd = &cobra.Command{
 	Use:   "exec",
 	Short: TRAPI("/soralets/{soralet_id}/test:post:summary"),
-	Long:  TRAPI(`/soralets/{soralet_id}/test:post:description`),
+	Long:  TRAPI(`/soralets/{soralet_id}/test:post:description`) + "\n\n" + createLinkToAPIReference("Soralet", "testSoralet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/soralets_get.go
+++ b/soracom/generated/cmd/soralets_get.go
@@ -21,7 +21,7 @@ func init() {
 var SoraletsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/soralets/{soralet_id}:get:summary"),
-	Long:  TRAPI(`/soralets/{soralet_id}:get:description`),
+	Long:  TRAPI(`/soralets/{soralet_id}:get:description`) + "\n\n" + createLinkToAPIReference("Soralet", "getSoralet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/soralets_get_logs.go
+++ b/soracom/generated/cmd/soralets_get_logs.go
@@ -46,7 +46,7 @@ func init() {
 var SoraletsGetLogsCmd = &cobra.Command{
 	Use:   "get-logs",
 	Short: TRAPI("/soralets/{soralet_id}/logs:get:summary"),
-	Long:  TRAPI(`/soralets/{soralet_id}/logs:get:description`),
+	Long:  TRAPI(`/soralets/{soralet_id}/logs:get:description`) + "\n\n" + createLinkToAPIReference("Soralet", "getSoraletLogs"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/soralets_list.go
+++ b/soracom/generated/cmd/soralets_list.go
@@ -41,7 +41,7 @@ func init() {
 var SoraletsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/soralets:get:summary"),
-	Long:  TRAPI(`/soralets:get:description`),
+	Long:  TRAPI(`/soralets:get:description`) + "\n\n" + createLinkToAPIReference("Soralet", "listSoralets"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/soralets_list_versions.go
+++ b/soracom/generated/cmd/soralets_list_versions.go
@@ -46,7 +46,7 @@ func init() {
 var SoraletsListVersionsCmd = &cobra.Command{
 	Use:   "list-versions",
 	Short: TRAPI("/soralets/{soralet_id}/versions:get:summary"),
-	Long:  TRAPI(`/soralets/{soralet_id}/versions:get:description`),
+	Long:  TRAPI(`/soralets/{soralet_id}/versions:get:description`) + "\n\n" + createLinkToAPIReference("Soralet", "listSoraletVersions"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/soralets_test.go
+++ b/soracom/generated/cmd/soralets_test.go
@@ -60,7 +60,7 @@ func init() {
 var SoraletsTestCmd = &cobra.Command{
 	Use:   "test",
 	Short: TRAPI("/soralets/{soralet_id}/test:post:summary"),
-	Long:  TRAPI(`/soralets/{soralet_id}/test:post:description`),
+	Long:  TRAPI(`/soralets/{soralet_id}/test:post:description`) + "\n\n" + createLinkToAPIReference("Soralet", "testSoralet"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/soralets_upload.go
+++ b/soracom/generated/cmd/soralets_upload.go
@@ -35,7 +35,7 @@ func init() {
 var SoraletsUploadCmd = &cobra.Command{
 	Use:   "upload",
 	Short: TRAPI("/soralets/{soralet_id}/versions:post:summary"),
-	Long:  TRAPI(`/soralets/{soralet_id}/versions:post:description`),
+	Long:  TRAPI(`/soralets/{soralet_id}/versions:post:description`) + "\n\n" + createLinkToAPIReference("Soralet", "uploadSoraletCode"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/stats_air_export.go
+++ b/soracom/generated/cmd/stats_air_export.go
@@ -50,7 +50,7 @@ func init() {
 var StatsAirExportCmd = &cobra.Command{
 	Use:   "export",
 	Short: TRAPI("/stats/air/operators/{operator_id}/export:post:summary"),
-	Long:  TRAPI(`/stats/air/operators/{operator_id}/export:post:description`),
+	Long:  TRAPI(`/stats/air/operators/{operator_id}/export:post:description`) + "\n\n" + createLinkToAPIReference("Stats", "exportAirStats"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/stats_air_get.go
+++ b/soracom/generated/cmd/stats_air_get.go
@@ -41,7 +41,7 @@ func init() {
 var StatsAirGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/stats/air/subscribers/{imsi}:get:summary"),
-	Long:  TRAPI(`/stats/air/subscribers/{imsi}:get:description`),
+	Long:  TRAPI(`/stats/air/subscribers/{imsi}:get:description`) + "\n\n" + createLinkToAPIReference("Stats", "getAirStats"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/stats_air_sims_get.go
+++ b/soracom/generated/cmd/stats_air_sims_get.go
@@ -41,7 +41,7 @@ func init() {
 var StatsAirSimsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/stats/air/sims/{sim_id}:get:summary"),
-	Long:  TRAPI(`/stats/air/sims/{sim_id}:get:description`),
+	Long:  TRAPI(`/stats/air/sims/{sim_id}:get:description`) + "\n\n" + createLinkToAPIReference("Stats", "getAirStatsOfSim"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/stats_beam_export.go
+++ b/soracom/generated/cmd/stats_beam_export.go
@@ -50,7 +50,7 @@ func init() {
 var StatsBeamExportCmd = &cobra.Command{
 	Use:   "export",
 	Short: TRAPI("/stats/beam/operators/{operator_id}/export:post:summary"),
-	Long:  TRAPI(`/stats/beam/operators/{operator_id}/export:post:description`),
+	Long:  TRAPI(`/stats/beam/operators/{operator_id}/export:post:description`) + "\n\n" + createLinkToAPIReference("Stats", "exportBeamStats"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/stats_beam_get.go
+++ b/soracom/generated/cmd/stats_beam_get.go
@@ -41,7 +41,7 @@ func init() {
 var StatsBeamGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/stats/beam/subscribers/{imsi}:get:summary"),
-	Long:  TRAPI(`/stats/beam/subscribers/{imsi}:get:description`),
+	Long:  TRAPI(`/stats/beam/subscribers/{imsi}:get:description`) + "\n\n" + createLinkToAPIReference("Stats", "getBeamStats"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/stats_funk_export.go
+++ b/soracom/generated/cmd/stats_funk_export.go
@@ -50,7 +50,7 @@ func init() {
 var StatsFunkExportCmd = &cobra.Command{
 	Use:   "export",
 	Short: TRAPI("/stats/funk/operators/{operator_id}/export:post:summary"),
-	Long:  TRAPI(`/stats/funk/operators/{operator_id}/export:post:description`),
+	Long:  TRAPI(`/stats/funk/operators/{operator_id}/export:post:description`) + "\n\n" + createLinkToAPIReference("Stats", "exportFunkStats"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/stats_funk_get.go
+++ b/soracom/generated/cmd/stats_funk_get.go
@@ -41,7 +41,7 @@ func init() {
 var StatsFunkGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/stats/funk/subscribers/{imsi}:get:summary"),
-	Long:  TRAPI(`/stats/funk/subscribers/{imsi}:get:description`),
+	Long:  TRAPI(`/stats/funk/subscribers/{imsi}:get:description`) + "\n\n" + createLinkToAPIReference("Stats", "getFunkStats"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/stats_funnel_export.go
+++ b/soracom/generated/cmd/stats_funnel_export.go
@@ -50,7 +50,7 @@ func init() {
 var StatsFunnelExportCmd = &cobra.Command{
 	Use:   "export",
 	Short: TRAPI("/stats/funnel/operators/{operator_id}/export:post:summary"),
-	Long:  TRAPI(`/stats/funnel/operators/{operator_id}/export:post:description`),
+	Long:  TRAPI(`/stats/funnel/operators/{operator_id}/export:post:description`) + "\n\n" + createLinkToAPIReference("Stats", "exportFunnelStats"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/stats_funnel_get.go
+++ b/soracom/generated/cmd/stats_funnel_get.go
@@ -41,7 +41,7 @@ func init() {
 var StatsFunnelGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/stats/funnel/subscribers/{imsi}:get:summary"),
-	Long:  TRAPI(`/stats/funnel/subscribers/{imsi}:get:description`),
+	Long:  TRAPI(`/stats/funnel/subscribers/{imsi}:get:description`) + "\n\n" + createLinkToAPIReference("Stats", "getFunnelStats"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/stats_harvest_get.go
+++ b/soracom/generated/cmd/stats_harvest_get.go
@@ -9,24 +9,39 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// StatsHarvestGetCmdOperatorId holds value of 'operator_id' option
-var StatsHarvestGetCmdOperatorId string
+// StatsHarvestGetCmdImsi holds value of 'imsi' option
+var StatsHarvestGetCmdImsi string
 
-// StatsHarvestGetCmdYearMonth holds value of 'year_month' option
-var StatsHarvestGetCmdYearMonth string
+// StatsHarvestGetCmdPeriod holds value of 'period' option
+var StatsHarvestGetCmdPeriod string
+
+// StatsHarvestGetCmdFrom holds value of 'from' option
+var StatsHarvestGetCmdFrom int64
+
+// StatsHarvestGetCmdTo holds value of 'to' option
+var StatsHarvestGetCmdTo int64
+
+// StatsHarvestGetCmdOutputJSONL indicates to output with jsonl format
+var StatsHarvestGetCmdOutputJSONL bool
 
 func init() {
-	StatsHarvestGetCmd.Flags().StringVar(&StatsHarvestGetCmdOperatorId, "operator-id", "", TRAPI("operator_id"))
+	StatsHarvestGetCmd.Flags().StringVar(&StatsHarvestGetCmdImsi, "imsi", "", TRAPI("imsi"))
 
-	StatsHarvestGetCmd.Flags().StringVar(&StatsHarvestGetCmdYearMonth, "year-month", "", TRAPI("Year/Month in 'YYYYMM' format."))
+	StatsHarvestGetCmd.Flags().StringVar(&StatsHarvestGetCmdPeriod, "period", "", TRAPI("Units of aggregate data. For minutes, the interval is around 5 minutes."))
+
+	StatsHarvestGetCmd.Flags().Int64Var(&StatsHarvestGetCmdFrom, "from", 0, TRAPI("Start time in unixtime for the aggregate data."))
+
+	StatsHarvestGetCmd.Flags().Int64Var(&StatsHarvestGetCmdTo, "to", 0, TRAPI("End time in unixtime for the aggregate data."))
+
+	StatsHarvestGetCmd.Flags().BoolVar(&StatsHarvestGetCmdOutputJSONL, "jsonl", false, TRCLI("cli.common_params.jsonl.short_help"))
 	StatsHarvestCmd.AddCommand(StatsHarvestGetCmd)
 }
 
 // StatsHarvestGetCmd defines 'get' subcommand
 var StatsHarvestGetCmd = &cobra.Command{
 	Use:   "get",
-	Short: TRAPI("/stats/harvest/operators/{operator_id}:get:summary"),
-	Long:  TRAPI(`/stats/harvest/operators/{operator_id}:get:description`),
+	Short: TRAPI("/stats/harvest/subscribers/{imsi}:get:summary"),
+	Long:  TRAPI(`/stats/harvest/subscribers/{imsi}:get:description`) + "\n\n" + createLinkToAPIReference("Stats", "getHarvestStats"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {
@@ -66,6 +81,10 @@ var StatsHarvestGetCmd = &cobra.Command{
 		if rawOutput {
 			_, err = os.Stdout.Write([]byte(body))
 		} else {
+			if StatsHarvestGetCmdOutputJSONL {
+				return printStringAsJSONL(body)
+			}
+
 			return prettyPrintStringAsJSON(body)
 		}
 		return err
@@ -73,13 +92,31 @@ var StatsHarvestGetCmd = &cobra.Command{
 }
 
 func collectStatsHarvestGetCmdParams(ac *apiClient) (*apiParams, error) {
-	if StatsHarvestGetCmdOperatorId == "" {
-		StatsHarvestGetCmdOperatorId = ac.OperatorID
+	var parsedBody interface{}
+	var err error
+	err = checkIfRequiredStringParameterIsSupplied("imsi", "imsi", "path", parsedBody, StatsHarvestGetCmdImsi)
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkIfRequiredStringParameterIsSupplied("period", "period", "query", parsedBody, StatsHarvestGetCmdPeriod)
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkIfRequiredIntegerParameterIsSupplied("from", "from", "query", parsedBody, StatsHarvestGetCmdFrom)
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkIfRequiredIntegerParameterIsSupplied("to", "to", "query", parsedBody, StatsHarvestGetCmdTo)
+	if err != nil {
+		return nil, err
 	}
 
 	return &apiParams{
 		method: "GET",
-		path:   buildPathForStatsHarvestGetCmd("/stats/harvest/operators/{operator_id}"),
+		path:   buildPathForStatsHarvestGetCmd("/stats/harvest/subscribers/{imsi}"),
 		query:  buildQueryForStatsHarvestGetCmd(),
 
 		noRetryOnError: noRetryOnError,
@@ -88,9 +125,9 @@ func collectStatsHarvestGetCmdParams(ac *apiClient) (*apiParams, error) {
 
 func buildPathForStatsHarvestGetCmd(path string) string {
 
-	escapedOperatorId := url.PathEscape(StatsHarvestGetCmdOperatorId)
+	escapedImsi := url.PathEscape(StatsHarvestGetCmdImsi)
 
-	path = strReplace(path, "{"+"operator_id"+"}", escapedOperatorId, -1)
+	path = strReplace(path, "{"+"imsi"+"}", escapedImsi, -1)
 
 	return path
 }
@@ -98,8 +135,16 @@ func buildPathForStatsHarvestGetCmd(path string) string {
 func buildQueryForStatsHarvestGetCmd() url.Values {
 	result := url.Values{}
 
-	if StatsHarvestGetCmdYearMonth != "" {
-		result.Add("year_month", StatsHarvestGetCmdYearMonth)
+	if StatsHarvestGetCmdPeriod != "" {
+		result.Add("period", StatsHarvestGetCmdPeriod)
+	}
+
+	if StatsHarvestGetCmdFrom != 0 {
+		result.Add("from", sprintf("%d", StatsHarvestGetCmdFrom))
+	}
+
+	if StatsHarvestGetCmdTo != 0 {
+		result.Add("to", sprintf("%d", StatsHarvestGetCmdTo))
 	}
 
 	return result

--- a/soracom/generated/cmd/stats_napter_audit_logs_get.go
+++ b/soracom/generated/cmd/stats_napter_audit_logs_get.go
@@ -21,7 +21,7 @@ func init() {
 var StatsNapterAuditLogsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/stats/napter/audit_logs:get:summary"),
-	Long:  TRAPI(`/stats/napter/audit_logs:get:description`),
+	Long:  TRAPI(`/stats/napter/audit_logs:get:description`) + "\n\n" + createLinkToAPIReference("Stats", "getNapterAuditLogsExportedDataStats"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_activate.go
+++ b/soracom/generated/cmd/subscribers_activate.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersActivateCmd = &cobra.Command{
 	Use:   "activate",
 	Short: TRAPI("/subscribers/{imsi}/activate:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/activate:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/activate:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "activateSubscriber"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_deactivate.go
+++ b/soracom/generated/cmd/subscribers_deactivate.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersDeactivateCmd = &cobra.Command{
 	Use:   "deactivate",
 	Short: TRAPI("/subscribers/{imsi}/deactivate:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/deactivate:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/deactivate:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "deactivateSubscriber"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_delete_session.go
+++ b/soracom/generated/cmd/subscribers_delete_session.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersDeleteSessionCmd = &cobra.Command{
 	Use:   "delete-session",
 	Short: TRAPI("/subscribers/{imsi}/delete_session:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/delete_session:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/delete_session:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "deleteSubscriberSession"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_delete_tag.go
+++ b/soracom/generated/cmd/subscribers_delete_tag.go
@@ -26,7 +26,7 @@ func init() {
 var SubscribersDeleteTagCmd = &cobra.Command{
 	Use:   "delete-tag",
 	Short: TRAPI("/subscribers/{imsi}/tags/{tag_name}:delete:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/tags/{tag_name}:delete:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/tags/{tag_name}:delete:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "deleteSubscriberTag"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_delete_transfer_token.go
+++ b/soracom/generated/cmd/subscribers_delete_transfer_token.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersDeleteTransferTokenCmd = &cobra.Command{
 	Use:   "delete-transfer-token",
 	Short: TRAPI("/subscribers/transfer_token/{token}:delete:summary"),
-	Long:  TRAPI(`/subscribers/transfer_token/{token}:delete:description`),
+	Long:  TRAPI(`/subscribers/transfer_token/{token}:delete:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "deleteSubscriberTransferToken"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_disable_termination.go
+++ b/soracom/generated/cmd/subscribers_disable_termination.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersDisableTerminationCmd = &cobra.Command{
 	Use:   "disable-termination",
 	Short: TRAPI("/subscribers/{imsi}/disable_termination:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/disable_termination:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/disable_termination:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "disableTermination"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_downlink_ping.go
+++ b/soracom/generated/cmd/subscribers_downlink_ping.go
@@ -40,7 +40,7 @@ func init() {
 var SubscribersDownlinkPingCmd = &cobra.Command{
 	Use:   "downlink-ping",
 	Short: TRAPI("/subscribers/{imsi}/downlink/ping:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/downlink/ping:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/downlink/ping:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "subscriberDownlinkPingToUserEquipment"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_enable_termination.go
+++ b/soracom/generated/cmd/subscribers_enable_termination.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersEnableTerminationCmd = &cobra.Command{
 	Use:   "enable-termination",
 	Short: TRAPI("/subscribers/{imsi}/enable_termination:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/enable_termination:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/enable_termination:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "enableTermination"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_export.go
+++ b/soracom/generated/cmd/subscribers_export.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersExportCmd = &cobra.Command{
 	Use:   "export",
 	Short: TRAPI("/subscribers/export:post:summary"),
-	Long:  TRAPI(`/subscribers/export:post:description`),
+	Long:  TRAPI(`/subscribers/export:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "exportSubscribers"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_get.go
+++ b/soracom/generated/cmd/subscribers_get.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/subscribers/{imsi}:get:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}:get:description`),
+	Long:  TRAPI(`/subscribers/{imsi}:get:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "getSubscriber"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_get_data.go
+++ b/soracom/generated/cmd/subscribers_get_data.go
@@ -56,7 +56,7 @@ func init() {
 var SubscribersGetDataCmd = &cobra.Command{
 	Use:   "get-data",
 	Short: TRAPI("/subscribers/{imsi}/data:get:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/data:get:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/data:get:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "getDataFromSubscriber"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_issue_transfer_token.go
+++ b/soracom/generated/cmd/subscribers_issue_transfer_token.go
@@ -35,7 +35,7 @@ func init() {
 var SubscribersIssueTransferTokenCmd = &cobra.Command{
 	Use:   "issue-transfer-token",
 	Short: TRAPI("/subscribers/transfer_token/issue:post:summary"),
-	Long:  TRAPI(`/subscribers/transfer_token/issue:post:description`),
+	Long:  TRAPI(`/subscribers/transfer_token/issue:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "issueSubscriberTransferToken"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_list.go
+++ b/soracom/generated/cmd/subscribers_list.go
@@ -66,7 +66,7 @@ func init() {
 var SubscribersListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/subscribers:get:summary"),
-	Long:  TRAPI(`/subscribers:get:description`),
+	Long:  TRAPI(`/subscribers:get:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "listSubscribers"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_put_bundles.go
+++ b/soracom/generated/cmd/subscribers_put_bundles.go
@@ -30,7 +30,7 @@ func init() {
 var SubscribersPutBundlesCmd = &cobra.Command{
 	Use:   "put-bundles",
 	Short: TRAPI("/subscribers/{imsi}/bundles:put:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/bundles:put:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/bundles:put:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "putBundles"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_put_tags.go
+++ b/soracom/generated/cmd/subscribers_put_tags.go
@@ -30,7 +30,7 @@ func init() {
 var SubscribersPutTagsCmd = &cobra.Command{
 	Use:   "put-tags",
 	Short: TRAPI("/subscribers/{imsi}/tags:put:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/tags:put:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/tags:put:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "putSubscriberTags"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_register.go
+++ b/soracom/generated/cmd/subscribers_register.go
@@ -40,7 +40,7 @@ func init() {
 var SubscribersRegisterCmd = &cobra.Command{
 	Use:   "register",
 	Short: TRAPI("/subscribers/{imsi}/register:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/register:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/register:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "registerSubscriber"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_report_local_info.go
+++ b/soracom/generated/cmd/subscribers_report_local_info.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersReportLocalInfoCmd = &cobra.Command{
 	Use:   "report-local-info",
 	Short: TRAPI("/subscribers/{imsi}/report_local_info:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/report_local_info:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/report_local_info:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "reportLocalInfo"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_send_sms.go
+++ b/soracom/generated/cmd/subscribers_send_sms.go
@@ -40,7 +40,7 @@ func init() {
 var SubscribersSendSmsCmd = &cobra.Command{
 	Use:   "send-sms",
 	Short: TRAPI("/subscribers/{imsi}/send_sms:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/send_sms:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/send_sms:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "sendSms"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_send_sms_by_msisdn.go
+++ b/soracom/generated/cmd/subscribers_send_sms_by_msisdn.go
@@ -40,7 +40,7 @@ func init() {
 var SubscribersSendSmsByMsisdnCmd = &cobra.Command{
 	Use:   "send-sms-by-msisdn",
 	Short: TRAPI("/subscribers/msisdn/{msisdn}/send_sms:post:summary"),
-	Long:  TRAPI(`/subscribers/msisdn/{msisdn}/send_sms:post:description`),
+	Long:  TRAPI(`/subscribers/msisdn/{msisdn}/send_sms:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "sendSmsByMsisdn"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_session_events.go
+++ b/soracom/generated/cmd/subscribers_session_events.go
@@ -51,7 +51,7 @@ func init() {
 var SubscribersSessionEventsCmd = &cobra.Command{
 	Use:   "session-events",
 	Short: TRAPI("/subscribers/{imsi}/events/sessions:get:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/events/sessions:get:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/events/sessions:get:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "listSessionEvents"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_set_expiry_time.go
+++ b/soracom/generated/cmd/subscribers_set_expiry_time.go
@@ -40,7 +40,7 @@ func init() {
 var SubscribersSetExpiryTimeCmd = &cobra.Command{
 	Use:   "set-expiry-time",
 	Short: TRAPI("/subscribers/{imsi}/set_expiry_time:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/set_expiry_time:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/set_expiry_time:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "setExpiryTime"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_set_group.go
+++ b/soracom/generated/cmd/subscribers_set_group.go
@@ -35,7 +35,7 @@ func init() {
 var SubscribersSetGroupCmd = &cobra.Command{
 	Use:   "set-group",
 	Short: TRAPI("/subscribers/{imsi}/set_group:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/set_group:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/set_group:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "setGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_set_imei_lock.go
+++ b/soracom/generated/cmd/subscribers_set_imei_lock.go
@@ -35,7 +35,7 @@ func init() {
 var SubscribersSetImeiLockCmd = &cobra.Command{
 	Use:   "set-imei-lock",
 	Short: TRAPI("/subscribers/{imsi}/set_imei_lock:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/set_imei_lock:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/set_imei_lock:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "setImeiLock"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_set_to_standby.go
+++ b/soracom/generated/cmd/subscribers_set_to_standby.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersSetToStandbyCmd = &cobra.Command{
 	Use:   "set-to-standby",
 	Short: TRAPI("/subscribers/{imsi}/set_to_standby:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/set_to_standby:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/set_to_standby:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "setSubscriberToStandby"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_suspend.go
+++ b/soracom/generated/cmd/subscribers_suspend.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersSuspendCmd = &cobra.Command{
 	Use:   "suspend",
 	Short: TRAPI("/subscribers/{imsi}/suspend:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/suspend:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/suspend:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "suspendSubscriber"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_terminate.go
+++ b/soracom/generated/cmd/subscribers_terminate.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersTerminateCmd = &cobra.Command{
 	Use:   "terminate",
 	Short: TRAPI("/subscribers/{imsi}/terminate:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/terminate:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/terminate:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "terminateSubscriber"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_unset_expiry_time.go
+++ b/soracom/generated/cmd/subscribers_unset_expiry_time.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersUnsetExpiryTimeCmd = &cobra.Command{
 	Use:   "unset-expiry-time",
 	Short: TRAPI("/subscribers/{imsi}/unset_expiry_time:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/unset_expiry_time:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/unset_expiry_time:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "unsetExpiryTime"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_unset_group.go
+++ b/soracom/generated/cmd/subscribers_unset_group.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersUnsetGroupCmd = &cobra.Command{
 	Use:   "unset-group",
 	Short: TRAPI("/subscribers/{imsi}/unset_group:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/unset_group:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/unset_group:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "unsetGroup"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_unset_imei_lock.go
+++ b/soracom/generated/cmd/subscribers_unset_imei_lock.go
@@ -21,7 +21,7 @@ func init() {
 var SubscribersUnsetImeiLockCmd = &cobra.Command{
 	Use:   "unset-imei-lock",
 	Short: TRAPI("/subscribers/{imsi}/unset_imei_lock:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/unset_imei_lock:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/unset_imei_lock:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "unsetImeiLock"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_update_speed_class.go
+++ b/soracom/generated/cmd/subscribers_update_speed_class.go
@@ -35,7 +35,7 @@ func init() {
 var SubscribersUpdateSpeedClassCmd = &cobra.Command{
 	Use:   "update-speed-class",
 	Short: TRAPI("/subscribers/{imsi}/update_speed_class:post:summary"),
-	Long:  TRAPI(`/subscribers/{imsi}/update_speed_class:post:description`),
+	Long:  TRAPI(`/subscribers/{imsi}/update_speed_class:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "updateSpeedClass"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/subscribers_verify_transfer_token.go
+++ b/soracom/generated/cmd/subscribers_verify_transfer_token.go
@@ -30,7 +30,7 @@ func init() {
 var SubscribersVerifyTransferTokenCmd = &cobra.Command{
 	Use:   "verify-transfer-token",
 	Short: TRAPI("/subscribers/transfer_token/verify:post:summary"),
-	Long:  TRAPI(`/subscribers/transfer_token/verify:post:description`),
+	Long:  TRAPI(`/subscribers/transfer_token/verify:post:description`) + "\n\n" + createLinkToAPIReference("Subscriber", "verifySubscriberTransferToken"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/system_notifications_delete.go
+++ b/soracom/generated/cmd/system_notifications_delete.go
@@ -26,7 +26,7 @@ func init() {
 var SystemNotificationsDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/operators/{operator_id}/system_notifications/{type}:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/system_notifications/{type}:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/system_notifications/{type}:delete:description`) + "\n\n" + createLinkToAPIReference("SystemNotification", "deleteSystemNotification"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/system_notifications_get.go
+++ b/soracom/generated/cmd/system_notifications_get.go
@@ -26,7 +26,7 @@ func init() {
 var SystemNotificationsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/operators/{operator_id}/system_notifications/{type}:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/system_notifications/{type}:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/system_notifications/{type}:get:description`) + "\n\n" + createLinkToAPIReference("SystemNotification", "getSystemNotification"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/system_notifications_list.go
+++ b/soracom/generated/cmd/system_notifications_list.go
@@ -26,7 +26,7 @@ func init() {
 var SystemNotificationsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/operators/{operator_id}/system_notifications:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/system_notifications:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/system_notifications:get:description`) + "\n\n" + createLinkToAPIReference("SystemNotification", "listSystemNotifications"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/system_notifications_set.go
+++ b/soracom/generated/cmd/system_notifications_set.go
@@ -40,7 +40,7 @@ func init() {
 var SystemNotificationsSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: TRAPI("/operators/{operator_id}/system_notifications/{type}:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/system_notifications/{type}:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/system_notifications/{type}:post:description`) + "\n\n" + createLinkToAPIReference("SystemNotification", "setSystemNotification"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_attach_role.go
+++ b/soracom/generated/cmd/users_attach_role.go
@@ -40,7 +40,7 @@ func init() {
 var UsersAttachRoleCmd = &cobra.Command{
 	Use:   "attach-role",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/roles:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/roles:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/roles:post:description`) + "\n\n" + createLinkToAPIReference("Role", "attachRole"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_auth_keys_delete.go
+++ b/soracom/generated/cmd/users_auth_keys_delete.go
@@ -31,7 +31,7 @@ func init() {
 var UsersAuthKeysDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/auth_keys/{auth_key_id}:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/auth_keys/{auth_key_id}:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/auth_keys/{auth_key_id}:delete:description`) + "\n\n" + createLinkToAPIReference("User", "deleteUserAuthKey"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_auth_keys_generate.go
+++ b/soracom/generated/cmd/users_auth_keys_generate.go
@@ -26,7 +26,7 @@ func init() {
 var UsersAuthKeysGenerateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/auth_keys:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/auth_keys:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/auth_keys:post:description`) + "\n\n" + createLinkToAPIReference("User", "generateUserAuthKey"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_auth_keys_get.go
+++ b/soracom/generated/cmd/users_auth_keys_get.go
@@ -31,7 +31,7 @@ func init() {
 var UsersAuthKeysGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/auth_keys/{auth_key_id}:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/auth_keys/{auth_key_id}:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/auth_keys/{auth_key_id}:get:description`) + "\n\n" + createLinkToAPIReference("User", "getUserAuthKey"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_auth_keys_list.go
+++ b/soracom/generated/cmd/users_auth_keys_list.go
@@ -31,7 +31,7 @@ func init() {
 var UsersAuthKeysListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/auth_keys:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/auth_keys:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/auth_keys:get:description`) + "\n\n" + createLinkToAPIReference("User", "listUserAuthKeys"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_create.go
+++ b/soracom/generated/cmd/users_create.go
@@ -40,7 +40,7 @@ func init() {
 var UsersCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}:post:description`) + "\n\n" + createLinkToAPIReference("User", "createUser"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_default_permissions_delete.go
+++ b/soracom/generated/cmd/users_default_permissions_delete.go
@@ -21,7 +21,7 @@ func init() {
 var UsersDefaultPermissionsDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/operators/{operator_id}/users/default_permissions:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/default_permissions:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/default_permissions:delete:description`) + "\n\n" + createLinkToAPIReference("User", "deleteDefaultPermissions"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_default_permissions_get.go
+++ b/soracom/generated/cmd/users_default_permissions_get.go
@@ -21,7 +21,7 @@ func init() {
 var UsersDefaultPermissionsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/operators/{operator_id}/users/default_permissions:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/default_permissions:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/default_permissions:get:description`) + "\n\n" + createLinkToAPIReference("User", "getDefaultPermissions"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_default_permissions_update.go
+++ b/soracom/generated/cmd/users_default_permissions_update.go
@@ -35,7 +35,7 @@ func init() {
 var UsersDefaultPermissionsUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: TRAPI("/operators/{operator_id}/users/default_permissions:put:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/default_permissions:put:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/default_permissions:put:description`) + "\n\n" + createLinkToAPIReference("User", "updateDefaultPermissions"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_delete.go
+++ b/soracom/generated/cmd/users_delete.go
@@ -26,7 +26,7 @@ func init() {
 var UsersDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}:delete:description`) + "\n\n" + createLinkToAPIReference("User", "deleteUser"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_detach_role.go
+++ b/soracom/generated/cmd/users_detach_role.go
@@ -31,7 +31,7 @@ func init() {
 var UsersDetachRoleCmd = &cobra.Command{
 	Use:   "detach-role",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/roles/{role_id}:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/roles/{role_id}:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/roles/{role_id}:delete:description`) + "\n\n" + createLinkToAPIReference("Role", "detachRole"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_get.go
+++ b/soracom/generated/cmd/users_get.go
@@ -26,7 +26,7 @@ func init() {
 var UsersGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}:get:description`) + "\n\n" + createLinkToAPIReference("User", "getUser"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_list.go
+++ b/soracom/generated/cmd/users_list.go
@@ -26,7 +26,7 @@ func init() {
 var UsersListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/operators/{operator_id}/users:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users:get:description`) + "\n\n" + createLinkToAPIReference("User", "listUsers"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_list_roles.go
+++ b/soracom/generated/cmd/users_list_roles.go
@@ -31,7 +31,7 @@ func init() {
 var UsersListRolesCmd = &cobra.Command{
 	Use:   "list-roles",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/roles:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/roles:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/roles:get:description`) + "\n\n" + createLinkToAPIReference("Role", "listUserRoles"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_mfa_enable.go
+++ b/soracom/generated/cmd/users_mfa_enable.go
@@ -26,7 +26,7 @@ func init() {
 var UsersMfaEnableCmd = &cobra.Command{
 	Use:   "enable",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/mfa:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/mfa:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/mfa:post:description`) + "\n\n" + createLinkToAPIReference("User", "enableUserMFA"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_mfa_get.go
+++ b/soracom/generated/cmd/users_mfa_get.go
@@ -26,7 +26,7 @@ func init() {
 var UsersMfaGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/mfa:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/mfa:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/mfa:get:description`) + "\n\n" + createLinkToAPIReference("User", "getUserMFAStatus"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_mfa_revoke.go
+++ b/soracom/generated/cmd/users_mfa_revoke.go
@@ -26,7 +26,7 @@ func init() {
 var UsersMfaRevokeCmd = &cobra.Command{
 	Use:   "revoke",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/mfa:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/mfa:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/mfa:delete:description`) + "\n\n" + createLinkToAPIReference("User", "revokeUserMFA"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_mfa_verify.go
+++ b/soracom/generated/cmd/users_mfa_verify.go
@@ -40,7 +40,7 @@ func init() {
 var UsersMfaVerifyCmd = &cobra.Command{
 	Use:   "verify",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/mfa/verify:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/mfa/verify:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/mfa/verify:post:description`) + "\n\n" + createLinkToAPIReference("User", "verifyUserMFA"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_password_configured.go
+++ b/soracom/generated/cmd/users_password_configured.go
@@ -26,7 +26,7 @@ func init() {
 var UsersPasswordConfiguredCmd = &cobra.Command{
 	Use:   "configured",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/password:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/password:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/password:get:description`) + "\n\n" + createLinkToAPIReference("User", "hasUserPassword"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_password_create.go
+++ b/soracom/generated/cmd/users_password_create.go
@@ -40,7 +40,7 @@ func init() {
 var UsersPasswordCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/password:post:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/password:post:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/password:post:description`) + "\n\n" + createLinkToAPIReference("User", "createUserPassword"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_password_delete.go
+++ b/soracom/generated/cmd/users_password_delete.go
@@ -26,7 +26,7 @@ func init() {
 var UsersPasswordDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/password:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/password:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/password:delete:description`) + "\n\n" + createLinkToAPIReference("User", "deleteUserPassword"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_password_update.go
+++ b/soracom/generated/cmd/users_password_update.go
@@ -45,7 +45,7 @@ func init() {
 var UsersPasswordUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/password:put:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/password:put:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/password:put:description`) + "\n\n" + createLinkToAPIReference("User", "updateUserPassword"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_permissions_delete.go
+++ b/soracom/generated/cmd/users_permissions_delete.go
@@ -26,7 +26,7 @@ func init() {
 var UsersPermissionsDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/permission:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/permission:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/permission:delete:description`) + "\n\n" + createLinkToAPIReference("User", "deleteUserPermission"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_permissions_get.go
+++ b/soracom/generated/cmd/users_permissions_get.go
@@ -26,7 +26,7 @@ func init() {
 var UsersPermissionsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/permission:get:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/permission:get:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/permission:get:description`) + "\n\n" + createLinkToAPIReference("User", "getUserPermission"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_permissions_update.go
+++ b/soracom/generated/cmd/users_permissions_update.go
@@ -45,7 +45,7 @@ func init() {
 var UsersPermissionsUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/permission:put:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/permission:put:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/permission:put:description`) + "\n\n" + createLinkToAPIReference("User", "updateUserPermission"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_revoke_user_auth_tokens.go
+++ b/soracom/generated/cmd/users_revoke_user_auth_tokens.go
@@ -26,7 +26,7 @@ func init() {
 var UsersRevokeUserAuthTokensCmd = &cobra.Command{
 	Use:   "revoke-user-auth-tokens",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}/tokens:delete:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/tokens:delete:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}/tokens:delete:description`) + "\n\n" + createLinkToAPIReference("User", "revokeUserAuthTokens"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/users_update.go
+++ b/soracom/generated/cmd/users_update.go
@@ -40,7 +40,7 @@ func init() {
 var UsersUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: TRAPI("/operators/{operator_id}/users/{user_name}:put:summary"),
-	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}:put:description`),
+	Long:  TRAPI(`/operators/{operator_id}/users/{user_name}:put:description`) + "\n\n" + createLinkToAPIReference("User", "updateUser"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/volume_discounts_available_discounts.go
+++ b/soracom/generated/cmd/volume_discounts_available_discounts.go
@@ -17,7 +17,7 @@ func init() {
 var VolumeDiscountsAvailableDiscountsCmd = &cobra.Command{
 	Use:   "available-discounts",
 	Short: TRAPI("/volume_discounts/available_discounts:get:summary"),
-	Long:  TRAPI(`/volume_discounts/available_discounts:get:description`),
+	Long:  TRAPI(`/volume_discounts/available_discounts:get:description`) + "\n\n" + createLinkToAPIReference("Order", "listAvailableDiscounts"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/volume_discounts_confirm.go
+++ b/soracom/generated/cmd/volume_discounts_confirm.go
@@ -21,7 +21,7 @@ func init() {
 var VolumeDiscountsConfirmCmd = &cobra.Command{
 	Use:   "confirm",
 	Short: TRAPI("/volume_discounts/{order_id}/confirm:put:summary"),
-	Long:  TRAPI(`/volume_discounts/{order_id}/confirm:put:description`),
+	Long:  TRAPI(`/volume_discounts/{order_id}/confirm:put:description`) + "\n\n" + createLinkToAPIReference("Order", "confirmVolumeDiscountOrder"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/volume_discounts_create.go
+++ b/soracom/generated/cmd/volume_discounts_create.go
@@ -50,7 +50,7 @@ func init() {
 var VolumeDiscountsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/volume_discounts:post:summary"),
-	Long:  TRAPI(`/volume_discounts:post:description`),
+	Long:  TRAPI(`/volume_discounts:post:description`) + "\n\n" + createLinkToAPIReference("Order", "createVolumeDiscountQuotation"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/volume_discounts_get.go
+++ b/soracom/generated/cmd/volume_discounts_get.go
@@ -21,7 +21,7 @@ func init() {
 var VolumeDiscountsGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/volume_discounts/{contract_id}:get:summary"),
-	Long:  TRAPI(`/volume_discounts/{contract_id}:get:description`),
+	Long:  TRAPI(`/volume_discounts/{contract_id}:get:description`) + "\n\n" + createLinkToAPIReference("Payment", "getVolumeDiscount"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/volume_discounts_list.go
+++ b/soracom/generated/cmd/volume_discounts_list.go
@@ -17,7 +17,7 @@ func init() {
 var VolumeDiscountsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/volume_discounts:get:summary"),
-	Long:  TRAPI(`/volume_discounts:get:description`),
+	Long:  TRAPI(`/volume_discounts:get:description`) + "\n\n" + createLinkToAPIReference("Payment", "listVolumeDiscounts"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_close_gate.go
+++ b/soracom/generated/cmd/vpg_close_gate.go
@@ -21,7 +21,7 @@ func init() {
 var VpgCloseGateCmd = &cobra.Command{
 	Use:   "close-gate",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/gate/close:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/close:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/close:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "closeGate"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_create.go
+++ b/soracom/generated/cmd/vpg_create.go
@@ -40,7 +40,7 @@ func init() {
 var VpgCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: TRAPI("/virtual_private_gateways:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "createVirtualPrivateGateway"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_create_mirroring_peer.go
+++ b/soracom/generated/cmd/vpg_create_mirroring_peer.go
@@ -50,7 +50,7 @@ func init() {
 var VpgCreateMirroringPeerCmd = &cobra.Command{
 	Use:   "create-mirroring-peer",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/mirroring/peers:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/mirroring/peers:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/mirroring/peers:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "createMirroringPeer"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_create_packet_capture_session.go
+++ b/soracom/generated/cmd/vpg_create_packet_capture_session.go
@@ -40,7 +40,7 @@ func init() {
 var VpgCreatePacketCaptureSessionCmd = &cobra.Command{
 	Use:   "create-packet-capture-session",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/packet_capture_sessions:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "createPacketCaptureSession"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_create_vpc_peering_connection.go
+++ b/soracom/generated/cmd/vpg_create_vpc_peering_connection.go
@@ -50,7 +50,7 @@ func init() {
 var VpgCreateVpcPeeringConnectionCmd = &cobra.Command{
 	Use:   "create-vpc-peering-connection",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/vpc_peering_connections:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/vpc_peering_connections:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/vpc_peering_connections:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "createVpcPeeringConnection"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_delete_ip_address_map_entry.go
+++ b/soracom/generated/cmd/vpg_delete_ip_address_map_entry.go
@@ -26,7 +26,7 @@ func init() {
 var VpgDeleteIpAddressMapEntryCmd = &cobra.Command{
 	Use:   "delete-ip-address-map-entry",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/ip_address_map/{key}:delete:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/ip_address_map/{key}:delete:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/ip_address_map/{key}:delete:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "deleteVirtualPrivateGatewayIpAddressMapEntry"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_delete_mirroring_peer.go
+++ b/soracom/generated/cmd/vpg_delete_mirroring_peer.go
@@ -26,7 +26,7 @@ func init() {
 var VpgDeleteMirroringPeerCmd = &cobra.Command{
 	Use:   "delete-mirroring-peer",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/mirroring/peers/{ipaddr}:delete:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/mirroring/peers/{ipaddr}:delete:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/mirroring/peers/{ipaddr}:delete:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "deleteMirroringPeer"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_delete_packet_capture_session.go
+++ b/soracom/generated/cmd/vpg_delete_packet_capture_session.go
@@ -26,7 +26,7 @@ func init() {
 var VpgDeletePacketCaptureSessionCmd = &cobra.Command{
 	Use:   "delete-packet-capture-session",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}:delete:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}:delete:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}:delete:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "deletePacketCaptureSession"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_delete_vpc_peering_connection.go
+++ b/soracom/generated/cmd/vpg_delete_vpc_peering_connection.go
@@ -26,7 +26,7 @@ func init() {
 var VpgDeleteVpcPeeringConnectionCmd = &cobra.Command{
 	Use:   "delete-vpc-peering-connection",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/vpc_peering_connections/{pcx_id}:delete:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/vpc_peering_connections/{pcx_id}:delete:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/vpc_peering_connections/{pcx_id}:delete:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "deleteVpcPeeringConnection"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_disable_gate_privacy_separator.go
+++ b/soracom/generated/cmd/vpg_disable_gate_privacy_separator.go
@@ -21,7 +21,7 @@ func init() {
 var VpgDisableGatePrivacySeparatorCmd = &cobra.Command{
 	Use:   "disable-gate-privacy-separator",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/gate/disable_privacy_separator:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/disable_privacy_separator:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/disable_privacy_separator:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "disableGatePrivacySeparator"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_enable_gate_privacy_separator.go
+++ b/soracom/generated/cmd/vpg_enable_gate_privacy_separator.go
@@ -21,7 +21,7 @@ func init() {
 var VpgEnableGatePrivacySeparatorCmd = &cobra.Command{
 	Use:   "enable-gate-privacy-separator",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/gate/enable_privacy_separator:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/enable_privacy_separator:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/enable_privacy_separator:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "enableGatePrivacySeparator"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_get.go
+++ b/soracom/generated/cmd/vpg_get.go
@@ -21,7 +21,7 @@ func init() {
 var VpgGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}:get:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}:get:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}:get:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "getVirtualPrivateGateway"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_get_packet_capture_session.go
+++ b/soracom/generated/cmd/vpg_get_packet_capture_session.go
@@ -26,7 +26,7 @@ func init() {
 var VpgGetPacketCaptureSessionCmd = &cobra.Command{
 	Use:   "get-packet-capture-session",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}:get:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}:get:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}:get:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "getPacketCaptureSession"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_list.go
+++ b/soracom/generated/cmd/vpg_list.go
@@ -51,7 +51,7 @@ func init() {
 var VpgListCmd = &cobra.Command{
 	Use:   "list",
 	Short: TRAPI("/virtual_private_gateways:get:summary"),
-	Long:  TRAPI(`/virtual_private_gateways:get:description`),
+	Long:  TRAPI(`/virtual_private_gateways:get:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "listVirtualPrivateGateways"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_list_gate_peers.go
+++ b/soracom/generated/cmd/vpg_list_gate_peers.go
@@ -26,7 +26,7 @@ func init() {
 var VpgListGatePeersCmd = &cobra.Command{
 	Use:   "list-gate-peers",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/gate/peers:get:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/peers:get:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/peers:get:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "listGatePeers"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_list_ip_address_map_entries.go
+++ b/soracom/generated/cmd/vpg_list_ip_address_map_entries.go
@@ -26,7 +26,7 @@ func init() {
 var VpgListIpAddressMapEntriesCmd = &cobra.Command{
 	Use:   "list-ip-address-map-entries",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/ip_address_map:get:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/ip_address_map:get:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/ip_address_map:get:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "listVirtualPrivateGatewayIpAddressMapEntries"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_list_packet_capture_sessions.go
+++ b/soracom/generated/cmd/vpg_list_packet_capture_sessions.go
@@ -41,7 +41,7 @@ func init() {
 var VpgListPacketCaptureSessionsCmd = &cobra.Command{
 	Use:   "list-packet-capture-sessions",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/packet_capture_sessions:get:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions:get:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions:get:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "listPacketCaptureSessions"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_open_gate.go
+++ b/soracom/generated/cmd/vpg_open_gate.go
@@ -40,7 +40,7 @@ func init() {
 var VpgOpenGateCmd = &cobra.Command{
 	Use:   "open-gate",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/gate/open:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/open:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/open:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "openGate"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_put_ip_address_map_entry.go
+++ b/soracom/generated/cmd/vpg_put_ip_address_map_entry.go
@@ -40,7 +40,7 @@ func init() {
 var VpgPutIpAddressMapEntryCmd = &cobra.Command{
 	Use:   "put-ip-address-map-entry",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/ip_address_map:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/ip_address_map:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/ip_address_map:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "putVirtualPrivateGatewayIpAddressMapEntry"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_register_gate_peer.go
+++ b/soracom/generated/cmd/vpg_register_gate_peer.go
@@ -40,7 +40,7 @@ func init() {
 var VpgRegisterGatePeerCmd = &cobra.Command{
 	Use:   "register-gate-peer",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/gate/peers:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/peers:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/peers:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "registerGatePeer"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_set_inspection.go
+++ b/soracom/generated/cmd/vpg_set_inspection.go
@@ -35,7 +35,7 @@ func init() {
 var VpgSetInspectionCmd = &cobra.Command{
 	Use:   "set-inspection",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/set_inspection:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/set_inspection:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/set_inspection:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "setInspectionConfiguration"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_set_redirection.go
+++ b/soracom/generated/cmd/vpg_set_redirection.go
@@ -45,7 +45,7 @@ func init() {
 var VpgSetRedirectionCmd = &cobra.Command{
 	Use:   "set-redirection",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/set_redirection:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/set_redirection:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/set_redirection:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "setRedirectionConfiguration"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_set_routing_filter.go
+++ b/soracom/generated/cmd/vpg_set_routing_filter.go
@@ -30,7 +30,7 @@ func init() {
 var VpgSetRoutingFilterCmd = &cobra.Command{
 	Use:   "set-routing-filter",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/set_routing_filter:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/set_routing_filter:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/set_routing_filter:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "setRoutingFilter"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_stop_packet_capture_session.go
+++ b/soracom/generated/cmd/vpg_stop_packet_capture_session.go
@@ -26,7 +26,7 @@ func init() {
 var VpgStopPacketCaptureSessionCmd = &cobra.Command{
 	Use:   "stop-packet-capture-session",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}/stop:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}/stop:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/packet_capture_sessions/{session_id}/stop:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "stopPacketCaptureSession"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_terminate.go
+++ b/soracom/generated/cmd/vpg_terminate.go
@@ -21,7 +21,7 @@ func init() {
 var VpgTerminateCmd = &cobra.Command{
 	Use:   "terminate",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/terminate:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/terminate:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/terminate:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "terminateVirtualPrivateGateway"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_unregister_gate_peer.go
+++ b/soracom/generated/cmd/vpg_unregister_gate_peer.go
@@ -26,7 +26,7 @@ func init() {
 var VpgUnregisterGatePeerCmd = &cobra.Command{
 	Use:   "unregister-gate-peer",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/gate/peers/{outer_ip_address}:delete:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/peers/{outer_ip_address}:delete:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/gate/peers/{outer_ip_address}:delete:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "unregisterGatePeer"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_unset_inspection.go
+++ b/soracom/generated/cmd/vpg_unset_inspection.go
@@ -21,7 +21,7 @@ func init() {
 var VpgUnsetInspectionCmd = &cobra.Command{
 	Use:   "unset-inspection",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/unset_inspection:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/unset_inspection:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/unset_inspection:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "unsetInspectionConfiguration"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_unset_redirection.go
+++ b/soracom/generated/cmd/vpg_unset_redirection.go
@@ -21,7 +21,7 @@ func init() {
 var VpgUnsetRedirectionCmd = &cobra.Command{
 	Use:   "unset-redirection",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/unset_redirection:post:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/unset_redirection:post:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/unset_redirection:post:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "unsetRedirectionConfiguration"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {

--- a/soracom/generated/cmd/vpg_update_mirroring_peer.go
+++ b/soracom/generated/cmd/vpg_update_mirroring_peer.go
@@ -35,7 +35,7 @@ func init() {
 var VpgUpdateMirroringPeerCmd = &cobra.Command{
 	Use:   "update-mirroring-peer",
 	Short: TRAPI("/virtual_private_gateways/{vpg_id}/junction/mirroring/peers/{ipaddr}:put:summary"),
-	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/mirroring/peers/{ipaddr}:put:description`),
+	Long:  TRAPI(`/virtual_private_gateways/{vpg_id}/junction/mirroring/peers/{ipaddr}:put:description`) + "\n\n" + createLinkToAPIReference("VirtualPrivateGateway", "updateMirroringPeer"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if len(args) > 0 {


### PR DESCRIPTION
コマンドの引数やレスポンスの型などについての詳細は API リファレンスのサイトを参照してもらうとよいのではということで、ヘルプメッセージ中に API リファレンスへのリンク（URL）を表示するようにしました。

実行時のイメージは以下のとおりです：

英語：
```
$ ./soracom/dist/0.0.0/soracom_0.0.0_linux_amd64 users delete -h        
Deletes the SAM user.

For more information on the arguments and response of this command, see https://developers.soracom.io/en/api/#!/User/deleteUser

Usage:
  soracom users delete [flags]

Flags:
  -h, --help                 help for delete
      --operator-id string   operator_id
      --user-name string     user_name
...
```

日本語：
```
$ LANG=ja ./soracom/dist/0.0.0/soracom_0.0.0_linux_amd64 users delete -h
SAM ユーザーを削除する。

このコマンドの引数やレスポンスについての詳細は, https://users.soracom.io/ja-jp/tools/api/reference/#/User/deleteUser を参照してください。

Usage:
  soracom users delete [flags]

Flags:
  -h, --help                 help for delete
      --operator-id string   operator_id
      --user-name string     user_name
...
```
