### PR TITLE
support string slice parameters in request body

### DIFF
--- a/generators/cmd/templates/leaf.gotmpl
+++ b/generators/cmd/templates/leaf.gotmpl
@@ -384,6 +384,14 @@ func buildBodyFor{{$suffix}}() (string, error) {
   {{end}}
   {{end}}
 
+  {{range .StringSliceFlags}}
+  {{if eq .In "body"}}
+  if len({{$prefix}}{{.VarName}}) != 0 {
+    result["{{.Name}}"] = {{$prefix}}{{.VarName}}
+  }
+  {{end}}
+  {{end}}
+
   {{range .IntegerFlags}}
   {{if eq .In "body"}}
   if {{$prefix}}{{.VarName}} != {{.DefaultValue}} {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tj/assert v0.0.3
-	golang.org/x/sys v0.0.0-20220823224334-20c2bfdbfe24
+	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -426,6 +426,8 @@ golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdp
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220823224334-20c2bfdbfe24 h1:TyKJRhyo17yWxOMCTHKWrc5rddHORMlnZ/j57umaUd8=
 golang.org/x/sys v0.0.0-20220823224334-20c2bfdbfe24/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec h1:BkDtF2Ih9xZ7le9ndzTA7KJow28VbQW3odyk/8drmuI=
+golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/soracom/generated/cmd/lagoon_migration_migrate.go
+++ b/soracom/generated/cmd/lagoon_migration_migrate.go
@@ -15,10 +15,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// LagoonMigrationMigrateCmdDashboardIds holds multiple values of 'dashboardIds' option
+var LagoonMigrationMigrateCmdDashboardIds []string
+
 // LagoonMigrationMigrateCmdBody holds contents of request body to be sent
 var LagoonMigrationMigrateCmdBody string
 
 func init() {
+	LagoonMigrationMigrateCmd.Flags().StringSliceVar(&LagoonMigrationMigrateCmdDashboardIds, "dashboard-ids", []string{}, TRAPI("A list of dashboard IDs to migrate"))
+
 	LagoonMigrationMigrateCmd.Flags().StringVar(&LagoonMigrationMigrateCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	LagoonMigrationCmd.AddCommand(LagoonMigrationMigrateCmd)
 }
@@ -142,6 +147,10 @@ func buildBodyForLagoonMigrationMigrateCmd() (string, error) {
 
 	if result == nil {
 		result = make(map[string]interface{})
+	}
+
+	if len(LagoonMigrationMigrateCmdDashboardIds) != 0 {
+		result["dashboardIds"] = LagoonMigrationMigrateCmdDashboardIds
 	}
 
 	resultBytes, err := json.Marshal(result)

--- a/soracom/generated/cmd/lora_network_sets_create.go
+++ b/soracom/generated/cmd/lora_network_sets_create.go
@@ -25,6 +25,9 @@ var LoraNetworkSetsCreateCmdNetworkSetId string
 // LoraNetworkSetsCreateCmdOperatorId holds value of 'operatorId' option
 var LoraNetworkSetsCreateCmdOperatorId string
 
+// LoraNetworkSetsCreateCmdAllowedOperators holds multiple values of 'allowedOperators' option
+var LoraNetworkSetsCreateCmdAllowedOperators []string
+
 // LoraNetworkSetsCreateCmdBody holds contents of request body to be sent
 var LoraNetworkSetsCreateCmdBody string
 
@@ -36,6 +39,8 @@ func init() {
 	LoraNetworkSetsCreateCmd.Flags().StringVar(&LoraNetworkSetsCreateCmdNetworkSetId, "network-set-id", "", TRAPI(""))
 
 	LoraNetworkSetsCreateCmd.Flags().StringVar(&LoraNetworkSetsCreateCmdOperatorId, "operator-id", "", TRAPI(""))
+
+	LoraNetworkSetsCreateCmd.Flags().StringSliceVar(&LoraNetworkSetsCreateCmdAllowedOperators, "allowed-operators", []string{}, TRAPI(""))
 
 	LoraNetworkSetsCreateCmd.Flags().StringVar(&LoraNetworkSetsCreateCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	LoraNetworkSetsCmd.AddCommand(LoraNetworkSetsCreateCmd)
@@ -175,6 +180,10 @@ func buildBodyForLoraNetworkSetsCreateCmd() (string, error) {
 
 	if LoraNetworkSetsCreateCmdOperatorId != "" {
 		result["operatorId"] = LoraNetworkSetsCreateCmdOperatorId
+	}
+
+	if len(LoraNetworkSetsCreateCmdAllowedOperators) != 0 {
+		result["allowedOperators"] = LoraNetworkSetsCreateCmdAllowedOperators
 	}
 
 	resultBytes, err := json.Marshal(result)

--- a/soracom/generated/cmd/sandbox_init.go
+++ b/soracom/generated/cmd/sandbox_init.go
@@ -25,6 +25,9 @@ var SandboxInitCmdEmail string
 // SandboxInitCmdPassword holds value of 'password' option
 var SandboxInitCmdPassword string
 
+// SandboxInitCmdCoverageTypes holds multiple values of 'coverageTypes' option
+var SandboxInitCmdCoverageTypes []string
+
 // SandboxInitCmdRegisterPaymentMethod holds value of 'registerPaymentMethod' option
 var SandboxInitCmdRegisterPaymentMethod bool
 
@@ -39,6 +42,8 @@ func init() {
 	SandboxInitCmd.Flags().StringVar(&SandboxInitCmdEmail, "email", "", TRAPI(""))
 
 	SandboxInitCmd.Flags().StringVar(&SandboxInitCmdPassword, "password", "", TRAPI(""))
+
+	SandboxInitCmd.Flags().StringSliceVar(&SandboxInitCmdCoverageTypes, "coverage-types", []string{}, TRAPI("Coverage type.- `g`: Global coverage- `jp`: Japan coverage"))
 
 	SandboxInitCmd.Flags().BoolVar(&SandboxInitCmdRegisterPaymentMethod, "register-payment-method", true, TRAPI(""))
 
@@ -195,6 +200,10 @@ func buildBodyForSandboxInitCmd() (string, error) {
 
 	if SandboxInitCmdPassword != "" {
 		result["password"] = SandboxInitCmdPassword
+	}
+
+	if len(SandboxInitCmdCoverageTypes) != 0 {
+		result["coverageTypes"] = SandboxInitCmdCoverageTypes
 	}
 
 	if SandboxInitCmdRegisterPaymentMethod != true {

--- a/soracom/generated/cmd/sandbox_subscribers_create.go
+++ b/soracom/generated/cmd/sandbox_subscribers_create.go
@@ -16,11 +16,16 @@ import (
 // SandboxSubscribersCreateCmdSubscription holds value of 'subscription' option
 var SandboxSubscribersCreateCmdSubscription string
 
+// SandboxSubscribersCreateCmdBundles holds multiple values of 'bundles' option
+var SandboxSubscribersCreateCmdBundles []string
+
 // SandboxSubscribersCreateCmdBody holds contents of request body to be sent
 var SandboxSubscribersCreateCmdBody string
 
 func init() {
 	SandboxSubscribersCreateCmd.Flags().StringVar(&SandboxSubscribersCreateCmdSubscription, "subscription", "", TRAPI("Subscription. Specify one of:"))
+
+	SandboxSubscribersCreateCmd.Flags().StringSliceVar(&SandboxSubscribersCreateCmdBundles, "bundles", []string{}, TRAPI("Bundle. If necessary, specify one of:"))
 
 	SandboxSubscribersCreateCmd.Flags().StringVar(&SandboxSubscribersCreateCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	SandboxSubscribersCmd.AddCommand(SandboxSubscribersCreateCmd)
@@ -148,6 +153,10 @@ func buildBodyForSandboxSubscribersCreateCmd() (string, error) {
 
 	if SandboxSubscribersCreateCmdSubscription != "" {
 		result["subscription"] = SandboxSubscribersCreateCmdSubscription
+	}
+
+	if len(SandboxSubscribersCreateCmdBundles) != 0 {
+		result["bundles"] = SandboxSubscribersCreateCmdBundles
 	}
 
 	resultBytes, err := json.Marshal(result)

--- a/soracom/generated/cmd/subscribers_issue_transfer_token.go
+++ b/soracom/generated/cmd/subscribers_issue_transfer_token.go
@@ -19,6 +19,9 @@ var SubscribersIssueTransferTokenCmdTransferDestinationOperatorEmail string
 // SubscribersIssueTransferTokenCmdTransferDestinationOperatorId holds value of 'transferDestinationOperatorId' option
 var SubscribersIssueTransferTokenCmdTransferDestinationOperatorId string
 
+// SubscribersIssueTransferTokenCmdTransferImsi holds multiple values of 'transferImsi' option
+var SubscribersIssueTransferTokenCmdTransferImsi []string
+
 // SubscribersIssueTransferTokenCmdBody holds contents of request body to be sent
 var SubscribersIssueTransferTokenCmdBody string
 
@@ -26,6 +29,8 @@ func init() {
 	SubscribersIssueTransferTokenCmd.Flags().StringVar(&SubscribersIssueTransferTokenCmdTransferDestinationOperatorEmail, "transfer-destination-operator-email", "", TRAPI("Email address of the destination operator."))
 
 	SubscribersIssueTransferTokenCmd.Flags().StringVar(&SubscribersIssueTransferTokenCmdTransferDestinationOperatorId, "transfer-destination-operator-id", "", TRAPI("Operator ID of the destination operator."))
+
+	SubscribersIssueTransferTokenCmd.Flags().StringSliceVar(&SubscribersIssueTransferTokenCmdTransferImsi, "transfer-imsi", []string{}, TRAPI("List of IMSIs to be transferred."))
 
 	SubscribersIssueTransferTokenCmd.Flags().StringVar(&SubscribersIssueTransferTokenCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	SubscribersCmd.AddCommand(SubscribersIssueTransferTokenCmd)
@@ -108,6 +113,11 @@ func collectSubscribersIssueTransferTokenCmdParams(ac *apiClient) (*apiParams, e
 		return nil, err
 	}
 
+	err = checkIfRequiredStringSliceParameterIsSupplied("transferImsi", "transfer-imsi", "body", parsedBody, SubscribersIssueTransferTokenCmdTransferImsi)
+	if err != nil {
+		return nil, err
+	}
+
 	return &apiParams{
 		method:      "POST",
 		path:        buildPathForSubscribersIssueTransferTokenCmd("/subscribers/transfer_token/issue"),
@@ -167,6 +177,10 @@ func buildBodyForSubscribersIssueTransferTokenCmd() (string, error) {
 
 	if SubscribersIssueTransferTokenCmdTransferDestinationOperatorId != "" {
 		result["transferDestinationOperatorId"] = SubscribersIssueTransferTokenCmdTransferDestinationOperatorId
+	}
+
+	if len(SubscribersIssueTransferTokenCmdTransferImsi) != 0 {
+		result["transferImsi"] = SubscribersIssueTransferTokenCmdTransferImsi
 	}
 
 	resultBytes, err := json.Marshal(result)

--- a/soracom/generated/cmd/system_notifications_set.go
+++ b/soracom/generated/cmd/system_notifications_set.go
@@ -22,6 +22,9 @@ var SystemNotificationsSetCmdPassword string
 // SystemNotificationsSetCmdType holds value of 'type' option
 var SystemNotificationsSetCmdType string
 
+// SystemNotificationsSetCmdEmailIdList holds multiple values of 'emailIdList' option
+var SystemNotificationsSetCmdEmailIdList []string
+
 // SystemNotificationsSetCmdBody holds contents of request body to be sent
 var SystemNotificationsSetCmdBody string
 
@@ -31,6 +34,8 @@ func init() {
 	SystemNotificationsSetCmd.Flags().StringVar(&SystemNotificationsSetCmdPassword, "password", "", TRAPI("Password of the operator. This is necessary when type is primary."))
 
 	SystemNotificationsSetCmd.Flags().StringVar(&SystemNotificationsSetCmdType, "type", "", TRAPI("system notification type"))
+
+	SystemNotificationsSetCmd.Flags().StringSliceVar(&SystemNotificationsSetCmdEmailIdList, "email-id-list", []string{}, TRAPI(""))
 
 	SystemNotificationsSetCmd.Flags().StringVar(&SystemNotificationsSetCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	SystemNotificationsCmd.AddCommand(SystemNotificationsSetCmd)
@@ -112,6 +117,11 @@ func collectSystemNotificationsSetCmdParams(ac *apiClient) (*apiParams, error) {
 		return nil, err
 	}
 
+	err = checkIfRequiredStringSliceParameterIsSupplied("emailIdList", "email-id-list", "body", parsedBody, SystemNotificationsSetCmdEmailIdList)
+	if err != nil {
+		return nil, err
+	}
+
 	return &apiParams{
 		method:      "POST",
 		path:        buildPathForSystemNotificationsSetCmd("/operators/{operator_id}/system_notifications/{type}"),
@@ -175,6 +185,10 @@ func buildBodyForSystemNotificationsSetCmd() (string, error) {
 
 	if SystemNotificationsSetCmdPassword != "" {
 		result["password"] = SystemNotificationsSetCmdPassword
+	}
+
+	if len(SystemNotificationsSetCmdEmailIdList) != 0 {
+		result["emailIdList"] = SystemNotificationsSetCmdEmailIdList
 	}
 
 	resultBytes, err := json.Marshal(result)


### PR DESCRIPTION
リクエスト Body の JSON のトップレベルの要素は `--body` を使わなくてもコマンドライン引数で直接指定することができるという機能がありますが、文字列の配列には対応していなかったので対応させました。

たとえば、`soracom system-notifications set` コマンドは Body に以下のような引数を指定できますが、

```
{
  "emailIdList": ["foo@example.com", "bar@example.com"],
  "password": "P@$$w0rd",
}
```

従来は `password` のみ `soracom` コマンドに引数として直接指定することができ、`emailIdList` は `--body` 引数として JSON 形式で指定する必要がありました:

```
soracom system-notifications set --type primary --password "$password" --body "{\"emailIdList\":[\"foo@example.com\",\"bar@example.com\"]}"
```

今回の変更により、

```
soracom system-notifications set --type primary --password "$password" --email-id-list "foo@example.com" --email-id-list "bar@example.com"
```

というふうに指定できるようになりました。



ついでに軽くリファクタリングを行ったので変更量がすこし多くなってしまいました :bow: 