### PR TITLE
Include License in package

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -65,8 +65,11 @@ build_deb_package() {
   mkdir -p "$tmpdir/usr/bin/"
   cp "$bindir/$bin" "$tmpdir/usr/bin/soracom"
 
-  mkdir -p "$tmpdir/usr/doc/shared/soracom/"
-  cat << EOD > "$tmpdir/usr/doc/shared/soracom/copyright"
+  local license_text
+  license_text="$( sed -e '1,4d' -e 's/^$/./' -e 's/^/ /' -e '$s/^ \.$//' "$d/LICENSE" )"
+
+  mkdir -p "$tmpdir/usr/share/doc/soracom/"
+  cat << EOD > "$tmpdir/usr/share/doc/soracom/copyright"
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: soracom-cli
 Source: https://github.com/soracom/soracom-cli
@@ -76,23 +79,7 @@ Copyright: 2015 Soracom, Inc.
 License: MIT
 
 License: MIT
- Permission is hereby granted, free of charge, to any person obtaining a
- copy of this software and associated documentation files (the "Software"),
- to deal in the Software without restriction, including without limitation
- the rights to use, copy, modify, merge, publish, distribute, sublicense,
- and/or sell copies of the Software, and to permit persons to whom the
- Software is furnished to do so, subject to the following conditions:
- .
- The above copyright notice and this permission notice shall be included
- in all copies or substantial portions of the Software.
- .
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
- CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
- TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
- SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+${license_text}
 EOD
   
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -59,11 +59,45 @@ build_deb_package() {
       ;;
   esac
 
-  fsize="$( stat --printf="%s" "$bindir/$bin" )"
-  fsize="$(( fsize / 1024 ))"
-
   tmpdir="$( mktemp -d )"
   trap 'remove_tmpdir $tmpdir' RETURN
+
+  mkdir -p "$tmpdir/usr/bin/"
+  cp "$bindir/$bin" "$tmpdir/usr/bin/soracom"
+
+  mkdir -p "$tmpdir/usr/doc/shared/soracom/"
+  cat << EOD > "$tmpdir/usr/doc/shared/soracom/copyright"
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: soracom-cli
+Source: https://github.com/soracom/soracom-cli
+
+Files: *
+Copyright: 2015 Soracom, Inc.
+License: MIT
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+EOD
+  
+
+  fsize="$( find $tmpdir -type f -not -path "$tmpdir/DEBIAN/*" -exec du -cb {} + | tail -1 | cut -f1 )"
+  fsize="$(( fsize / 1024 ))"
 
   mkdir -p "$tmpdir/DEBIAN"
   cat << EOD > "$tmpdir/DEBIAN/control"
@@ -76,9 +110,6 @@ Architecture: $arch
 Description: A command line tool \`soracom\' to invoke SORACOM API.
 Installed-Size: $fsize
 EOD
-
-  mkdir -p "$tmpdir/usr/bin/"
-  cp "$bindir/$bin" "$tmpdir/usr/bin/soracom"
 
   fakeroot dpkg-deb --build "$tmpdir" "$bindir/soracom_${VERSION}_$arch.deb" &> /dev/null
 }


### PR DESCRIPTION
お世話になっております。
メカトラックス株式会社の清永と申します。
現在、弊社リポジトリ（mechatrax.github.io）にて御社の soracom-cli を再配布しております。
誠に勝手ではございますが、ビルドするパッケージにライセンスを含めるよう変更していただくことは可能でしょうか。
お忙しいところ恐れ入りますが、ご検討のほど宜しくお願いいたします。