### PR TITLE
Avoid using backticks in parameter help text

### DIFF
--- a/generators/cmd/src/gen_leaf_cmd.go
+++ b/generators/cmd/src/gen_leaf_cmd.go
@@ -843,7 +843,7 @@ func containsString(ss []string, target string) bool {
 }
 
 func convertDescriptionToShortHelp(description string) string {
-	return trimTemplate(escapeDoubleQuotationMarks(removeLineBreaks(description)))
+	return replaceBackticksWithSingleQuotationMarks(trimTemplate(escapeDoubleQuotationMarks(removeLineBreaks(description))))
 }
 
 var lineBreaks = regexp.MustCompile(`[\r\n]`)
@@ -861,4 +861,8 @@ var templateRegex = regexp.MustCompile(`^\s*\${(.+)}\s*$`)
 func trimTemplate(s string) string {
 	b1 := templateRegex.ReplaceAll([]byte(s), []byte("$1"))
 	return string(b1)
+}
+
+func replaceBackticksWithSingleQuotationMarks(s string) string {
+	return strings.ReplaceAll(s, "`", "'")
 }

--- a/soracom/generated/cmd/audit_logs_api_get.go
+++ b/soracom/generated/cmd/audit_logs_api_get.go
@@ -33,7 +33,7 @@ var AuditLogsApiGetCmdOutputJSONL bool
 func init() {
 	AuditLogsApiGetCmd.Flags().StringVar(&AuditLogsApiGetCmdApiKind, "api-kind", "", TRAPI("Filter item for audit log retrieval by API kind."))
 
-	AuditLogsApiGetCmd.Flags().StringVar(&AuditLogsApiGetCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `requestedTimeEpochMs` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
+	AuditLogsApiGetCmd.Flags().StringVar(&AuditLogsApiGetCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of 'requestedTimeEpochMs' in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
 	AuditLogsApiGetCmd.Flags().Int64Var(&AuditLogsApiGetCmdFromEpochMs, "from-epoch-ms", 0, TRAPI("Start time for the log search range (unixtime milliseconds)."))
 

--- a/soracom/generated/cmd/audit_logs_napter_get.go
+++ b/soracom/generated/cmd/audit_logs_napter_get.go
@@ -34,7 +34,7 @@ var AuditLogsNapterGetCmdPaginate bool
 var AuditLogsNapterGetCmdOutputJSONL bool
 
 func init() {
-	AuditLogsNapterGetCmd.Flags().StringVar(&AuditLogsNapterGetCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
+	AuditLogsNapterGetCmd.Flags().StringVar(&AuditLogsNapterGetCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of 'time' in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
 	AuditLogsNapterGetCmd.Flags().StringVar(&AuditLogsNapterGetCmdResourceId, "resource-id", "", TRAPI("Identity of the target resource to query log entries."))
 

--- a/soracom/generated/cmd/bills_export.go
+++ b/soracom/generated/cmd/bills_export.go
@@ -16,7 +16,7 @@ var BillsExportCmdExportMode string
 var BillsExportCmdYyyyMM string
 
 func init() {
-	BillsExportCmd.Flags().StringVar(&BillsExportCmdExportMode, "export-mode", "", TRAPI("Specify how to get the URL to download the billing details CSV.- `async`: Get the `exportedFieldId` without waiting for the URL to be issued on the SORACOM platform. Specify this `exportedFieldId` in [`Files:getExportedFile API`](#/Files/getExportedFile) to get the URL. If the file size of the billing details CSV is huge, use `async`.- `sync` (default): Wait for the URL to be issued on the SORACOM platform. However, if the file size of the billing details CSV is huge, it may time out and the URL cannot be retrieved. If the timeout occurs, specify `async`."))
+	BillsExportCmd.Flags().StringVar(&BillsExportCmdExportMode, "export-mode", "", TRAPI("Specify how to get the URL to download the billing details CSV.- 'async': Get the 'exportedFieldId' without waiting for the URL to be issued on the SORACOM platform. Specify this 'exportedFieldId' in ['Files:getExportedFile API'](#/Files/getExportedFile) to get the URL. If the file size of the billing details CSV is huge, use 'async'.- 'sync' (default): Wait for the URL to be issued on the SORACOM platform. However, if the file size of the billing details CSV is huge, it may time out and the URL cannot be retrieved. If the timeout occurs, specify 'async'."))
 
 	BillsExportCmd.Flags().StringVar(&BillsExportCmdYyyyMM, "yyyy-mm", "", TRAPI("Target year and month"))
 	BillsCmd.AddCommand(BillsExportCmd)

--- a/soracom/generated/cmd/cell_locations_get.go
+++ b/soracom/generated/cmd/cell_locations_get.go
@@ -33,9 +33,9 @@ var CellLocationsGetCmdTac string
 func init() {
 	CellLocationsGetCmd.Flags().StringVar(&CellLocationsGetCmdCid, "cid", "", TRAPI("CID - Cell ID (for 3G)"))
 
-	CellLocationsGetCmd.Flags().StringVar(&CellLocationsGetCmdEci, "eci", "", TRAPI("ECID - Enhanced Cell ID (for 4G) - specify either `ecid` or `eci`"))
+	CellLocationsGetCmd.Flags().StringVar(&CellLocationsGetCmdEci, "eci", "", TRAPI("ECID - Enhanced Cell ID (for 4G) - specify either 'ecid' or 'eci'"))
 
-	CellLocationsGetCmd.Flags().StringVar(&CellLocationsGetCmdEcid, "ecid", "", TRAPI("ECID - Enhanced Cell ID (for 4G) - specify either `ecid` or `eci`"))
+	CellLocationsGetCmd.Flags().StringVar(&CellLocationsGetCmdEcid, "ecid", "", TRAPI("ECID - Enhanced Cell ID (for 4G) - specify either 'ecid' or 'eci'"))
 
 	CellLocationsGetCmd.Flags().StringVar(&CellLocationsGetCmdLac, "lac", "", TRAPI("LAC - Location Area Code (for 3G)"))
 

--- a/soracom/generated/cmd/data_get.go
+++ b/soracom/generated/cmd/data_get.go
@@ -36,7 +36,7 @@ var DataGetCmdOutputJSONL bool
 func init() {
 	DataGetCmd.Flags().StringVar(&DataGetCmdImsi, "imsi", "", TRAPI("IMSI of the target subscriber that generated data entries."))
 
-	DataGetCmd.Flags().StringVar(&DataGetCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
+	DataGetCmd.Flags().StringVar(&DataGetCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of 'time' in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
 	DataGetCmd.Flags().StringVar(&DataGetCmdSort, "sort", "desc", TRAPI("Sort order of the data entries. Either descending (latest data entry first) or ascending (oldest data entry first)."))
 

--- a/soracom/generated/cmd/data_get_entries.go
+++ b/soracom/generated/cmd/data_get_entries.go
@@ -37,7 +37,7 @@ var DataGetEntriesCmdPaginate bool
 var DataGetEntriesCmdOutputJSONL bool
 
 func init() {
-	DataGetEntriesCmd.Flags().StringVar(&DataGetEntriesCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
+	DataGetEntriesCmd.Flags().StringVar(&DataGetEntriesCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of 'time' in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
 	DataGetEntriesCmd.Flags().StringVar(&DataGetEntriesCmdResourceId, "resource-id", "", TRAPI("ID of data source resource"))
 

--- a/soracom/generated/cmd/data_list_source_resources.go
+++ b/soracom/generated/cmd/data_list_source_resources.go
@@ -25,7 +25,7 @@ var DataListSourceResourcesCmdPaginate bool
 var DataListSourceResourcesCmdOutputJSONL bool
 
 func init() {
-	DataListSourceResourcesCmd.Flags().StringVar(&DataListSourceResourcesCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `resourceId` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
+	DataListSourceResourcesCmd.Flags().StringVar(&DataListSourceResourcesCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of 'resourceId' in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
 	DataListSourceResourcesCmd.Flags().StringVar(&DataListSourceResourcesCmdResourceType, "resource-type", "", TRAPI("Type of data source resource"))
 

--- a/soracom/generated/cmd/devices_get_data.go
+++ b/soracom/generated/cmd/devices_get_data.go
@@ -36,7 +36,7 @@ var DevicesGetDataCmdOutputJSONL bool
 func init() {
 	DevicesGetDataCmd.Flags().StringVar(&DevicesGetDataCmdDeviceId, "device-id", "", TRAPI("Device ID of the target subscriber that generated data entries."))
 
-	DevicesGetDataCmd.Flags().StringVar(&DevicesGetDataCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
+	DevicesGetDataCmd.Flags().StringVar(&DevicesGetDataCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of 'time' in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
 	DevicesGetDataCmd.Flags().StringVar(&DevicesGetDataCmdSort, "sort", "desc", TRAPI("Sort order of the data entries. Either descending (latest data entry first) or ascending (oldest data entry first)."))
 

--- a/soracom/generated/cmd/gadgets_list.go
+++ b/soracom/generated/cmd/gadgets_list.go
@@ -40,7 +40,7 @@ func init() {
 
 	GadgetsListCmd.Flags().StringVar(&GadgetsListCmdTagName, "tag-name", "", TRAPI("Tag name for filtering the search (exact match)."))
 
-	GadgetsListCmd.Flags().StringVar(&GadgetsListCmdTagValue, "tag-value", "", TRAPI("Tag search string for filtering the search. Required when `tag_name` has been specified."))
+	GadgetsListCmd.Flags().StringVar(&GadgetsListCmdTagValue, "tag-value", "", TRAPI("Tag search string for filtering the search. Required when 'tag_name' has been specified."))
 
 	GadgetsListCmd.Flags().StringVar(&GadgetsListCmdTagValueMatchMode, "tag-value-match-mode", "exact", TRAPI("Tag match mode."))
 

--- a/soracom/generated/cmd/logs_get.go
+++ b/soracom/generated/cmd/logs_get.go
@@ -37,7 +37,7 @@ var LogsGetCmdPaginate bool
 var LogsGetCmdOutputJSONL bool
 
 func init() {
-	LogsGetCmd.Flags().StringVar(&LogsGetCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
+	LogsGetCmd.Flags().StringVar(&LogsGetCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of 'time' in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
 	LogsGetCmd.Flags().StringVar(&LogsGetCmdResourceId, "resource-id", "", TRAPI("Identity of the target resource to query log entries."))
 

--- a/soracom/generated/cmd/lora_devices_get_data.go
+++ b/soracom/generated/cmd/lora_devices_get_data.go
@@ -36,7 +36,7 @@ var LoraDevicesGetDataCmdOutputJSONL bool
 func init() {
 	LoraDevicesGetDataCmd.Flags().StringVar(&LoraDevicesGetDataCmdDeviceId, "device-id", "", TRAPI("Device ID of the target subscriber that generated data entries."))
 
-	LoraDevicesGetDataCmd.Flags().StringVar(&LoraDevicesGetDataCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
+	LoraDevicesGetDataCmd.Flags().StringVar(&LoraDevicesGetDataCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of 'time' in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
 	LoraDevicesGetDataCmd.Flags().StringVar(&LoraDevicesGetDataCmdSort, "sort", "desc", TRAPI("Sort order of the data entries. Either descending (latest data entry first) or ascending (oldest data entry first)."))
 

--- a/soracom/generated/cmd/lora_devices_list.go
+++ b/soracom/generated/cmd/lora_devices_list.go
@@ -35,7 +35,7 @@ func init() {
 
 	LoraDevicesListCmd.Flags().StringVar(&LoraDevicesListCmdTagName, "tag-name", "", TRAPI("Tag name for filtering the search (exact match)."))
 
-	LoraDevicesListCmd.Flags().StringVar(&LoraDevicesListCmdTagValue, "tag-value", "", TRAPI("Tag search string for filtering the search. Required when `tag_name` has been specified."))
+	LoraDevicesListCmd.Flags().StringVar(&LoraDevicesListCmdTagValue, "tag-value", "", TRAPI("Tag search string for filtering the search. Required when 'tag_name' has been specified."))
 
 	LoraDevicesListCmd.Flags().StringVar(&LoraDevicesListCmdTagValueMatchMode, "tag-value-match-mode", "exact", TRAPI("Tag match mode."))
 

--- a/soracom/generated/cmd/lora_gateways_list.go
+++ b/soracom/generated/cmd/lora_gateways_list.go
@@ -35,7 +35,7 @@ func init() {
 
 	LoraGatewaysListCmd.Flags().StringVar(&LoraGatewaysListCmdTagName, "tag-name", "", TRAPI("Tag name for filtering the search (exact match)."))
 
-	LoraGatewaysListCmd.Flags().StringVar(&LoraGatewaysListCmdTagValue, "tag-value", "", TRAPI("Tag search string for filtering the search. Required when `tag_name` has been specified."))
+	LoraGatewaysListCmd.Flags().StringVar(&LoraGatewaysListCmdTagValue, "tag-value", "", TRAPI("Tag search string for filtering the search. Required when 'tag_name' has been specified."))
 
 	LoraGatewaysListCmd.Flags().StringVar(&LoraGatewaysListCmdTagValueMatchMode, "tag-value-match-mode", "exact", TRAPI("Tag match mode."))
 

--- a/soracom/generated/cmd/lora_network_sets_list.go
+++ b/soracom/generated/cmd/lora_network_sets_list.go
@@ -35,7 +35,7 @@ func init() {
 
 	LoraNetworkSetsListCmd.Flags().StringVar(&LoraNetworkSetsListCmdTagName, "tag-name", "", TRAPI("Tag name for filtering the search (exact match)."))
 
-	LoraNetworkSetsListCmd.Flags().StringVar(&LoraNetworkSetsListCmdTagValue, "tag-value", "", TRAPI("Tag search string for filtering the search. Required when `tag_name` has been specified."))
+	LoraNetworkSetsListCmd.Flags().StringVar(&LoraNetworkSetsListCmdTagValue, "tag-value", "", TRAPI("Tag search string for filtering the search. Required when 'tag_name' has been specified."))
 
 	LoraNetworkSetsListCmd.Flags().StringVar(&LoraNetworkSetsListCmdTagValueMatchMode, "tag-value-match-mode", "exact", TRAPI("Tag match mode."))
 

--- a/soracom/generated/cmd/orders_cancel.go
+++ b/soracom/generated/cmd/orders_cancel.go
@@ -13,7 +13,7 @@ import (
 var OrdersCancelCmdOrderId string
 
 func init() {
-	OrdersCancelCmd.Flags().StringVar(&OrdersCancelCmdOrderId, "order-id", "", TRAPI("Order ID. You can get it by calling [`Order:listOrders API`](#/Order/listOrders)."))
+	OrdersCancelCmd.Flags().StringVar(&OrdersCancelCmdOrderId, "order-id", "", TRAPI("Order ID. You can get it by calling ['Order:listOrders API'](#/Order/listOrders)."))
 	OrdersCmd.AddCommand(OrdersCancelCmd)
 }
 

--- a/soracom/generated/cmd/orders_confirm.go
+++ b/soracom/generated/cmd/orders_confirm.go
@@ -13,7 +13,7 @@ import (
 var OrdersConfirmCmdOrderId string
 
 func init() {
-	OrdersConfirmCmd.Flags().StringVar(&OrdersConfirmCmdOrderId, "order-id", "", TRAPI("Order ID. You can get it by calling [`Order:listOrders API`](#/Order/listOrders)."))
+	OrdersConfirmCmd.Flags().StringVar(&OrdersConfirmCmdOrderId, "order-id", "", TRAPI("Order ID. You can get it by calling ['Order:listOrders API'](#/Order/listOrders)."))
 	OrdersCmd.AddCommand(OrdersConfirmCmd)
 }
 

--- a/soracom/generated/cmd/orders_get.go
+++ b/soracom/generated/cmd/orders_get.go
@@ -13,7 +13,7 @@ import (
 var OrdersGetCmdOrderId string
 
 func init() {
-	OrdersGetCmd.Flags().StringVar(&OrdersGetCmdOrderId, "order-id", "", TRAPI("Order ID. You can get it by calling [`Order:listOrders API`](#/Order/listOrders)."))
+	OrdersGetCmd.Flags().StringVar(&OrdersGetCmdOrderId, "order-id", "", TRAPI("Order ID. You can get it by calling ['Order:listOrders API'](#/Order/listOrders)."))
 	OrdersCmd.AddCommand(OrdersGetCmd)
 }
 

--- a/soracom/generated/cmd/orders_list_subscribers.go
+++ b/soracom/generated/cmd/orders_list_subscribers.go
@@ -24,7 +24,7 @@ var OrdersListSubscribersCmdPaginate bool
 func init() {
 	OrdersListSubscribersCmd.Flags().StringVar(&OrdersListSubscribersCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("Serial number of the last subscriber in the previous page that is set to response header with X-Soracom-Next-Key."))
 
-	OrdersListSubscribersCmd.Flags().StringVar(&OrdersListSubscribersCmdOrderId, "order-id", "", TRAPI("Order ID. You can get it by calling [`Order:listOrders API`](#/Order/listOrders)."))
+	OrdersListSubscribersCmd.Flags().StringVar(&OrdersListSubscribersCmdOrderId, "order-id", "", TRAPI("Order ID. You can get it by calling ['Order:listOrders API'](#/Order/listOrders)."))
 
 	OrdersListSubscribersCmd.Flags().Int64Var(&OrdersListSubscribersCmdLimit, "limit", 0, TRAPI("Max number of subscribers in a response."))
 

--- a/soracom/generated/cmd/orders_register_subscribers.go
+++ b/soracom/generated/cmd/orders_register_subscribers.go
@@ -13,7 +13,7 @@ import (
 var OrdersRegisterSubscribersCmdOrderId string
 
 func init() {
-	OrdersRegisterSubscribersCmd.Flags().StringVar(&OrdersRegisterSubscribersCmdOrderId, "order-id", "", TRAPI("Order ID. You can get it by calling [`Order:listOrders API`](#/Order/listOrders)."))
+	OrdersRegisterSubscribersCmd.Flags().StringVar(&OrdersRegisterSubscribersCmdOrderId, "order-id", "", TRAPI("Order ID. You can get it by calling ['Order:listOrders API'](#/Order/listOrders)."))
 	OrdersCmd.AddCommand(OrdersRegisterSubscribersCmd)
 }
 

--- a/soracom/generated/cmd/orders_resource_initial_setting_update.go
+++ b/soracom/generated/cmd/orders_resource_initial_setting_update.go
@@ -20,7 +20,7 @@ var OrdersResourceInitialSettingUpdateCmdOrderId string
 var OrdersResourceInitialSettingUpdateCmdBody string
 
 func init() {
-	OrdersResourceInitialSettingUpdateCmd.Flags().StringVar(&OrdersResourceInitialSettingUpdateCmdOrderId, "order-id", "", TRAPI("Order ID. You can get it by calling [`Order:listOrders API`](#/Order/listOrders)."))
+	OrdersResourceInitialSettingUpdateCmd.Flags().StringVar(&OrdersResourceInitialSettingUpdateCmdOrderId, "order-id", "", TRAPI("Order ID. You can get it by calling ['Order:listOrders API'](#/Order/listOrders)."))
 
 	OrdersResourceInitialSettingUpdateCmd.Flags().StringVar(&OrdersResourceInitialSettingUpdateCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	OrdersResourceInitialSettingCmd.AddCommand(OrdersResourceInitialSettingUpdateCmd)

--- a/soracom/generated/cmd/query_subscribers.go
+++ b/soracom/generated/cmd/query_subscribers.go
@@ -64,7 +64,7 @@ func init() {
 
 	QuerySubscribersCmd.Flags().StringSliceVar(&QuerySubscribersCmdImsi, "imsi", []string{}, TRAPI("IMSI to search"))
 
-	QuerySubscribersCmd.Flags().StringSliceVar(&QuerySubscribersCmdModuleType, "module-type", []string{}, TRAPI("Module type (e.g. `mini`, `virtual`) to search"))
+	QuerySubscribersCmd.Flags().StringSliceVar(&QuerySubscribersCmdModuleType, "module-type", []string{}, TRAPI("Module type (e.g. 'mini', 'virtual') to search"))
 
 	QuerySubscribersCmd.Flags().StringSliceVar(&QuerySubscribersCmdMsisdn, "msisdn", []string{}, TRAPI("MSISDN to search"))
 
@@ -72,7 +72,7 @@ func init() {
 
 	QuerySubscribersCmd.Flags().StringSliceVar(&QuerySubscribersCmdSerialNumber, "serial-number", []string{}, TRAPI("Serial number to search"))
 
-	QuerySubscribersCmd.Flags().StringSliceVar(&QuerySubscribersCmdSubscription, "subscription", []string{}, TRAPI("Subscription (e.g. `plan01s`) to search"))
+	QuerySubscribersCmd.Flags().StringSliceVar(&QuerySubscribersCmdSubscription, "subscription", []string{}, TRAPI("Subscription (e.g. 'plan01s') to search"))
 
 	QuerySubscribersCmd.Flags().StringSliceVar(&QuerySubscribersCmdTag, "tag", []string{}, TRAPI("String of tag values to search"))
 

--- a/soracom/generated/cmd/resource_summaries_get.go
+++ b/soracom/generated/cmd/resource_summaries_get.go
@@ -13,7 +13,7 @@ import (
 var ResourceSummariesGetCmdResourceSummaryType string
 
 func init() {
-	ResourceSummariesGetCmd.Flags().StringVar(&ResourceSummariesGetCmdResourceSummaryType, "resource-summary-type", "", TRAPI("The type of the resource summary.- `simsPerStatus`: The number of IoT SIMs per status"))
+	ResourceSummariesGetCmd.Flags().StringVar(&ResourceSummariesGetCmdResourceSummaryType, "resource-summary-type", "", TRAPI("The type of the resource summary.- 'simsPerStatus': The number of IoT SIMs per status"))
 	ResourceSummariesCmd.AddCommand(ResourceSummariesGetCmd)
 }
 

--- a/soracom/generated/cmd/sandbox_init.go
+++ b/soracom/generated/cmd/sandbox_init.go
@@ -43,7 +43,7 @@ func init() {
 
 	SandboxInitCmd.Flags().StringVar(&SandboxInitCmdPassword, "password", "", TRAPI(""))
 
-	SandboxInitCmd.Flags().StringSliceVar(&SandboxInitCmdCoverageTypes, "coverage-types", []string{}, TRAPI("Coverage type.- `g`: Global coverage- `jp`: Japan coverage"))
+	SandboxInitCmd.Flags().StringSliceVar(&SandboxInitCmdCoverageTypes, "coverage-types", []string{}, TRAPI("Coverage type.- 'g': Global coverage- 'jp': Japan coverage"))
 
 	SandboxInitCmd.Flags().BoolVar(&SandboxInitCmdRegisterPaymentMethod, "register-payment-method", true, TRAPI(""))
 

--- a/soracom/generated/cmd/sigfox_devices_get_data.go
+++ b/soracom/generated/cmd/sigfox_devices_get_data.go
@@ -36,7 +36,7 @@ var SigfoxDevicesGetDataCmdOutputJSONL bool
 func init() {
 	SigfoxDevicesGetDataCmd.Flags().StringVar(&SigfoxDevicesGetDataCmdDeviceId, "device-id", "", TRAPI("Device ID of the target subscriber that generated data entries."))
 
-	SigfoxDevicesGetDataCmd.Flags().StringVar(&SigfoxDevicesGetDataCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
+	SigfoxDevicesGetDataCmd.Flags().StringVar(&SigfoxDevicesGetDataCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of 'time' in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
 	SigfoxDevicesGetDataCmd.Flags().StringVar(&SigfoxDevicesGetDataCmdSort, "sort", "desc", TRAPI("Sort order of the data entries. Either descending (latest data entry first) or ascending (oldest data entry first)."))
 

--- a/soracom/generated/cmd/sigfox_devices_list.go
+++ b/soracom/generated/cmd/sigfox_devices_list.go
@@ -35,7 +35,7 @@ func init() {
 
 	SigfoxDevicesListCmd.Flags().StringVar(&SigfoxDevicesListCmdTagName, "tag-name", "", TRAPI("Tag name for filtering the search (exact match)."))
 
-	SigfoxDevicesListCmd.Flags().StringVar(&SigfoxDevicesListCmdTagValue, "tag-value", "", TRAPI("Tag search string for filtering the search. Required when `tag_name` has been specified."))
+	SigfoxDevicesListCmd.Flags().StringVar(&SigfoxDevicesListCmdTagValue, "tag-value", "", TRAPI("Tag search string for filtering the search. Required when 'tag_name' has been specified."))
 
 	SigfoxDevicesListCmd.Flags().StringVar(&SigfoxDevicesListCmdTagValueMatchMode, "tag-value-match-mode", "exact", TRAPI("Tag match mode."))
 

--- a/soracom/generated/cmd/sims_create.go
+++ b/soracom/generated/cmd/sims_create.go
@@ -23,9 +23,9 @@ var SimsCreateCmdType string
 var SimsCreateCmdBody string
 
 func init() {
-	SimsCreateCmd.Flags().StringVar(&SimsCreateCmdSubscription, "subscription", "", TRAPI("To create a virtual SIM/Subscriber, specify `planArc01`."))
+	SimsCreateCmd.Flags().StringVar(&SimsCreateCmdSubscription, "subscription", "", TRAPI("To create a virtual SIM/Subscriber, specify 'planArc01'."))
 
-	SimsCreateCmd.Flags().StringVar(&SimsCreateCmdType, "type", "", TRAPI("To create a virtual SIM/Subscriber, specify `virtual`."))
+	SimsCreateCmd.Flags().StringVar(&SimsCreateCmdType, "type", "", TRAPI("To create a virtual SIM/Subscriber, specify 'virtual'."))
 
 	SimsCreateCmd.Flags().StringVar(&SimsCreateCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	SimsCmd.AddCommand(SimsCreateCmd)

--- a/soracom/generated/cmd/sims_get_data.go
+++ b/soracom/generated/cmd/sims_get_data.go
@@ -34,7 +34,7 @@ var SimsGetDataCmdPaginate bool
 var SimsGetDataCmdOutputJSONL bool
 
 func init() {
-	SimsGetDataCmd.Flags().StringVar(&SimsGetDataCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
+	SimsGetDataCmd.Flags().StringVar(&SimsGetDataCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of 'time' in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
 	SimsGetDataCmd.Flags().StringVar(&SimsGetDataCmdSimId, "sim-id", "", TRAPI("Sim Id of the target SIM."))
 

--- a/soracom/generated/cmd/sims_send_sms.go
+++ b/soracom/generated/cmd/sims_send_sms.go
@@ -30,7 +30,7 @@ func init() {
 
 	SimsSendSmsCmd.Flags().StringVar(&SimsSendSmsCmdSimId, "sim-id", "", TRAPI("SIM ID of the target SIM."))
 
-	SimsSendSmsCmd.Flags().Int64Var(&SimsSendSmsCmdEncodingType, "encoding-type", 2, TRAPI("Encoding type of the message body. Default is `2` (`DCS_UCS2`).- `1`: Send in GSM 7-bit that only supports standard alphabet. Kanji, Cyrillic, and Arabic characters cannot be sent. Maximum 160 characters (maximum 140 bytes).    Example: `{\"encodingType\": 1, \"payload\": \"Test message.\"}`- `2`: Send in UCS-2, which supports Kanji, Cyrillic, Arabic, etc. Maximum 70 characters.    Example: `{\"encodingType\": 2, \"payload\": \"テストメッセージ\"}`"))
+	SimsSendSmsCmd.Flags().Int64Var(&SimsSendSmsCmdEncodingType, "encoding-type", 2, TRAPI("Encoding type of the message body. Default is '2' ('DCS_UCS2').- '1': Send in GSM 7-bit that only supports standard alphabet. Kanji, Cyrillic, and Arabic characters cannot be sent. Maximum 160 characters (maximum 140 bytes).    Example: '{\"encodingType\": 1, \"payload\": \"Test message.\"}'- '2': Send in UCS-2, which supports Kanji, Cyrillic, Arabic, etc. Maximum 70 characters.    Example: '{\"encodingType\": 2, \"payload\": \"テストメッセージ\"}'"))
 
 	SimsSendSmsCmd.Flags().StringVar(&SimsSendSmsCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	SimsCmd.AddCommand(SimsSendSmsCmd)

--- a/soracom/generated/cmd/sims_set_expiry_time.go
+++ b/soracom/generated/cmd/sims_set_expiry_time.go
@@ -26,7 +26,7 @@ var SimsSetExpiryTimeCmdExpiryTime int64
 var SimsSetExpiryTimeCmdBody string
 
 func init() {
-	SimsSetExpiryTimeCmd.Flags().StringVar(&SimsSetExpiryTimeCmdExpiryAction, "expiry-action", "", TRAPI("Action at expiration. Specify one of the following Please refer to [Soracom Air Expiration Function](https://developers.soracom.io/en/docs/air/expiration/) for more detail. You have to disable termination protection if you want to specify `terminate` as an action.If omitted, a null value is set.- `doNothing` : do nothing- `deleteSession` : delete session of the SIM if any- `deactivate` : change the SIM status to Inactive- `suspend` : change the SIM status to Suspended- `terminate` : forcibly end any existing connections, and terminate the SIM- null value : not set (It works the same as `doNothing`)"))
+	SimsSetExpiryTimeCmd.Flags().StringVar(&SimsSetExpiryTimeCmdExpiryAction, "expiry-action", "", TRAPI("Action at expiration. Specify one of the following Please refer to [Soracom Air Expiration Function](https://developers.soracom.io/en/docs/air/expiration/) for more detail. You have to disable termination protection if you want to specify 'terminate' as an action.If omitted, a null value is set.- 'doNothing' : do nothing- 'deleteSession' : delete session of the SIM if any- 'deactivate' : change the SIM status to Inactive- 'suspend' : change the SIM status to Suspended- 'terminate' : forcibly end any existing connections, and terminate the SIM- null value : not set (It works the same as 'doNothing')"))
 
 	SimsSetExpiryTimeCmd.Flags().StringVar(&SimsSetExpiryTimeCmdSimId, "sim-id", "", TRAPI("SIM ID of the target SIM."))
 

--- a/soracom/generated/cmd/sims_update_speed_class.go
+++ b/soracom/generated/cmd/sims_update_speed_class.go
@@ -25,7 +25,7 @@ var SimsUpdateSpeedClassCmdBody string
 func init() {
 	SimsUpdateSpeedClassCmd.Flags().StringVar(&SimsUpdateSpeedClassCmdSimId, "sim-id", "", TRAPI("SIM ID of the target SIM."))
 
-	SimsUpdateSpeedClassCmd.Flags().StringVar(&SimsUpdateSpeedClassCmdSpeedClass, "speed-class", "", TRAPI("Speed class. Specify one of the following. Please specify the speed class that matches the subscription.- For plan01s, plan01s - Low Data Volume, planP1, planX3 X3-5MB, plan-D:    - `s1.minimum`    - `s1.slow`    - `s1.standard`    - `s1.fast`    - `s1.4xfast`- For plan-KM1:    - `t1.standard`- For plan-DU:    - `u1.standard`    - `u1.slow`- For virtual SIM/Subscriber:    - `arc.standard`"))
+	SimsUpdateSpeedClassCmd.Flags().StringVar(&SimsUpdateSpeedClassCmdSpeedClass, "speed-class", "", TRAPI("Speed class. Specify one of the following. Please specify the speed class that matches the subscription.- For plan01s, plan01s - Low Data Volume, planP1, planX3 X3-5MB, plan-D:    - 's1.minimum'    - 's1.slow'    - 's1.standard'    - 's1.fast'    - 's1.4xfast'- For plan-KM1:    - 't1.standard'- For plan-DU:    - 'u1.standard'    - 'u1.slow'- For virtual SIM/Subscriber:    - 'arc.standard'"))
 
 	SimsUpdateSpeedClassCmd.Flags().StringVar(&SimsUpdateSpeedClassCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	SimsCmd.AddCommand(SimsUpdateSpeedClassCmd)

--- a/soracom/generated/cmd/sora_cam_devices_events_list.go
+++ b/soracom/generated/cmd/sora_cam_devices_events_list.go
@@ -36,15 +36,15 @@ var SoraCamDevicesEventsListCmdOutputJSONL bool
 func init() {
 	SoraCamDevicesEventsListCmd.Flags().StringVar(&SoraCamDevicesEventsListCmdDeviceId, "device-id", "", TRAPI("Device ID of the target compatible camera device. If this ID is not specified, the event history of all camera devices owned by the operator will be retrieved."))
 
-	SoraCamDevicesEventsListCmd.Flags().StringVar(&SoraCamDevicesEventsListCmdSort, "sort", "desc", TRAPI("Sort order of the events.- `desc`: Descending order (latest data entry first)- `asc`: Ascending order (oldest data entry first)"))
+	SoraCamDevicesEventsListCmd.Flags().StringVar(&SoraCamDevicesEventsListCmdSort, "sort", "desc", TRAPI("Sort order of the events.- 'desc': Descending order (latest data entry first)- 'asc': Ascending order (oldest data entry first)"))
 
-	SoraCamDevicesEventsListCmd.Flags().Int64Var(&SoraCamDevicesEventsListCmdFrom, "from", 0, TRAPI("Start time of the events to be searched (unix time in milliseconds). If not specified, `from` is set to the oldest event time."))
+	SoraCamDevicesEventsListCmd.Flags().Int64Var(&SoraCamDevicesEventsListCmdFrom, "from", 0, TRAPI("Start time of the events to be searched (unix time in milliseconds). If not specified, 'from' is set to the oldest event time."))
 
 	SoraCamDevicesEventsListCmd.Flags().Int64Var(&SoraCamDevicesEventsListCmdLastEvaluatedKey, "last-evaluated-key", 0, TRAPI("Value of the x-soracom-next-key header in the response to the last listSoraCamDeviceEvents request. By specifying this parameter, you can continue to retrieve the list from the last request."))
 
 	SoraCamDevicesEventsListCmd.Flags().Int64Var(&SoraCamDevicesEventsListCmdLimit, "limit", 10, TRAPI("Maximum number of items to retrieve in one request. Note that the response may contain fewer items than the specified limit."))
 
-	SoraCamDevicesEventsListCmd.Flags().Int64Var(&SoraCamDevicesEventsListCmdTo, "to", 0, TRAPI("End time of the events to be searched (unix time in milliseconds). If not specified, `to` is set to the current time."))
+	SoraCamDevicesEventsListCmd.Flags().Int64Var(&SoraCamDevicesEventsListCmdTo, "to", 0, TRAPI("End time of the events to be searched (unix time in milliseconds). If not specified, 'to' is set to the current time."))
 
 	SoraCamDevicesEventsListCmd.Flags().BoolVar(&SoraCamDevicesEventsListCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
 

--- a/soracom/generated/cmd/sora_cam_devices_events_list_for_device.go
+++ b/soracom/generated/cmd/sora_cam_devices_events_list_for_device.go
@@ -38,13 +38,13 @@ func init() {
 
 	SoraCamDevicesEventsListForDeviceCmd.Flags().StringVar(&SoraCamDevicesEventsListForDeviceCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("Value of the x-soracom-next-key header in the response to the last listSoraCamDeviceEventsForDevice request. By specifying this parameter, you can continue to retrieve the list from the last request."))
 
-	SoraCamDevicesEventsListForDeviceCmd.Flags().StringVar(&SoraCamDevicesEventsListForDeviceCmdSort, "sort", "desc", TRAPI("Sort order of the events.- `desc`: Descending order (latest data entry first)- `asc`: Ascending order (oldest data entry first)"))
+	SoraCamDevicesEventsListForDeviceCmd.Flags().StringVar(&SoraCamDevicesEventsListForDeviceCmdSort, "sort", "desc", TRAPI("Sort order of the events.- 'desc': Descending order (latest data entry first)- 'asc': Ascending order (oldest data entry first)"))
 
-	SoraCamDevicesEventsListForDeviceCmd.Flags().Int64Var(&SoraCamDevicesEventsListForDeviceCmdFrom, "from", 0, TRAPI("Start time of the events to be searched (unix time in milliseconds). If not specified, `from` is set to the oldest event time."))
+	SoraCamDevicesEventsListForDeviceCmd.Flags().Int64Var(&SoraCamDevicesEventsListForDeviceCmdFrom, "from", 0, TRAPI("Start time of the events to be searched (unix time in milliseconds). If not specified, 'from' is set to the oldest event time."))
 
 	SoraCamDevicesEventsListForDeviceCmd.Flags().Int64Var(&SoraCamDevicesEventsListForDeviceCmdLimit, "limit", 10, TRAPI("Maximum number of items to retrieve in one request. Note that the response may contain fewer items than the specified limit."))
 
-	SoraCamDevicesEventsListForDeviceCmd.Flags().Int64Var(&SoraCamDevicesEventsListForDeviceCmdTo, "to", 0, TRAPI("End time of the events to be searched (unix time in milliseconds). If not specified, `to` is set to the current time."))
+	SoraCamDevicesEventsListForDeviceCmd.Flags().Int64Var(&SoraCamDevicesEventsListForDeviceCmdTo, "to", 0, TRAPI("End time of the events to be searched (unix time in milliseconds). If not specified, 'to' is set to the current time."))
 
 	SoraCamDevicesEventsListForDeviceCmd.Flags().BoolVar(&SoraCamDevicesEventsListForDeviceCmdPaginate, "fetch-all", false, TRCLI("cli.common_params.paginate.short_help"))
 

--- a/soracom/generated/cmd/sora_cam_devices_get_streaming_video.go
+++ b/soracom/generated/cmd/sora_cam_devices_get_streaming_video.go
@@ -21,9 +21,9 @@ var SoraCamDevicesGetStreamingVideoCmdTo int64
 func init() {
 	SoraCamDevicesGetStreamingVideoCmd.Flags().StringVar(&SoraCamDevicesGetStreamingVideoCmdDeviceId, "device-id", "", TRAPI("Device ID of the target compatible camera device."))
 
-	SoraCamDevicesGetStreamingVideoCmd.Flags().Int64Var(&SoraCamDevicesGetStreamingVideoCmdFrom, "from", 0, TRAPI("Start time of recorded video (UNIX time in milliseconds).- Omit both `from` and `to` to get information for downloading real-time video."))
+	SoraCamDevicesGetStreamingVideoCmd.Flags().Int64Var(&SoraCamDevicesGetStreamingVideoCmdFrom, "from", 0, TRAPI("Start time of recorded video (UNIX time in milliseconds).- Omit both 'from' and 'to' to get information for downloading real-time video."))
 
-	SoraCamDevicesGetStreamingVideoCmd.Flags().Int64Var(&SoraCamDevicesGetStreamingVideoCmdTo, "to", 0, TRAPI("End time of recorded video (UNIX time in milliseconds).- Omit both `from` and `to` to get information for downloading real-time video.- The maximum viewing time for a single API call is 300 seconds (5 minutes). Make sure the difference between `from` and `to` does not exceed 300 seconds."))
+	SoraCamDevicesGetStreamingVideoCmd.Flags().Int64Var(&SoraCamDevicesGetStreamingVideoCmdTo, "to", 0, TRAPI("End time of recorded video (UNIX time in milliseconds).- Omit both 'from' and 'to' to get information for downloading real-time video.- The maximum viewing time for a single API call is 300 seconds (5 minutes). Make sure the difference between 'from' and 'to' does not exceed 300 seconds."))
 	SoraCamDevicesCmd.AddCommand(SoraCamDevicesGetStreamingVideoCmd)
 }
 

--- a/soracom/generated/cmd/sora_cam_devices_images_list_exports.go
+++ b/soracom/generated/cmd/sora_cam_devices_images_list_exports.go
@@ -32,7 +32,7 @@ func init() {
 
 	SoraCamDevicesImagesListExportsCmd.Flags().StringVar(&SoraCamDevicesImagesListExportsCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("Value of the x-soracom-next-key header in the response to the last listSoraCamDeviceImageExports request. By specifying this parameter, you can continue to retrieve the list from the last request."))
 
-	SoraCamDevicesImagesListExportsCmd.Flags().StringVar(&SoraCamDevicesImagesListExportsCmdSort, "sort", "desc", TRAPI("Sort order. The list in the response is sorted in ascending (`asc`) or descending (`desc`) order of `requestedTime`. The default is `desc` i.e. newer items are sorted first."))
+	SoraCamDevicesImagesListExportsCmd.Flags().StringVar(&SoraCamDevicesImagesListExportsCmdSort, "sort", "desc", TRAPI("Sort order. The list in the response is sorted in ascending ('asc') or descending ('desc') order of 'requestedTime'. The default is 'desc' i.e. newer items are sorted first."))
 
 	SoraCamDevicesImagesListExportsCmd.Flags().Int64Var(&SoraCamDevicesImagesListExportsCmdLimit, "limit", 10, TRAPI("Maximum number of items to retrieve in one request. Note that the response may contain fewer items than the specified limit."))
 

--- a/soracom/generated/cmd/sora_cam_devices_images_list_exports_for_device.go
+++ b/soracom/generated/cmd/sora_cam_devices_images_list_exports_for_device.go
@@ -32,7 +32,7 @@ func init() {
 
 	SoraCamDevicesImagesListExportsForDeviceCmd.Flags().StringVar(&SoraCamDevicesImagesListExportsForDeviceCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("Value of the x-soracom-next-key header in the response to the last listSoraCamDeviceImageExportsForDevice request. By specifying this parameter, you can continue to retrieve the list from the last request."))
 
-	SoraCamDevicesImagesListExportsForDeviceCmd.Flags().StringVar(&SoraCamDevicesImagesListExportsForDeviceCmdSort, "sort", "desc", TRAPI("Sort order. The list in the response is sorted in ascending (`asc`) or descending (`desc`) order of `requestedTime`. The default is `desc` i.e. newer items are sorted first."))
+	SoraCamDevicesImagesListExportsForDeviceCmd.Flags().StringVar(&SoraCamDevicesImagesListExportsForDeviceCmdSort, "sort", "desc", TRAPI("Sort order. The list in the response is sorted in ascending ('asc') or descending ('desc') order of 'requestedTime'. The default is 'desc' i.e. newer items are sorted first."))
 
 	SoraCamDevicesImagesListExportsForDeviceCmd.Flags().Int64Var(&SoraCamDevicesImagesListExportsForDeviceCmdLimit, "limit", 10, TRAPI("Maximum number of items to retrieve in one request. Note that the response may contain fewer items than the specified limit."))
 

--- a/soracom/generated/cmd/sora_cam_devices_videos_export.go
+++ b/soracom/generated/cmd/sora_cam_devices_videos_export.go
@@ -30,7 +30,7 @@ func init() {
 
 	SoraCamDevicesVideosExportCmd.Flags().Int64Var(&SoraCamDevicesVideosExportCmdFrom, "from", 0, TRAPI("Start time for exporting (unix time in milliseconds)."))
 
-	SoraCamDevicesVideosExportCmd.Flags().Int64Var(&SoraCamDevicesVideosExportCmdTo, "to", 0, TRAPI("End time for exporting (unix time in milliseconds).- The maximum time for a single API call to export is 300 seconds (5 minutes). Make sure the difference between `from` and `to` does not exceed 300 seconds."))
+	SoraCamDevicesVideosExportCmd.Flags().Int64Var(&SoraCamDevicesVideosExportCmdTo, "to", 0, TRAPI("End time for exporting (unix time in milliseconds).- The maximum time for a single API call to export is 300 seconds (5 minutes). Make sure the difference between 'from' and 'to' does not exceed 300 seconds."))
 
 	SoraCamDevicesVideosExportCmd.Flags().StringVar(&SoraCamDevicesVideosExportCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	SoraCamDevicesVideosCmd.AddCommand(SoraCamDevicesVideosExportCmd)

--- a/soracom/generated/cmd/sora_cam_devices_videos_list_exports.go
+++ b/soracom/generated/cmd/sora_cam_devices_videos_list_exports.go
@@ -32,7 +32,7 @@ func init() {
 
 	SoraCamDevicesVideosListExportsCmd.Flags().StringVar(&SoraCamDevicesVideosListExportsCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("Value of the x-soracom-next-key header in the response to the last listSoraCamDeviceVideoExports request. By specifying this parameter, you can continue to retrieve the list from the last request."))
 
-	SoraCamDevicesVideosListExportsCmd.Flags().StringVar(&SoraCamDevicesVideosListExportsCmdSort, "sort", "desc", TRAPI("Sort order. The list in the response is sorted in ascending (`asc`) or descending (`desc`) order of `requestedTime`. The default is `desc` i.e. newer items are sorted first."))
+	SoraCamDevicesVideosListExportsCmd.Flags().StringVar(&SoraCamDevicesVideosListExportsCmdSort, "sort", "desc", TRAPI("Sort order. The list in the response is sorted in ascending ('asc') or descending ('desc') order of 'requestedTime'. The default is 'desc' i.e. newer items are sorted first."))
 
 	SoraCamDevicesVideosListExportsCmd.Flags().Int64Var(&SoraCamDevicesVideosListExportsCmdLimit, "limit", 10, TRAPI("Maximum number of items to retrieve in one request. Note that the response may contain fewer items than the specified limit."))
 

--- a/soracom/generated/cmd/sora_cam_devices_videos_list_exports_for_device.go
+++ b/soracom/generated/cmd/sora_cam_devices_videos_list_exports_for_device.go
@@ -32,7 +32,7 @@ func init() {
 
 	SoraCamDevicesVideosListExportsForDeviceCmd.Flags().StringVar(&SoraCamDevicesVideosListExportsForDeviceCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("Value of the x-soracom-next-key header in the response to the last listSoraCamDeviceVideoExportsForDevice request. By specifying this parameter, you can continue to retrieve the list from the last request."))
 
-	SoraCamDevicesVideosListExportsForDeviceCmd.Flags().StringVar(&SoraCamDevicesVideosListExportsForDeviceCmdSort, "sort", "desc", TRAPI("Sort order. The list in the response is sorted in ascending (`asc`) or descending (`desc`) order of `requestedTime`. The default is `desc` i.e. newer items are sorted first."))
+	SoraCamDevicesVideosListExportsForDeviceCmd.Flags().StringVar(&SoraCamDevicesVideosListExportsForDeviceCmdSort, "sort", "desc", TRAPI("Sort order. The list in the response is sorted in ascending ('asc') or descending ('desc') order of 'requestedTime'. The default is 'desc' i.e. newer items are sorted first."))
 
 	SoraCamDevicesVideosListExportsForDeviceCmd.Flags().Int64Var(&SoraCamDevicesVideosListExportsForDeviceCmdLimit, "limit", 10, TRAPI("Maximum number of items to retrieve in one request. Note that the response may contain fewer items than the specified limit."))
 

--- a/soracom/generated/cmd/stats_air_export.go
+++ b/soracom/generated/cmd/stats_air_export.go
@@ -32,11 +32,11 @@ var StatsAirExportCmdTo int64
 var StatsAirExportCmdBody string
 
 func init() {
-	StatsAirExportCmd.Flags().StringVar(&StatsAirExportCmdExportMode, "export-mode", "", TRAPI("Specify how to obtain the URL to download the Air Data Usage Report CSV.- `async`: Get the `exportedFieldId` without waiting for the URL to be issued on the Soracom platform. Specify this `exportedFieldId` in [`Files:getExportedFile API`](#/Files/getExportedFile) to get the URL. If the file size of the Air Data Usage Report CSV is huge, specify `async`.- `sync` (default): Wait for the URL to be issued on the Soracom platform. However, if the file size of the Air Data Usage Report CSV is huge, it may time out and the URL cannot be retrieved. If the timeout occurs, specify `async`."))
+	StatsAirExportCmd.Flags().StringVar(&StatsAirExportCmdExportMode, "export-mode", "", TRAPI("Specify how to obtain the URL to download the Air Data Usage Report CSV.- 'async': Get the 'exportedFieldId' without waiting for the URL to be issued on the Soracom platform. Specify this 'exportedFieldId' in ['Files:getExportedFile API'](#/Files/getExportedFile) to get the URL. If the file size of the Air Data Usage Report CSV is huge, specify 'async'.- 'sync' (default): Wait for the URL to be issued on the Soracom platform. However, if the file size of the Air Data Usage Report CSV is huge, it may time out and the URL cannot be retrieved. If the timeout occurs, specify 'async'."))
 
 	StatsAirExportCmd.Flags().StringVar(&StatsAirExportCmdOperatorId, "operator-id", "", TRAPI("Operator ID"))
 
-	StatsAirExportCmd.Flags().StringVar(&StatsAirExportCmdPeriod, "period", "", TRAPI("Degree of detail of history.- `month`: Monthly- `day`: Daily- `minutes`: Every minute"))
+	StatsAirExportCmd.Flags().StringVar(&StatsAirExportCmdPeriod, "period", "", TRAPI("Degree of detail of history.- 'month': Monthly- 'day': Daily- 'minutes': Every minute"))
 
 	StatsAirExportCmd.Flags().Int64Var(&StatsAirExportCmdFrom, "from", 0, TRAPI("Start date and time for the aggregate data (UNIX time in seconds)"))
 

--- a/soracom/generated/cmd/stats_beam_export.go
+++ b/soracom/generated/cmd/stats_beam_export.go
@@ -36,7 +36,7 @@ func init() {
 
 	StatsBeamExportCmd.Flags().StringVar(&StatsBeamExportCmdOperatorId, "operator-id", "", TRAPI("Operator ID"))
 
-	StatsBeamExportCmd.Flags().StringVar(&StatsBeamExportCmdPeriod, "period", "", TRAPI("Degree of detail of history.- `month`: Monthly- `day`: Daily- `minutes`: Every minute"))
+	StatsBeamExportCmd.Flags().StringVar(&StatsBeamExportCmdPeriod, "period", "", TRAPI("Degree of detail of history.- 'month': Monthly- 'day': Daily- 'minutes': Every minute"))
 
 	StatsBeamExportCmd.Flags().Int64Var(&StatsBeamExportCmdFrom, "from", 0, TRAPI("Start date and time for the aggregate data (UNIX time in seconds)"))
 

--- a/soracom/generated/cmd/stats_funk_export.go
+++ b/soracom/generated/cmd/stats_funk_export.go
@@ -36,7 +36,7 @@ func init() {
 
 	StatsFunkExportCmd.Flags().StringVar(&StatsFunkExportCmdOperatorId, "operator-id", "", TRAPI("Operator ID"))
 
-	StatsFunkExportCmd.Flags().StringVar(&StatsFunkExportCmdPeriod, "period", "", TRAPI("Degree of detail of history.- `month`: Monthly- `day`: Daily- `minutes`: Every minute"))
+	StatsFunkExportCmd.Flags().StringVar(&StatsFunkExportCmdPeriod, "period", "", TRAPI("Degree of detail of history.- 'month': Monthly- 'day': Daily- 'minutes': Every minute"))
 
 	StatsFunkExportCmd.Flags().Int64Var(&StatsFunkExportCmdFrom, "from", 0, TRAPI("Start date and time for the aggregate data (UNIX time in seconds)"))
 

--- a/soracom/generated/cmd/stats_funnel_export.go
+++ b/soracom/generated/cmd/stats_funnel_export.go
@@ -36,7 +36,7 @@ func init() {
 
 	StatsFunnelExportCmd.Flags().StringVar(&StatsFunnelExportCmdOperatorId, "operator-id", "", TRAPI("Operator ID"))
 
-	StatsFunnelExportCmd.Flags().StringVar(&StatsFunnelExportCmdPeriod, "period", "", TRAPI("Degree of detail of history.- `month`: Monthly- `day`: Daily- `minutes`: Every minute"))
+	StatsFunnelExportCmd.Flags().StringVar(&StatsFunnelExportCmdPeriod, "period", "", TRAPI("Degree of detail of history.- 'month': Monthly- 'day': Daily- 'minutes': Every minute"))
 
 	StatsFunnelExportCmd.Flags().Int64Var(&StatsFunnelExportCmdFrom, "from", 0, TRAPI("Start date and time for the aggregate data (UNIX time in seconds)"))
 

--- a/soracom/generated/cmd/subscribers_get_data.go
+++ b/soracom/generated/cmd/subscribers_get_data.go
@@ -36,7 +36,7 @@ var SubscribersGetDataCmdOutputJSONL bool
 func init() {
 	SubscribersGetDataCmd.Flags().StringVar(&SubscribersGetDataCmdImsi, "imsi", "", TRAPI("IMSI of the target subscriber that generated data entries."))
 
-	SubscribersGetDataCmd.Flags().StringVar(&SubscribersGetDataCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of `time` in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
+	SubscribersGetDataCmd.Flags().StringVar(&SubscribersGetDataCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The value of 'time' in the last log entry retrieved in the previous page. By specifying this parameter, you can continue to retrieve the list from the next page onward."))
 
 	SubscribersGetDataCmd.Flags().StringVar(&SubscribersGetDataCmdSort, "sort", "desc", TRAPI("Sort order of the data entries. Either descending (latest data entry first) or ascending (oldest data entry first)."))
 

--- a/soracom/generated/cmd/subscribers_list.go
+++ b/soracom/generated/cmd/subscribers_list.go
@@ -42,15 +42,15 @@ var SubscribersListCmdOutputJSONL bool
 func init() {
 	SubscribersListCmd.Flags().StringVar(&SubscribersListCmdLastEvaluatedKey, "last-evaluated-key", "", TRAPI("The IMSI of the last subscriber retrieved on the current page. By specifying this parameter, you can continue to retrieve the list from the next subscriber onward."))
 
-	SubscribersListCmd.Flags().StringVar(&SubscribersListCmdSerialNumberFilter, "serial-number-filter", "", TRAPI("Serial number for filtering the search. Can specify multiple values delimited by `|`. Returns subscribers with serial number starting with the specified value(s)."))
+	SubscribersListCmd.Flags().StringVar(&SubscribersListCmdSerialNumberFilter, "serial-number-filter", "", TRAPI("Serial number for filtering the search. Can specify multiple values delimited by '|'. Returns subscribers with serial number starting with the specified value(s)."))
 
-	SubscribersListCmd.Flags().StringVar(&SubscribersListCmdSpeedClassFilter, "speed-class-filter", "", TRAPI("Speed class for filtering the search. Can specify multiple values delimited by `|`. Valid values include: `s1.minimum`, `s1.slow`, `s1.standard`, `s1.fast`"))
+	SubscribersListCmd.Flags().StringVar(&SubscribersListCmdSpeedClassFilter, "speed-class-filter", "", TRAPI("Speed class for filtering the search. Can specify multiple values delimited by '|'. Valid values include: 's1.minimum', 's1.slow', 's1.standard', 's1.fast'"))
 
-	SubscribersListCmd.Flags().StringVar(&SubscribersListCmdStatusFilter, "status-filter", "", TRAPI("Status for filtering the search. Can specify multiple values delimited by `|`. Valid values include: `active`, `inactive`, `ready`, `instock`, `shipped`, `suspended`, and `terminated`."))
+	SubscribersListCmd.Flags().StringVar(&SubscribersListCmdStatusFilter, "status-filter", "", TRAPI("Status for filtering the search. Can specify multiple values delimited by '|'. Valid values include: 'active', 'inactive', 'ready', 'instock', 'shipped', 'suspended', and 'terminated'."))
 
 	SubscribersListCmd.Flags().StringVar(&SubscribersListCmdTagName, "tag-name", "", TRAPI("Tag name for filtering the search (exact match)."))
 
-	SubscribersListCmd.Flags().StringVar(&SubscribersListCmdTagValue, "tag-value", "", TRAPI("Tag search string for filtering the search. Required when `tag_name` has been specified."))
+	SubscribersListCmd.Flags().StringVar(&SubscribersListCmdTagValue, "tag-value", "", TRAPI("Tag search string for filtering the search. Required when 'tag_name' has been specified."))
 
 	SubscribersListCmd.Flags().StringVar(&SubscribersListCmdTagValueMatchMode, "tag-value-match-mode", "exact", TRAPI("Tag match mode."))
 

--- a/soracom/generated/cmd/subscribers_send_sms.go
+++ b/soracom/generated/cmd/subscribers_send_sms.go
@@ -30,7 +30,7 @@ func init() {
 
 	SubscribersSendSmsCmd.Flags().StringVar(&SubscribersSendSmsCmdPayload, "payload", "", TRAPI(""))
 
-	SubscribersSendSmsCmd.Flags().Int64Var(&SubscribersSendSmsCmdEncodingType, "encoding-type", 2, TRAPI("Encoding type of the message body. Default is `2` (`DCS_UCS2`).- `1`: Send in GSM 7-bit that only supports standard alphabet. Kanji, Cyrillic, and Arabic characters cannot be sent. Maximum 160 characters (maximum 140 bytes).    Example: `{\"encodingType\": 1, \"payload\": \"Test message.\"}`- `2`: Send in UCS-2, which supports Kanji, Cyrillic, Arabic, etc. Maximum 70 characters.    Example: `{\"encodingType\": 2, \"payload\": \"テストメッセージ\"}`"))
+	SubscribersSendSmsCmd.Flags().Int64Var(&SubscribersSendSmsCmdEncodingType, "encoding-type", 2, TRAPI("Encoding type of the message body. Default is '2' ('DCS_UCS2').- '1': Send in GSM 7-bit that only supports standard alphabet. Kanji, Cyrillic, and Arabic characters cannot be sent. Maximum 160 characters (maximum 140 bytes).    Example: '{\"encodingType\": 1, \"payload\": \"Test message.\"}'- '2': Send in UCS-2, which supports Kanji, Cyrillic, Arabic, etc. Maximum 70 characters.    Example: '{\"encodingType\": 2, \"payload\": \"テストメッセージ\"}'"))
 
 	SubscribersSendSmsCmd.Flags().StringVar(&SubscribersSendSmsCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	SubscribersCmd.AddCommand(SubscribersSendSmsCmd)

--- a/soracom/generated/cmd/subscribers_send_sms_by_msisdn.go
+++ b/soracom/generated/cmd/subscribers_send_sms_by_msisdn.go
@@ -30,7 +30,7 @@ func init() {
 
 	SubscribersSendSmsByMsisdnCmd.Flags().StringVar(&SubscribersSendSmsByMsisdnCmdPayload, "payload", "", TRAPI(""))
 
-	SubscribersSendSmsByMsisdnCmd.Flags().Int64Var(&SubscribersSendSmsByMsisdnCmdEncodingType, "encoding-type", 2, TRAPI("Encoding type of the message body. Default is `2` (`DCS_UCS2`).- `1`: Send in GSM 7-bit that only supports standard alphabet. Kanji, Cyrillic, and Arabic characters cannot be sent. Maximum 160 characters (maximum 140 bytes).    Example: `{\"encodingType\": 1, \"payload\": \"Test message.\"}`- `2`: Send in UCS-2, which supports Kanji, Cyrillic, Arabic, etc. Maximum 70 characters.    Example: `{\"encodingType\": 2, \"payload\": \"テストメッセージ\"}`"))
+	SubscribersSendSmsByMsisdnCmd.Flags().Int64Var(&SubscribersSendSmsByMsisdnCmdEncodingType, "encoding-type", 2, TRAPI("Encoding type of the message body. Default is '2' ('DCS_UCS2').- '1': Send in GSM 7-bit that only supports standard alphabet. Kanji, Cyrillic, and Arabic characters cannot be sent. Maximum 160 characters (maximum 140 bytes).    Example: '{\"encodingType\": 1, \"payload\": \"Test message.\"}'- '2': Send in UCS-2, which supports Kanji, Cyrillic, Arabic, etc. Maximum 70 characters.    Example: '{\"encodingType\": 2, \"payload\": \"テストメッセージ\"}'"))
 
 	SubscribersSendSmsByMsisdnCmd.Flags().StringVar(&SubscribersSendSmsByMsisdnCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	SubscribersCmd.AddCommand(SubscribersSendSmsByMsisdnCmd)

--- a/soracom/generated/cmd/subscribers_set_expiry_time.go
+++ b/soracom/generated/cmd/subscribers_set_expiry_time.go
@@ -26,7 +26,7 @@ var SubscribersSetExpiryTimeCmdExpiryTime int64
 var SubscribersSetExpiryTimeCmdBody string
 
 func init() {
-	SubscribersSetExpiryTimeCmd.Flags().StringVar(&SubscribersSetExpiryTimeCmdExpiryAction, "expiry-action", "", TRAPI("Action at expiration. Specify one of the following Please refer to [Soracom Air Expiration Function](https://developers.soracom.io/en/docs/air/expiration/) for more detail. You have to disable termination protection if you want to specify `terminate` as an action.If omitted, a null value is set.- `doNothing` : do nothing- `deleteSession` : delete session of the SIM if any- `deactivate` : change the SIM status to Inactive- `suspend` : change the SIM status to Suspended- `terminate` : forcibly end any existing connections, and terminate the SIM- null value : not set (It works the same as `doNothing`)"))
+	SubscribersSetExpiryTimeCmd.Flags().StringVar(&SubscribersSetExpiryTimeCmdExpiryAction, "expiry-action", "", TRAPI("Action at expiration. Specify one of the following Please refer to [Soracom Air Expiration Function](https://developers.soracom.io/en/docs/air/expiration/) for more detail. You have to disable termination protection if you want to specify 'terminate' as an action.If omitted, a null value is set.- 'doNothing' : do nothing- 'deleteSession' : delete session of the SIM if any- 'deactivate' : change the SIM status to Inactive- 'suspend' : change the SIM status to Suspended- 'terminate' : forcibly end any existing connections, and terminate the SIM- null value : not set (It works the same as 'doNothing')"))
 
 	SubscribersSetExpiryTimeCmd.Flags().StringVar(&SubscribersSetExpiryTimeCmdImsi, "imsi", "", TRAPI("IMSI of the target subscriber."))
 

--- a/soracom/generated/cmd/subscribers_update_speed_class.go
+++ b/soracom/generated/cmd/subscribers_update_speed_class.go
@@ -25,7 +25,7 @@ var SubscribersUpdateSpeedClassCmdBody string
 func init() {
 	SubscribersUpdateSpeedClassCmd.Flags().StringVar(&SubscribersUpdateSpeedClassCmdImsi, "imsi", "", TRAPI("IMSI of the target subscriber."))
 
-	SubscribersUpdateSpeedClassCmd.Flags().StringVar(&SubscribersUpdateSpeedClassCmdSpeedClass, "speed-class", "", TRAPI("Speed class. Specify one of the following. Please specify the speed class that matches the subscription.- For plan01s, plan01s - Low Data Volume, planP1, planX3 X3-5MB, plan-D:    - `s1.minimum`    - `s1.slow`    - `s1.standard`    - `s1.fast`    - `s1.4xfast`- For plan-KM1:    - `t1.standard`- For plan-DU:    - `u1.standard`    - `u1.slow`- For virtual SIM/Subscriber:    - `arc.standard`"))
+	SubscribersUpdateSpeedClassCmd.Flags().StringVar(&SubscribersUpdateSpeedClassCmdSpeedClass, "speed-class", "", TRAPI("Speed class. Specify one of the following. Please specify the speed class that matches the subscription.- For plan01s, plan01s - Low Data Volume, planP1, planX3 X3-5MB, plan-D:    - 's1.minimum'    - 's1.slow'    - 's1.standard'    - 's1.fast'    - 's1.4xfast'- For plan-KM1:    - 't1.standard'- For plan-DU:    - 'u1.standard'    - 'u1.slow'- For virtual SIM/Subscriber:    - 'arc.standard'"))
 
 	SubscribersUpdateSpeedClassCmd.Flags().StringVar(&SubscribersUpdateSpeedClassCmdBody, "body", "", TRCLI("cli.common_params.body.short_help"))
 	SubscribersCmd.AddCommand(SubscribersUpdateSpeedClassCmd)

--- a/soracom/generated/cmd/vpg_create.go
+++ b/soracom/generated/cmd/vpg_create.go
@@ -28,7 +28,7 @@ var VpgCreateCmdBody string
 func init() {
 	VpgCreateCmd.Flags().StringVar(&VpgCreateCmdDeviceSubnetCidrRange, "device-subnet-cidr-range", "10.128.0.0/9", TRAPI(""))
 
-	VpgCreateCmd.Flags().Int64Var(&VpgCreateCmdType, "type", 0, TRAPI("VPG Type.- `14` : Type-E- `15` : Type-F"))
+	VpgCreateCmd.Flags().Int64Var(&VpgCreateCmdType, "type", 0, TRAPI("VPG Type.- '14' : Type-E- '15' : Type-F"))
 
 	VpgCreateCmd.Flags().BoolVar(&VpgCreateCmdUseInternetGateway, "use-internet-gateway", true, TRAPI(""))
 


### PR DESCRIPTION
Due to an undocumented (or maybe just undiscovered by me) specification in Cobra, the library we use to build our CLI, it turns out that if the help text for a parameter contains a string enclosed in backticks (`), it is unintentionally used as the parameter type (or parameter value name). This is almost always undesirable behavior. For example, the following help text makse no sense or misleads the user:

```
soracom bills export --help

...

Flags:
      --export-mode async   Specify how to get the URL to download ...
  -h, --help                help for export
      --yyyy-mm string      Target year and month

...

```

Note that `--export-mode` parameter has `async` as its type. It should be `string` as same as for `--yyyy-mm`.

This commit avoid this behavior by replacing backticks (`) in the help text with single quotation marks (').