### PR TITLE
remove unused vars

### DIFF
--- a/test/find_unprovided_text_resources.sh
+++ b/test/find_unprovided_text_resources.sh
@@ -2,8 +2,6 @@
 set -Eeuo pipefail
 d="$( cd "$( dirname "$0" )"; cd ..; pwd -P )"
 
-RESET=$'\e[0m'
-BOLD=$'\e[1m'
 GREEN=$'\e[0;32m'
 RED=$'\e[0;31m'
 


### PR DESCRIPTION
スクリプトに未使用の変数があって shellcheck に引っかかり build.sh が通らなくなっていたので未使用の変数を削除します。