### PR TITLE
chore: Update scripts/update-homebrew-formula.sh in soracom-cli

### DIFF
--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -19,7 +19,7 @@ function cleanup {
 trap cleanup EXIT
 
 cd "$tmpdir"
-git clone git@github.com:soracom/homebrew-soracom-cli
+git clone https://github.com/soracom/homebrew-soracom-cli.git
 cd homebrew-soracom-cli
 git checkout master
 bash ./update-formula.sh "$version"

--- a/soracom/generated/cmd/self_update_test.go
+++ b/soracom/generated/cmd/self_update_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -202,5 +203,5 @@ func TestDetermineActualPathOf(t *testing.T) {
 
 	actualPath, err = determineActualPathOf(tempSymlinkPath)
 	assert.NoError(t, err)
-	assert.Equal(t, tempFilePath, actualPath)
+	assert.True(t, strings.Contains(actualPath, tempFilePath)) // https://github.com/soracom/soracom-cli/pull/99#pullrequestreview-2312477684
 }


### PR DESCRIPTION
- scripts/update-homebrew-formula.sh を更新して、公開鍵を登録しなくても clone できる HTTPS を使うのはどうでしょうか。
- 1.3.0 をリリースする流れで、soracom/generated/cmd/self_update_test.go が更新されていたので一緒に更新したいです。