### PR TITLE
Modify script to work correctly under branch protection settings

### DIFF
--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -8,6 +8,13 @@ if [[ "$version" == "" ]] || [[ "$git_username" == "" ]] || [[ "$git_email" == "
     exit 1
 fi
 
+# Check if GitHub CLI(gh) is installed
+command -v gh > /dev/null 2>&1 || {
+    echo "'gh' is required."
+    echo "Install gh by following the instructions: https://github.com/cli/cli#installation"
+    exit 1
+}
+
 set -Eeuo pipefail
 
 tmpdir=$(mktemp -d)


### PR DESCRIPTION
CLIリリース用スクリプトを修正しました。`homebrew-soracom-cli` リポジトリに直接プッシュを禁止するブランチ保護が設定されるようになったため、トピックブランチを作成してプルリクエストを作成するようにスクリプト処理を変更しました。