### PR TITLE
docs: add installation instructions using mise

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ brew install soracom-cli
 brew install bash-completion
 ```
 
+## Using mise
+
+If you are using [mise](https://mise.jdx.dev/) (v2025.7.7 or later), you can install `soracom` command by running the following command:
+
+```shell
+mise use -g github:soracom/soracom-cli
+```
+
 ## In other cases
 
 By running one of the following commands, the latest version of `soracom` command will be installed.

--- a/README_ja.md
+++ b/README_ja.md
@@ -54,6 +54,14 @@ brew install soracom-cli
 brew install bash-completion
 ```
 
+## mise を使用する場合
+
+[mise](https://mise.jdx.dev/) (v2025.7.7 以降) をお使いの場合は、以下のコマンドを実行することで `soracom` コマンドをインストールできます。
+
+```shell
+mise use -g github:soracom/soracom-cli
+```
+
 ## それ以外の場合
 
 以下に紹介するいずれかのコマンドを実行することで、最新版の `soracom` コマンドがダウンロードされてインストールされます。


### PR DESCRIPTION
mise コマンドを使って soracom-cli をインストールする方法を README に追加しました。